### PR TITLE
chore: rebrand app to Team-po

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# SSU-JJS Client
+![Team-po logo](./public/logo-full.svg)
+
+# Team-po Client
 
 Developer side-project random team matching service frontend.
 

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icon-light.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>project</title>
+    <title>Team-po</title>
   </head>
   <body>
     <div id="root"></div>

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,8 +1,8 @@
 openapi: 3.1.0
 info:
-  title: MatchQueue User API
+  title: Team-po User API
   version: 0.1.0
-  summary: Authentication and current-user endpoints for the MatchQueue frontend MVP.
+  summary: Authentication and current-user endpoints for the Team-po frontend MVP.
   description: |
     Initial contract for the user-facing authentication flow used by the frontend
     routes `/login`, `/signup`, `/verify-email`, and `/me`.
@@ -31,8 +31,8 @@ paths:
             examples:
               default:
                 value:
-                  email: preview@matchqueue.dev
-                  password: matchqueue123!
+                  email: preview@teampo.dev
+                  password: teampo123!
       responses:
         '200':
           description: Login completed
@@ -45,9 +45,9 @@ paths:
                   value:
                     user:
                       id: usr_01HQ7ZJ5M3P8Q2A2F4F4Q7T3VV
-                      email: preview@matchqueue.dev
+                      email: preview@teampo.dev
                       nickname: queue_runner
-                      profileImageUrl: https://images.matchqueue.dev/profiles/preview.png
+                      profileImageUrl: https://images.teampo.dev/profiles/preview.png
                       emailVerified: true
                       createdAt: '2026-03-05T09:00:00Z'
                       verifiedAt: '2026-03-05T09:15:00Z'
@@ -78,8 +78,8 @@ paths:
             examples:
               default:
                 value:
-                  email: new.dev@matchqueue.dev
-                  password: matchqueue123!
+                  email: new.dev@teampo.dev
+                  password: teampo123!
                   nickname: sprintmaker
                   profileImage: <binary image file>
       responses:
@@ -94,14 +94,14 @@ paths:
                   value:
                     user:
                       id: usr_01HQ81GHZ4BHZSE1M6P63PQXTX
-                      email: new.dev@matchqueue.dev
+                      email: new.dev@teampo.dev
                       nickname: sprintmaker
-                      profileImageUrl: https://images.matchqueue.dev/profiles/sprintmaker.png
+                      profileImageUrl: https://images.teampo.dev/profiles/sprintmaker.png
                       emailVerified: false
                       createdAt: '2026-03-08T07:00:00Z'
                       verifiedAt: null
                     verification:
-                      email: new.dev@matchqueue.dev
+                      email: new.dev@teampo.dev
                       deliveryStatus: queued
                       resendAfterSeconds: 60
         '400':
@@ -126,7 +126,7 @@ paths:
             examples:
               default:
                 value:
-                  email: new.dev@matchqueue.dev
+                  email: new.dev@teampo.dev
       responses:
         '200':
           description: Verification email queued
@@ -137,7 +137,7 @@ paths:
               examples:
                 success:
                   value:
-                    email: new.dev@matchqueue.dev
+                    email: new.dev@teampo.dev
                     deliveryStatus: queued
                     resendAfterSeconds: 60
         '400':
@@ -162,8 +162,8 @@ paths:
             examples:
               default:
                 value:
-                  email: new.dev@matchqueue.dev
-                  token: MATCHQUEUE-2026
+                  email: new.dev@teampo.dev
+                  token: TEAMPO-2026
       responses:
         '200':
           description: Email confirmed
@@ -176,9 +176,9 @@ paths:
                   value:
                     user:
                       id: usr_01HQ81GHZ4BHZSE1M6P63PQXTX
-                      email: new.dev@matchqueue.dev
+                      email: new.dev@teampo.dev
                       nickname: sprintmaker
-                      profileImageUrl: https://images.matchqueue.dev/profiles/sprintmaker.png
+                      profileImageUrl: https://images.teampo.dev/profiles/sprintmaker.png
                       emailVerified: true
                       createdAt: '2026-03-08T07:00:00Z'
                       verifiedAt: '2026-03-08T07:03:00Z'
@@ -210,9 +210,9 @@ paths:
                   value:
                     user:
                       id: usr_01HQ7ZJ5M3P8Q2A2F4F4Q7T3VV
-                      email: preview@matchqueue.dev
+                      email: preview@teampo.dev
                       nickname: queue_runner
-                      profileImageUrl: https://images.matchqueue.dev/profiles/preview.png
+                      profileImageUrl: https://images.teampo.dev/profiles/preview.png
                       emailVerified: true
                       createdAt: '2026-03-05T09:00:00Z'
                       verifiedAt: '2026-03-05T09:15:00Z'
@@ -295,7 +295,7 @@ components:
           type: string
           format: email
           examples:
-            - preview@matchqueue.dev
+            - preview@teampo.dev
         nickname:
           type: string
           minLength: 2
@@ -308,7 +308,7 @@ components:
             - 'null'
           format: uri
           examples:
-            - https://images.matchqueue.dev/profiles/preview.png
+            - https://images.teampo.dev/profiles/preview.png
         emailVerified:
           type: boolean
         createdAt:

--- a/public/icon-light.svg
+++ b/public/icon-light.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <!-- 
+    Team-po Icon Version (Light Mode)
+    Optimized for small sizes. Uses a clean white background with a subtle border,
+    and a dark slate stroke for the terminal prompt to match the full logo.
+  -->
+  <rect width="120" height="120" rx="28" fill="#FFFFFF" />
+  <rect x="1" y="1" width="118" height="118" rx="27" stroke="#F1F5F9" stroke-width="2" />
+  
+  <path 
+    d="M 22 44 L 48 64 L 22 84" 
+    stroke="#1E293B" 
+    stroke-width="16" 
+    stroke-linecap="round" 
+    stroke-linejoin="round" 
+  />
+  
+  <rect x="56" y="70" width="18" height="18" rx="6" fill="#10B981" />
+  <rect x="76" y="50" width="18" height="18" rx="6" fill="#3B82F6" />
+  <rect x="96" y="30" width="18" height="18" rx="6" fill="#6366F1" />
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <!-- 
+    Team-po Icon Version
+    Optimized for small sizes (favicons, app icons). 
+    Uses a dark rounded background block with thicker strokes 
+    scaled and centered for legibility.
+  -->
+  <rect width="120" height="120" rx="28" fill="#1E293B" />
+  
+  <path 
+    d="M 22 44 L 48 64 L 22 84" 
+    stroke="#F8FAFC" 
+    stroke-width="16" 
+    stroke-linecap="round" 
+    stroke-linejoin="round" 
+  />
+  
+  <rect x="56" y="70" width="18" height="18" rx="6" fill="#10B981" />
+  <rect x="76" y="50" width="18" height="18" rx="6" fill="#3B82F6" />
+  <rect x="96" y="30" width="18" height="18" rx="6" fill="#6366F1" />
+</svg>

--- a/public/logo-full.svg
+++ b/public/logo-full.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 450 120" fill="none">
+  <!-- 
+    Team-po Full Logo
+    Stroke thickness rolled back to 14. 
+    Rectangles shifted down so the top rect aligns perfectly with the visual top of the '>'.
+  -->
+  <g>
+    <!-- Terminal Prompt ">" (Top visual boundary is roughly y=37 due to stroke-width=14) -->
+    <path 
+      d="M 25 44 L 50 64 L 25 84" 
+      stroke="#1E293B" 
+      stroke-width="14" 
+      stroke-linecap="round" 
+      stroke-linejoin="round" 
+    />
+    
+    <!-- Ascending "Jandi" blocks -->
+    <rect x="58" y="77" width="16" height="16" rx="4" fill="#10B981" />
+    <rect x="78" y="57" width="16" height="16" rx="4" fill="#3B82F6" />
+    <rect x="98" y="37" width="16" height="16" rx="4" fill="#6366F1" />
+  </g>
+  
+  <!-- 
+    Typography: 
+    Sharp font leaning forward to the right (skewX -15) 
+    for a fast, forward-moving aesthetic.
+  -->
+  <g transform="translate(135, 85) skewX(-15)">
+    <text 
+      x="0" 
+      y="0" 
+      font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" 
+      font-weight="900" 
+      font-size="68" 
+      letter-spacing="-1.5"
+    >
+      <tspan fill="#1E293B">Team</tspan><tspan fill="#3B82F6">-po</tspan>
+    </text>
+  </g>
+</svg>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -4,7 +4,7 @@ export function SiteFooter() {
 	return (
 		<footer className="border-t border-border/60 bg-white/70 py-8">
 			<Container className="flex flex-col items-start justify-between gap-2 text-xs text-muted-foreground md:flex-row md:items-center">
-				<p>2026 MatchQueue. Team projects for dev learners.</p>
+				<p>2026 Team-po. Team projects for dev learners.</p>
 				<p>Random matching + lifecycle operations + weekly AI feedback.</p>
 			</Container>
 		</footer>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,4 +1,3 @@
-import { Code2 } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -21,11 +20,15 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 		<header className="sticky top-0 z-20 border-b border-border/50 bg-background/80 backdrop-blur-md">
 			<Container className="flex h-16 items-center justify-between gap-4">
 				<Link className="flex items-center gap-2" to="/">
-					<div className="flex size-9 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-soft">
-						<Code2 />
-					</div>
+					<img
+						alt="Team-po icon"
+						className="size-9 rounded-lg shadow-soft"
+						height={36}
+						src="/icon-light.svg"
+						width={36}
+					/>
 					<div>
-						<p className="font-display text-lg leading-none">MatchQueue</p>
+						<p className="font-display text-lg leading-none">Team-po</p>
 						<p className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
 							dev team project builder
 						</p>

--- a/src/features/auth/components/login-view.tsx
+++ b/src/features/auth/components/login-view.tsx
@@ -82,7 +82,7 @@ export function LoginView() {
 									email: event.target.value,
 								}));
 							}}
-							placeholder="you@matchqueue.dev"
+							placeholder="you@teampo.dev"
 							required
 							type="email"
 							value={form.email}

--- a/src/features/auth/components/signup-view.tsx
+++ b/src/features/auth/components/signup-view.tsx
@@ -130,7 +130,7 @@ export function SignupView() {
 									email: event.target.value,
 								}));
 							}}
-							placeholder="you@matchqueue.dev"
+							placeholder="you@teampo.dev"
 							required
 							type="email"
 							value={form.email}

--- a/src/features/auth/constants.ts
+++ b/src/features/auth/constants.ts
@@ -1,7 +1,7 @@
 export const previewAuth = {
-	email: "preview@matchqueue.dev",
-	password: "matchqueue123!",
-	verificationToken: "MATCHQUEUE-2026",
+	email: "preview@teampo.dev",
+	password: "teampo123!",
+	verificationToken: "TEAMPO-2026",
 };
 
 export function getProfileFallback(value: string) {

--- a/src/lib/api/mocks/auth-preview.ts
+++ b/src/lib/api/mocks/auth-preview.ts
@@ -1,12 +1,12 @@
 import type { UserProfile } from "@/lib/types/user";
 
 export const previewAuthSeed = {
-	email: "preview@matchqueue.dev",
+	email: "preview@teampo.dev",
 	nickname: "queue_runner",
-	password: "matchqueue123!",
+	password: "teampo123!",
 	profileImageUrl: "https://i.pravatar.cc/240?img=12",
 	userId: "user_preview_001",
-	verificationToken: "MATCHQUEUE-2026",
+	verificationToken: "TEAMPO-2026",
 };
 
 export function createPreviewUser(

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -37,7 +37,7 @@ function getPath(path: string) {
 }
 
 function isServerErrorTrigger(value: string) {
-	return value.trim() === "server-error@matchqueue.dev";
+	return value.trim() === "server-error@teampo.dev";
 }
 
 function isValidEmail(value: string) {
@@ -155,7 +155,7 @@ export const handlers = [
 			);
 		}
 
-		if (body.email.trim() === "taken@matchqueue.dev") {
+		if (body.email.trim() === "taken@teampo.dev") {
 			return buildErrorResponse(
 				409,
 				"이미 사용 중인 이메일입니다.",


### PR DESCRIPTION
## Summary
- replace MatchQueue branding with Team-po across the app shell and metadata
- apply the Team-po icon assets for the header, favicon, and README logo
- align mock/auth/OpenAPI example branding with the new service name

## Verification
- pnpm typecheck
- pnpm biome lint .
- pnpm build

Closes #5
