### PR TITLE
fix(branding): refresh svg logo assets

### DIFF
--- a/public/icon-light.svg
+++ b/public/icon-light.svg
@@ -1,21 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
-  <!-- 
-    Team-po Icon Version (Light Mode)
-    Optimized for small sizes. Uses a clean white background with a subtle border,
-    and a dark slate stroke for the terminal prompt to match the full logo.
-  -->
-  <rect width="120" height="120" rx="28" fill="#FFFFFF" />
-  <rect x="1" y="1" width="118" height="118" rx="27" stroke="#F1F5F9" stroke-width="2" />
-  
-  <path 
-    d="M 22 44 L 48 64 L 22 84" 
-    stroke="#1E293B" 
-    stroke-width="16" 
-    stroke-linecap="round" 
-    stroke-linejoin="round" 
-  />
-  
-  <rect x="56" y="70" width="18" height="18" rx="6" fill="#10B981" />
-  <rect x="76" y="50" width="18" height="18" rx="6" fill="#3B82F6" />
-  <rect x="96" y="30" width="18" height="18" rx="6" fill="#6366F1" />
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M94 0H26C11.6406 0 0 11.6406 0 26V94C0 108.359 11.6406 120 26 120H94C108.359 120 120 108.359 120 94V26C120 11.6406 108.359 0 94 0Z" fill="#F0F2F8" />
+  <path d="M81 59H73C70.7909 59 69 60.7909 69 63V71C69 73.2091 70.7909 75 73 75H81C83.2091 75 85 73.2091 85 71V63C85 60.7909 83.2091 59 81 59Z" fill="#2563EB" />
+  <path d="M64 76H56C53.7909 76 52 77.7909 52 80V88C52 90.2091 53.7909 92 56 92H64C66.2091 92 68 90.2091 68 88V80C68 77.7909 66.2091 76 64 76Z" fill="#44BC80" />
+  <path d="M98 42H90C87.7909 42 86 43.7909 86 46V54C86 56.2091 87.7909 58 90 58H98C100.209 58 102 56.2091 102 54V46C102 43.7909 100.209 42 98 42Z" fill="#5048E5" />
+  <path d="M29 38L53 60L29 82" stroke="#1E2A3A" stroke-width="13" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,21 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
-  <!-- 
-    Team-po Icon Version
-    Optimized for small sizes (favicons, app icons). 
-    Uses a dark rounded background block with thicker strokes 
-    scaled and centered for legibility.
-  -->
-  <rect width="120" height="120" rx="28" fill="#1E293B" />
-  
-  <path 
-    d="M 22 44 L 48 64 L 22 84" 
-    stroke="#F8FAFC" 
-    stroke-width="16" 
-    stroke-linecap="round" 
-    stroke-linejoin="round" 
-  />
-  
-  <rect x="56" y="70" width="18" height="18" rx="6" fill="#10B981" />
-  <rect x="76" y="50" width="18" height="18" rx="6" fill="#3B82F6" />
-  <rect x="96" y="30" width="18" height="18" rx="6" fill="#6366F1" />
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M94 0H26C11.6406 0 0 11.6406 0 26V94C0 108.359 11.6406 120 26 120H94C108.359 120 120 108.359 120 94V26C120 11.6406 108.359 0 94 0Z" fill="#1E2A3A" />
+  <path d="M81 59H73C70.7909 59 69 60.7909 69 63V71C69 73.2091 70.7909 75 73 75H81C83.2091 75 85 73.2091 85 71V63C85 60.7909 83.2091 59 81 59Z" fill="#3B82F6" />
+  <path d="M64 76H56C53.7909 76 52 77.7909 52 80V88C52 90.2091 53.7909 92 56 92H64C66.2091 92 68 90.2091 68 88V80C68 77.7909 66.2091 76 64 76Z" fill="#44BC80" />
+  <path d="M98 42H90C87.7909 42 86 43.7909 86 46V54C86 56.2091 87.7909 58 90 58H98C100.209 58 102 56.2091 102 54V46C102 43.7909 100.209 42 98 42Z" fill="#6366F1" />
+  <path d="M29 38L53 60L29 82" stroke="#F8FAFC" stroke-width="13" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/public/logo-full.svg
+++ b/public/logo-full.svg
@@ -1,39 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 450 120" fill="none">
-  <!-- 
-    Team-po Full Logo
-    Stroke thickness rolled back to 14. 
-    Rectangles shifted down so the top rect aligns perfectly with the visual top of the '>'.
-  -->
+<svg width="450" height="120" viewBox="0 0 450 120" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g>
-    <!-- Terminal Prompt ">" (Top visual boundary is roughly y=37 due to stroke-width=14) -->
-    <path 
-      d="M 25 44 L 50 64 L 25 84" 
-      stroke="#1E293B" 
-      stroke-width="14" 
-      stroke-linecap="round" 
-      stroke-linejoin="round" 
-    />
-    
-    <!-- Ascending "Jandi" blocks -->
-    <rect x="58" y="77" width="16" height="16" rx="4" fill="#10B981" />
-    <rect x="78" y="57" width="16" height="16" rx="4" fill="#3B82F6" />
-    <rect x="98" y="37" width="16" height="16" rx="4" fill="#6366F1" />
+    <path d="M25 44L49 60L25 76" stroke="#1E293B" stroke-width="14" stroke-linecap="round" stroke-linejoin="round" />
+    <rect x="58" y="74" width="16" height="16" rx="4" fill="#44BC80" />
+    <rect x="75" y="57" width="16" height="16" rx="4" fill="#2563EB" />
+    <rect x="92" y="40" width="16" height="16" rx="4" fill="#5048E5" />
   </g>
-  
-  <!-- 
-    Typography: 
-    Sharp font leaning forward to the right (skewX -15) 
-    for a fast, forward-moving aesthetic.
-  -->
-  <g transform="translate(135, 85) skewX(-15)">
-    <text 
-      x="0" 
-      y="0" 
-      font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" 
-      font-weight="900" 
-      font-size="68" 
-      letter-spacing="-1.5"
-    >
+  <g transform="translate(128, 85) skewX(-15)">
+    <text x="0" y="0" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-weight="900" font-size="68" letter-spacing="-1.5">
       <tspan fill="#1E293B">Team</tspan><tspan fill="#3B82F6">-po</tspan>
     </text>
   </g>


### PR DESCRIPTION
## Summary
- refresh icon-light.svg with the approved updated geometry
- align icon.svg with the same design language for dark usage
- update the logo-full.svg symbol while keeping the existing wordmark treatment

Closes #7

## Validation
- pnpm tsc --noEmit
- pnpm biome lint .
- pnpm build