### PR TITLE
feat(auth): complete profile and matching request flow

### DIFF
--- a/email-templates/email-verification.html
+++ b/email-templates/email-verification.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="ko">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="x-apple-disable-message-reformatting" />
+		<title>Team-po 이메일 인증</title>
+		<style>
+			body,
+			table,
+			td,
+			a {
+				-webkit-text-size-adjust: 100%;
+				-ms-text-size-adjust: 100%;
+			}
+
+			table {
+				border-collapse: collapse;
+			}
+
+			body {
+				width: 100%;
+				min-width: 100%;
+				margin: 0;
+				padding: 0;
+				background-color: #f8fafc;
+			}
+
+			img {
+				-ms-interpolation-mode: bicubic;
+				border: 0;
+				outline: none;
+				text-decoration: none;
+			}
+
+			a {
+				color: #2563eb;
+				text-decoration: none;
+			}
+
+			.preheader {
+				display: none;
+				visibility: hidden;
+				opacity: 0;
+				color: transparent;
+				height: 0;
+				width: 0;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body style="margin: 0; padding: 0; background-color: #f8fafc">
+		<div class="preheader">
+			Team-po 이메일 인증번호입니다. 인증번호는 5분간 유효합니다.
+		</div>
+
+		<table
+			role="presentation"
+			width="100%"
+			cellspacing="0"
+			cellpadding="0"
+			border="0"
+			style="width: 100%; background-color: #f8fafc"
+		>
+			<tr>
+				<td
+					align="center"
+					class="outer-padding"
+					style="padding: 40px 20px"
+				>
+					<table
+						role="presentation"
+						width="100%"
+						cellspacing="0"
+						cellpadding="0"
+						border="0"
+						class="shell"
+						style="width: 100%; max-width: 600px"
+					>
+						<tr>
+							<td
+								class="card-padding"
+								style="
+									padding: 40px;
+									background-color: #ffffff;
+									border: 1px solid #e2e8f0;
+									border-radius: 16px;
+									box-shadow: 0 10px 25px rgba(14, 31, 53, 0.1);
+								"
+							>
+								<table
+									role="presentation"
+									width="100%"
+									cellspacing="0"
+									cellpadding="0"
+									border="0"
+								>
+									<tr>
+										<td>
+											<div
+												style="
+													display: inline-block;
+													padding: 7px 11px;
+													background-color: #eff6ff;
+													border: 1px solid #bfdbfe;
+													border-radius: 999px;
+													color: #2563eb;
+													font-family: Arial, Helvetica, sans-serif;
+													font-size: 12px;
+													font-weight: 800;
+													line-height: 16px;
+												"
+											>
+												회원가입 인증
+											</div>
+										</td>
+									</tr>
+
+									<tr>
+										<td style="padding-top: 22px">
+											<h1
+												class="title"
+												style="
+													margin: 0;
+													color: #0f172a;
+													font-family: Arial, Helvetica, sans-serif;
+													font-size: 32px;
+													font-weight: 800;
+													letter-spacing: -0.02em;
+													line-height: 40px;
+												"
+											>
+												이메일 인증번호를 확인해 주세요
+											</h1>
+										</td>
+									</tr>
+
+									<tr>
+										<td style="padding-top: 14px">
+											<p
+												style="
+													margin: 0;
+													color: #475569;
+													font-family: Arial, Helvetica, sans-serif;
+													font-size: 15px;
+													line-height: 24px;
+												"
+											>
+												Team-po 계정 생성을 완료하려면 아래 인증번호를 인증
+												화면에 입력해 주세요. 인증번호는 발급 후 5분간만
+												유효합니다.
+											</p>
+										</td>
+									</tr>
+
+									<tr>
+										<td style="padding-top: 28px">
+											<table
+												role="presentation"
+												width="100%"
+												cellspacing="0"
+												cellpadding="0"
+												border="0"
+												style="
+													width: 100%;
+													background-color: #f1f5f9;
+													border: 1px solid #dbeafe;
+													border-radius: 14px;
+												"
+											>
+												<tr>
+													<td
+														align="center"
+														style="padding: 26px 18px 24px"
+													>
+														<div
+															style="
+																color: #64748b;
+																font-family: Arial, Helvetica, sans-serif;
+																font-size: 12px;
+																font-weight: 800;
+																letter-spacing: 0.12em;
+																line-height: 16px;
+																text-transform: uppercase;
+															"
+														>
+															인증번호
+														</div>
+														<div
+															class="code"
+															style="
+																margin-top: 10px;
+																color: #2563eb;
+																font-family: 'Courier New', Courier, monospace;
+																font-size: 44px;
+																font-weight: 700;
+																letter-spacing: 8px;
+																line-height: 52px;
+															"
+														>
+															__VERIFICATION_CODE__
+														</div>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+
+									<tr>
+										<td style="padding-top: 22px">
+											<table
+												role="presentation"
+												width="100%"
+												cellspacing="0"
+												cellpadding="0"
+												border="0"
+												style="
+													width: 100%;
+													background-color: #fff7ed;
+													border: 1px solid #fed7aa;
+													border-radius: 12px;
+												"
+											>
+												<tr>
+													<td style="padding: 16px 18px">
+														<p
+															style="
+																margin: 0;
+																color: #9a3412;
+																font-family: Arial, Helvetica, sans-serif;
+																font-size: 13px;
+																font-weight: 700;
+																line-height: 20px;
+															"
+														>
+															요청하지 않은 인증 메일이라면 이 메일을 무시해도
+															됩니다. 인증번호는 절대 다른 사람에게 공유하지 마세요.
+														</p>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+
+						<tr>
+							<td align="center" style="padding: 22px 12px 0">
+								<p
+									style="
+										margin: 0;
+										color: #64748b;
+										font-family: Arial, Helvetica, sans-serif;
+										font-size: 12px;
+										line-height: 19px;
+									"
+								>
+									이 메일은 Team-po 이메일 인증을 위해 자동 발송되었습니다.<br />
+									&copy; Team-po. All rights reserved.
+								</p>
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
+</html>

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -15,13 +15,13 @@ tags:
   - name: Users
     description: User account resources
 paths:
-  /auth/login:
+  /users/sign-in:
     post:
       tags:
         - Auth
-      operationId: loginWithEmailPassword
+      operationId: signInWithEmailPassword
       summary: Log in with email and password
-      description: Issues a session token pair and returns the current user profile.
+      description: Issues a session token pair for the authenticated user.
       requestBody:
         required: true
         content:
@@ -43,19 +43,9 @@ paths:
               examples:
                 success:
                   value:
-                    user:
-                      id: usr_01HQ7ZJ5M3P8Q2A2F4F4Q7T3VV
-                      email: preview@teampo.dev
-                      nickname: queue_runner
-                      profileImageUrl: https://images.teampo.dev/profiles/preview.png
-                      emailVerified: true
-                      createdAt: '2026-03-05T09:00:00Z'
-                      verifiedAt: '2026-03-05T09:15:00Z'
-                    session:
-                      accessToken: mq_access_demo_token
-                      refreshToken: mq_refresh_demo_token
-                      tokenType: Bearer
-                      expiresAt: '2026-03-08T18:30:00Z'
+                    accessToken: mq_access_demo_token
+                    refreshToken: mq_refresh_demo_token
+                    expiresAt: '2026-03-08T18:30:00Z'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -325,17 +315,12 @@ components:
       required:
         - accessToken
         - refreshToken
-        - tokenType
         - expiresAt
       properties:
         accessToken:
           type: string
         refreshToken:
           type: string
-        tokenType:
-          type: string
-          enum:
-            - Bearer
         expiresAt:
           type: string
           format: date-time
@@ -354,16 +339,7 @@ components:
           minLength: 8
           maxLength: 128
     LoginResponse:
-      type: object
-      additionalProperties: false
-      required:
-        - user
-        - session
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-        session:
-          $ref: '#/components/schemas/Session'
+      $ref: '#/components/schemas/Session'
     CreateUserRequest:
       type: object
       additionalProperties: false

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -52,17 +52,17 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /users:
+  /users/sign-up:
     post:
       tags:
         - Users
       operationId: createUser
       summary: Sign up a new user
-      description: Creates a user account with email/password authentication and an optional profile image upload.
+      description: Creates a user account with email/password authentication and an optional uploaded profile image key.
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/json:
             schema:
               $ref: '#/components/schemas/CreateUserRequest'
             examples:
@@ -71,29 +71,11 @@ paths:
                   email: new.dev@teampo.dev
                   password: teampo123!
                   nickname: sprintmaker
-                  profileImage: <binary image file>
+                  level: 3
+                  profileImageKey: images/sign-up/avatar.png
       responses:
-        '201':
-          description: User created and verification email queued
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateUserResponse'
-              examples:
-                success:
-                  value:
-                    user:
-                      id: usr_01HQ81GHZ4BHZSE1M6P63PQXTX
-                      email: new.dev@teampo.dev
-                      nickname: sprintmaker
-                      profileImageUrl: https://images.teampo.dev/profiles/sprintmaker.png
-                      emailVerified: false
-                      createdAt: '2026-03-08T07:00:00Z'
-                      verifiedAt: null
-                    verification:
-                      email: new.dev@teampo.dev
-                      deliveryStatus: queued
-                      resendAfterSeconds: 60
+        '200':
+          description: User created
         '400':
           $ref: '#/components/responses/BadRequest'
         '409':
@@ -165,13 +147,12 @@ paths:
                 success:
                   value:
                     user:
-                      id: usr_01HQ81GHZ4BHZSE1M6P63PQXTX
                       email: new.dev@teampo.dev
                       nickname: sprintmaker
-                      profileImageUrl: https://images.teampo.dev/profiles/sprintmaker.png
-                      emailVerified: true
-                      createdAt: '2026-03-08T07:00:00Z'
-                      verifiedAt: '2026-03-08T07:03:00Z'
+                      profileImage: https://images.teampo.dev/profiles/sprintmaker.png
+                      description: null
+                      level: 3
+                      temperature: 50
                     verifiedAt: '2026-03-08T07:03:00Z'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -194,48 +175,44 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCurrentUserResponse'
+                $ref: '#/components/schemas/User'
               examples:
                 success:
                   value:
-                    user:
-                      id: usr_01HQ7ZJ5M3P8Q2A2F4F4Q7T3VV
-                      email: preview@teampo.dev
-                      nickname: queue_runner
-                      profileImageUrl: https://images.teampo.dev/profiles/preview.png
-                      emailVerified: true
-                      createdAt: '2026-03-05T09:00:00Z'
-                      verifiedAt: '2026-03-05T09:15:00Z'
+                    email: preview@teampo.dev
+                    nickname: queue_runner
+                    profileImage: https://images.teampo.dev/profiles/preview.png
+                    description: 빠르게 실험하고, 팀원과 맥락을 맞추는 일을 좋아합니다.
+                    level: 3
+                    temperature: 50
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-    patch:
+    put:
       tags:
         - Users
       operationId: updateCurrentUser
       summary: Update the current user profile
-      description: Updates the nickname and optional profile image for the signed-in user. Email cannot be changed.
+      description: Updates the nickname, level, description, and optional uploaded profile image key for the signed-in user. Email cannot be changed.
       security:
         - bearerAuth: []
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/json:
             schema:
               $ref: '#/components/schemas/UpdateCurrentUserRequest'
             examples:
               default:
                 value:
                   nickname: sprintmaker_v2
-                  profileImage: <binary image file>
+                  level: 4
+                  description: 협업 속도를 높이는 프론트엔드 개발자입니다.
+                  profileImageKey: images/users/1/avatar.png
       responses:
         '200':
           description: Current user updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateCurrentUserResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -268,19 +245,13 @@ components:
       type: object
       additionalProperties: false
       required:
-        - id
         - email
         - nickname
-        - profileImageUrl
-        - emailVerified
-        - createdAt
-        - verifiedAt
+        - profileImage
+        - description
+        - level
+        - temperature
       properties:
-        id:
-          type: string
-          description: Unique user identifier
-          examples:
-            - usr_01HQ7ZJ5M3P8Q2A2F4F4Q7T3VV
         email:
           type: string
           format: email
@@ -292,23 +263,27 @@ components:
           maxLength: 24
           examples:
             - queue_runner
-        profileImageUrl:
+        profileImage:
           type:
             - string
             - 'null'
           format: uri
           examples:
             - https://images.teampo.dev/profiles/preview.png
-        emailVerified:
-          type: boolean
-        createdAt:
-          type: string
-          format: date-time
-        verifiedAt:
+        description:
           type:
             - string
             - 'null'
-          format: date-time
+          examples:
+            - 빠르게 실험하고, 팀원과 맥락을 맞추는 일을 좋아합니다.
+        level:
+          type: integer
+          minimum: 1
+          maximum: 5
+        temperature:
+          type: integer
+          minimum: 0
+          maximum: 100
     Session:
       type: object
       additionalProperties: false
@@ -347,6 +322,7 @@ components:
         - email
         - password
         - nickname
+        - level
       properties:
         email:
           type: string
@@ -359,11 +335,15 @@ components:
           type: string
           minLength: 2
           maxLength: 24
-        profileImage:
+        level:
+          type: integer
+          minimum: 1
+          maximum: 5
+        profileImageKey:
           type:
             - string
             - 'null'
-          format: binary
+          description: Object key returned by the profile image upload-url endpoint.
     VerificationDeliveryStatus:
       type: string
       enum:
@@ -435,36 +415,34 @@ components:
           type: string
           format: date-time
     GetCurrentUserResponse:
-      type: object
-      additionalProperties: false
-      required:
-        - user
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
+      $ref: '#/components/schemas/User'
     UpdateCurrentUserRequest:
       type: object
       additionalProperties: false
       required:
         - nickname
+        - level
+        - description
       properties:
         nickname:
           type: string
           minLength: 2
           maxLength: 24
-        profileImage:
+        level:
+          type: integer
+          minimum: 1
+          maximum: 5
+        description:
           type:
             - string
             - 'null'
-          format: binary
+        profileImageKey:
+          type:
+            - string
+            - 'null'
+          description: Object key returned by the profile image upload-url endpoint.
     UpdateCurrentUserResponse:
-      type: object
-      additionalProperties: false
-      required:
-        - user
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
+      $ref: '#/components/schemas/User'
     ApiError:
       type: object
       additionalProperties: false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { EmailVerificationPage } from "@/pages/email-verification-page";
 import { LandingPage } from "@/pages/landing-page";
 import { LoginPage } from "@/pages/login-page";
+import { MatchPage } from "@/pages/match-page";
 import { ProfilePage } from "@/pages/profile-page";
 import { TeamPoPresentationFourthPage } from "@/pages/team-po-presentation-fourth-page";
 import { SignupPage } from "@/pages/signup-page";
@@ -47,6 +48,7 @@ export function App() {
 				<Route path="/signup" element={<SignupPage />} />
 				<Route path="/verify-email" element={<EmailVerificationPage />} />
 				<Route path="/me" element={<ProfilePage />} />
+				<Route path="/match" element={<MatchPage />} />
 				<Route path="*" element={<Navigate replace to="/" />} />
 			</Routes>
 		</BrowserRouter>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
+import { getAuthSession } from "@/lib/api/auth-session";
 import { cn } from "@/lib/utils";
 
 interface SiteHeaderProps {
@@ -15,6 +17,22 @@ const authLinks = [
 
 export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 	const location = useLocation();
+	const [isSignedIn, setIsSignedIn] = useState(() => Boolean(getAuthSession()));
+
+	useEffect(() => {
+		function syncAuthState() {
+			setIsSignedIn(Boolean(getAuthSession()));
+		}
+
+		syncAuthState();
+		window.addEventListener("storage", syncAuthState);
+		window.addEventListener("focus", syncAuthState);
+
+		return () => {
+			window.removeEventListener("storage", syncAuthState);
+			window.removeEventListener("focus", syncAuthState);
+		};
+	}, []);
 
 	return (
 		<header className="sticky top-0 z-20 border-b border-border/50 bg-background/80 backdrop-blur-md">
@@ -37,33 +55,46 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 
 				<div className="flex items-center gap-2">
 					{showMyPageLink ? (
-						<Link
-							className={cn(
-								"hidden text-sm text-muted-foreground transition-colors hover:text-foreground md:inline-flex",
-								location.pathname === "/me" && "text-foreground",
-							)}
-							to="/me"
-						>
-							내 정보
-						</Link>
+						<div className="hidden items-center gap-4 md:flex">
+							<Link
+								className={cn(
+									"text-sm text-muted-foreground transition-colors hover:text-foreground",
+									location.pathname === "/match" && "text-foreground",
+								)}
+								to="/match"
+							>
+								매칭
+							</Link>
+							<Link
+								className={cn(
+									"text-sm text-muted-foreground transition-colors hover:text-foreground",
+									location.pathname === "/me" && "text-foreground",
+								)}
+								to="/me"
+							>
+								내 정보
+							</Link>
+						</div>
 					) : null}
-					{authLinks.map((item) => {
-						const isActive = location.pathname === item.to;
-						const variant =
-							item.to === "/login"
-								? isActive
-									? "default"
-									: "default"
-								: isActive
-									? "outline"
-									: "outline";
+					{isSignedIn
+						? null
+						: authLinks.map((item) => {
+								const isActive = location.pathname === item.to;
+								const variant =
+									item.to === "/login"
+										? isActive
+											? "default"
+											: "default"
+										: isActive
+											? "outline"
+											: "outline";
 
-						return (
-							<Button asChild key={item.to} size="sm" variant={variant}>
-								<Link to={item.to}>{item.label}</Link>
-							</Button>
-						);
-					})}
+								return (
+									<Button asChild key={item.to} size="sm" variant={variant}>
+										<Link to={item.to}>{item.label}</Link>
+									</Button>
+								);
+							})}
 				</div>
 			</Container>
 		</header>

--- a/src/features/auth/components/email-verification-view.tsx
+++ b/src/features/auth/components/email-verification-view.tsx
@@ -1,187 +1,32 @@
-import { useState } from "react";
-import { CheckCheck, LoaderCircle, MailCheck, RotateCcw } from "lucide-react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { ArrowRight, MailX } from "lucide-react";
+import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
-import {
-	Field,
-	FieldDescription,
-	FieldError,
-	FieldGroup,
-	FieldLabel,
-} from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { AuthShell } from "@/features/auth/components/auth-shell";
-import {
-	hasValidationErrors,
-	validateVerifyEmailForm,
-} from "@/features/auth/lib/validation";
-import {
-	useResendEmailVerificationMutation,
-	useVerifyEmailMutation,
-} from "@/features/auth/hooks/use-auth-queries";
-import { getApiErrorMessage } from "@/lib/api/client";
 
 export function EmailVerificationView() {
-	const navigate = useNavigate();
-	const [searchParams] = useSearchParams();
-	const defaultEmail = searchParams.get("email") ?? "";
-	const [form, setForm] = useState({
-		email: defaultEmail,
-		token: "",
-	});
-	const [touched, setTouched] = useState({
-		email: Boolean(defaultEmail),
-		token: false,
-	});
-	const verifyMutation = useVerifyEmailMutation();
-	const resendMutation = useResendEmailVerificationMutation();
-	const errors = validateVerifyEmailForm(form);
-	const isVerifyDisabled =
-		verifyMutation.isPending || hasValidationErrors(errors);
-	const isResendDisabled = resendMutation.isPending || Boolean(errors.email);
-
-	function markTouched(field: keyof typeof touched) {
-		setTouched((current) => ({
-			...current,
-			[field]: true,
-		}));
-	}
-
-	async function handleVerify(event: React.FormEvent<HTMLFormElement>) {
-		event.preventDefault();
-
-		setTouched({
-			email: true,
-			token: true,
-		});
-
-		if (hasValidationErrors(errors)) {
-			return;
-		}
-
-		await verifyMutation.mutateAsync(form);
-		navigate("/me");
-	}
-
 	return (
 		<AuthShell
-			badge="Verify"
-			description="가입을 마무리하려면 이메일로 받은 인증 정보를 입력해 계정을 활성화해 주세요."
-			title="이제 계정을 활성화할 차례입니다"
+			badge="Account"
+			description="가입을 마쳤다면 로그인해서 프로필을 완성하고 매칭 요청을 시작할 수 있습니다."
+			title="이제 팀 매칭을 시작할 수 있습니다"
 		>
-			<form
-				className="flex flex-col gap-6"
-				onSubmit={(event) => void handleVerify(event)}
-			>
-				<FieldGroup>
-					<Field data-invalid={Boolean(touched.email && errors.email)}>
-						<FieldLabel htmlFor="verify-email">인증 대상 이메일</FieldLabel>
-						<Input
-							aria-invalid={Boolean(touched.email && errors.email)}
-							id="verify-email"
-							onBlur={() => markTouched("email")}
-							onChange={(event) => {
-								markTouched("email");
-								setForm((current) => ({
-									...current,
-									email: event.target.value,
-								}));
-							}}
-							required
-							type="email"
-							value={form.email}
-						/>
-						{touched.email && errors.email ? (
-							<FieldError>{errors.email}</FieldError>
-						) : null}
-					</Field>
+			<div className="rounded-xl border border-border/70 bg-secondary/35 p-5 text-sm leading-6 text-muted-foreground">
+				<MailX className="mb-3 size-5 text-primary" />
+				프로필을 채워두면 팀원이 내 역할과 경험치를 더 쉽게 파악할 수
+				있습니다.
+			</div>
 
-					<Field data-invalid={Boolean(touched.token && errors.token)}>
-						<FieldLabel htmlFor="verify-token">인증 토큰</FieldLabel>
-						<Input
-							aria-invalid={Boolean(touched.token && errors.token)}
-							id="verify-token"
-							onBlur={() => markTouched("token")}
-							onChange={(event) => {
-								markTouched("token");
-								setForm((current) => ({
-									...current,
-									token: event.target.value,
-								}));
-							}}
-							placeholder="메일로 받은 토큰을 입력하세요"
-							required
-							value={form.token}
-						/>
-						{touched.token && errors.token ? (
-							<FieldError>{errors.token}</FieldError>
-						) : (
-							<FieldDescription>
-								이메일에 포함된 인증 정보를 그대로 입력해 주세요.
-							</FieldDescription>
-						)}
-					</Field>
-				</FieldGroup>
-
-				{verifyMutation.error ? (
-					<FieldError>{getApiErrorMessage(verifyMutation.error)}</FieldError>
-				) : null}
-
-				<div className="flex flex-col gap-3">
-					<Button disabled={isVerifyDisabled} size="lg" type="submit">
-						{verifyMutation.isPending ? (
-							<LoaderCircle className="animate-spin" data-icon="inline-start" />
-						) : (
-							<CheckCheck data-icon="inline-start" />
-						)}
-						이메일 인증 완료
-					</Button>
-
-					<Button
-						disabled={isResendDisabled}
-						onClick={() => {
-							markTouched("email");
-
-							if (errors.email) {
-								return;
-							}
-
-							resendMutation.mutate({ email: form.email });
-						}}
-						type="button"
-						variant="outline"
-					>
-						{resendMutation.isPending ? (
-							<LoaderCircle className="animate-spin" data-icon="inline-start" />
-						) : (
-							<RotateCcw data-icon="inline-start" />
-						)}
-						인증 메일 재전송
-					</Button>
-				</div>
-			</form>
-
-			{resendMutation.isSuccess ? (
-				<div className="mt-6 rounded-2xl border border-primary/25 bg-primary/10 p-4 text-sm leading-6 text-primary">
-					<MailCheck className="mr-2 inline-flex align-text-bottom" />
-					{form.email} 주소로 인증 메일을 다시 보냈습니다.
-				</div>
-			) : null}
-
-			<div className="mt-6 flex flex-col gap-2 text-sm">
-				<p className="text-muted-foreground">
-					입력한 이메일 주소가 다르다면 회원가입 화면으로 돌아가 다시 진행해
-					주세요.
-				</p>
-				<div className="flex flex-wrap items-center gap-4">
-					<Button asChild className="h-auto px-0" variant="link">
-						<Link to="/signup">회원가입으로 돌아가기</Link>
-					</Button>
-					<Button asChild className="h-auto px-0" variant="link">
-						<Link to="/login">로그인으로 이동</Link>
-					</Button>
-				</div>
+			<div className="mt-6 flex flex-col gap-3 sm:flex-row">
+				<Button asChild>
+					<Link to="/login">
+						<ArrowRight data-icon="inline-start" />
+						로그인으로 이동
+					</Link>
+				</Button>
+				<Button asChild variant="outline">
+					<Link to="/signup">회원가입으로 돌아가기</Link>
+				</Button>
 			</div>
 		</AuthShell>
 	);

--- a/src/features/auth/components/login-view.tsx
+++ b/src/features/auth/components/login-view.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ArrowRight, LoaderCircle } from "lucide-react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -21,12 +21,13 @@ import { getApiErrorMessage } from "@/lib/api/client";
 
 export function LoginView() {
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
 	const [form, setForm] = useState({
-		email: "",
+		email: searchParams.get("email") ?? "",
 		password: "",
 	});
 	const [touched, setTouched] = useState({
-		email: false,
+		email: Boolean(searchParams.get("email")),
 		password: false,
 	});
 	const loginMutation = useLoginMutation();

--- a/src/features/auth/components/profile-image-picker.tsx
+++ b/src/features/auth/components/profile-image-picker.tsx
@@ -1,0 +1,69 @@
+import { useRef } from "react";
+import { Camera } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+interface ProfileImagePickerProps {
+	alt: string;
+	className?: string;
+	fallback: string;
+	inputId: string;
+	invalid?: boolean;
+	onBlur?: () => void;
+	onFileChange: (file: File | null) => void;
+	previewUrl: string | null;
+	size?: "md" | "lg";
+}
+
+export function ProfileImagePicker({
+	alt,
+	className,
+	fallback,
+	inputId,
+	invalid = false,
+	onBlur,
+	onFileChange,
+	previewUrl,
+	size = "md",
+}: ProfileImagePickerProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<div className={cn("relative shrink-0", className)}>
+			<input
+				accept="image/jpeg,image/png,image/gif,image/webp"
+				aria-invalid={invalid}
+				className="sr-only"
+				id={inputId}
+				onBlur={onBlur}
+				onChange={(event) => {
+					onFileChange(event.target.files?.[0] ?? null);
+				}}
+				ref={inputRef}
+				type="file"
+			/>
+			<button
+				aria-label="프로필 이미지 변경"
+				className="group relative block rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				onClick={() => inputRef.current?.click()}
+				type="button"
+			>
+				<Avatar
+					className={cn(
+						"border border-border/70 shadow-soft transition-transform duration-200 group-hover:scale-[1.02]",
+						size === "lg" ? "size-24" : "size-16",
+						invalid && "border-destructive/60",
+					)}
+				>
+					<AvatarImage alt={alt} src={previewUrl ?? undefined} />
+					<AvatarFallback>{fallback}</AvatarFallback>
+				</Avatar>
+				<span className="absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-full bg-brand-ink/65 text-[11px] font-semibold text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100">
+					<Camera className="size-4" />
+					수정
+				</span>
+			</button>
+		</div>
+	);
+}

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import {
-	ArrowUpRight,
+	ArrowRight,
 	Camera,
+	KeyRound,
 	LoaderCircle,
-	MailCheck,
 	RefreshCcw,
 	Trash2,
 } from "lucide-react";
@@ -12,6 +12,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -31,6 +32,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { getProfileFallback } from "@/features/auth/constants";
+import { ProfileImagePicker } from "@/features/auth/components/profile-image-picker";
 import {
 	getDeleteConfirmationError,
 	hasValidationErrors,
@@ -39,27 +41,40 @@ import {
 import {
 	useCurrentUserQuery,
 	useDeleteCurrentUserMutation,
+	useEditPasswordMutation,
 	useUpdateCurrentUserMutation,
 } from "@/features/auth/hooks/use-auth-queries";
 import { getApiErrorMessage } from "@/lib/api/client";
-import { formatDateTime } from "@/lib/utils/date";
+
+const levelOptions = [1, 2, 3, 4, 5] as const;
 
 export function ProfileView() {
 	const navigate = useNavigate();
 	const currentUserQuery = useCurrentUserQuery();
 	const updateCurrentUserMutation = useUpdateCurrentUserMutation();
+	const editPasswordMutation = useEditPasswordMutation();
 	const deleteCurrentUserMutation = useDeleteCurrentUserMutation();
 	const [form, setForm] = useState({
+		description: "",
 		email: "",
+		level: 3,
 		nickname: "",
 		profileImage: null as File | null,
 	});
 	const [touched, setTouched] = useState({
-		deleteConfirm: false,
+		description: false,
+		level: false,
 		nickname: false,
 		profileImage: false,
 	});
-	const [deleteConfirmValue, setDeleteConfirmValue] = useState("");
+	const [passwordForm, setPasswordForm] = useState({
+		afterPassword: "",
+		currentPassword: "",
+	});
+	const [deleteForm, setDeleteForm] = useState({
+		confirm: "",
+		password: "",
+	});
 	const [profileImagePreviewUrl, setProfileImagePreviewUrl] = useState<
 		string | null
 	>(null);
@@ -70,7 +85,9 @@ export function ProfileView() {
 		}
 
 		setForm({
+			description: currentUserQuery.data.description ?? "",
 			email: currentUserQuery.data.email,
+			level: currentUserQuery.data.level,
 			nickname: currentUserQuery.data.nickname,
 			profileImage: null,
 		});
@@ -91,21 +108,31 @@ export function ProfileView() {
 	}, [form.profileImage]);
 
 	const formErrors = validateProfileEditForm({
+		description: form.description,
+		level: form.level,
 		nickname: form.nickname,
 		profileImage: form.profileImage,
 	});
-	const deleteConfirmError = getDeleteConfirmationError(deleteConfirmValue);
+	const deleteConfirmError = getDeleteConfirmationError(deleteForm.confirm);
 	const currentUser = currentUserQuery.data;
 	const isProfileDirty = currentUser
-		? form.nickname.trim() !== currentUser.nickname ||
+		? form.description.trim() !== (currentUser.description ?? "") ||
+			form.level !== currentUser.level ||
+			form.nickname.trim() !== currentUser.nickname ||
 			form.profileImage !== null
 		: false;
 	const isProfileSubmitDisabled =
 		!isProfileDirty ||
 		hasValidationErrors(formErrors) ||
 		updateCurrentUserMutation.isPending;
+	const isPasswordSubmitDisabled =
+		editPasswordMutation.isPending ||
+		passwordForm.currentPassword.length < 8 ||
+		passwordForm.afterPassword.length < 8;
 	const isDeleteDisabled =
-		deleteCurrentUserMutation.isPending || Boolean(deleteConfirmError);
+		deleteCurrentUserMutation.isPending ||
+		Boolean(deleteConfirmError) ||
+		deleteForm.password.length < 8;
 
 	function markTouched(field: keyof typeof touched) {
 		setTouched((current) => ({
@@ -117,11 +144,12 @@ export function ProfileView() {
 	async function handleProfileSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 
-		setTouched((current) => ({
-			...current,
+		setTouched({
+			description: true,
+			level: true,
 			nickname: true,
 			profileImage: true,
-		}));
+		});
 
 		if (
 			!currentUserQuery.data ||
@@ -132,21 +160,35 @@ export function ProfileView() {
 		}
 
 		await updateCurrentUserMutation.mutateAsync({
-			nickname: form.nickname.trim(),
+			description: form.description,
+			level: form.level,
+			nickname: form.nickname,
 			profileImage: form.profileImage,
 		});
+		setForm((current) => ({ ...current, profileImage: null }));
+	}
+
+	async function handlePasswordSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+
+		if (isPasswordSubmitDisabled) {
+			return;
+		}
+
+		await editPasswordMutation.mutateAsync(passwordForm);
+		navigate("/login", { replace: true });
 	}
 
 	async function handleDeleteSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 
-		markTouched("deleteConfirm");
-
-		if (deleteConfirmError) {
+		if (isDeleteDisabled) {
 			return;
 		}
 
-		await deleteCurrentUserMutation.mutateAsync();
+		await deleteCurrentUserMutation.mutateAsync({
+			password: deleteForm.password,
+		});
 		navigate("/", { replace: true });
 	}
 
@@ -157,14 +199,15 @@ export function ProfileView() {
 				<Container className="flex flex-col gap-6">
 					<section className="overflow-hidden rounded-[2rem] border border-border/60 bg-white p-8 shadow-panel">
 						<div className="flex flex-col gap-4">
-							<p className="text-sm font-medium uppercase tracking-[0.16em] text-muted-foreground">
-								Account settings
-							</p>
+							<Badge className="w-fit" variant="brand">
+								Account
+							</Badge>
 							<h1 className="font-display text-4xl text-brand-ink md:text-5xl">
 								내 계정을 관리하세요
 							</h1>
 							<p className="max-w-3xl text-base leading-7 text-muted-foreground md:text-lg">
-								프로필 정보를 수정하고, 필요하면 계정을 정리할 수 있습니다.
+								팀원에게 보일 소개와 레벨을 정리하고, 계정을 안전하게
+								관리하세요.
 							</p>
 						</div>
 					</section>
@@ -182,9 +225,11 @@ export function ProfileView() {
 						<Card className="border-destructive/30 bg-white/90 shadow-soft">
 							<CardHeader>
 								<CardTitle>내 정보 조회에 실패했습니다</CardTitle>
-								<CardDescription>잠시 후 다시 시도해 주세요.</CardDescription>
+								<CardDescription>
+									로그인이 만료되었거나 서버 응답을 받을 수 없습니다.
+								</CardDescription>
 							</CardHeader>
-							<CardContent>
+							<CardContent className="flex flex-wrap gap-3">
 								<Button
 									onClick={() => void currentUserQuery.refetch()}
 									variant="outline"
@@ -192,70 +237,79 @@ export function ProfileView() {
 									<RefreshCcw data-icon="inline-start" />
 									다시 불러오기
 								</Button>
+								<Button asChild>
+									<Link to="/login">로그인으로 이동</Link>
+								</Button>
 							</CardContent>
 						</Card>
 					) : null}
 
-					{currentUserQuery.data ? (
-						<div className="grid gap-6 lg:grid-cols-[1.02fr_0.98fr]">
+					{!currentUserQuery.isLoading &&
+					!currentUserQuery.isError &&
+					!currentUserQuery.data ? (
+						<Card className="border-border/60 bg-white/90 shadow-soft">
+							<CardHeader>
+								<CardTitle>로그인이 필요합니다</CardTitle>
+								<CardDescription>
+									프로필을 관리하려면 먼저 로그인해 주세요.
+								</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<Button asChild>
+									<Link to="/login">
+										<ArrowRight data-icon="inline-start" />
+										로그인
+									</Link>
+								</Button>
+							</CardContent>
+						</Card>
+					) : null}
+
+					{currentUser ? (
+						<div className="grid gap-6 lg:grid-cols-[1fr_1fr]">
 							<Card className="border-border/60 bg-white/92 shadow-panel">
-								<CardHeader className="flex flex-col gap-5">
+								<CardHeader className="gap-5">
 									<div className="flex flex-col gap-4 md:flex-row md:items-center">
 										<Avatar className="size-24 border border-border/70 shadow-soft">
 											<AvatarImage
-												alt={currentUserQuery.data.nickname}
-												src={currentUserQuery.data.profileImageUrl ?? undefined}
+												alt={currentUser.nickname}
+												src={currentUser.profileImage ?? undefined}
 											/>
 											<AvatarFallback>
-												{getProfileFallback(currentUserQuery.data.nickname)}
+												{getProfileFallback(currentUser.nickname)}
 											</AvatarFallback>
 										</Avatar>
 										<div className="flex flex-col gap-3">
-											<div className="flex flex-wrap items-center gap-2">
-												<CardTitle className="font-display text-3xl text-brand-ink">
-													{currentUserQuery.data.nickname}
-												</CardTitle>
-												<span className="rounded-full border border-border/70 bg-secondary/55 px-3 py-1 text-xs font-medium text-muted-foreground">
-													{currentUserQuery.data.emailVerified
-														? "이메일 인증 완료"
-														: "이메일 인증 대기"}
-												</span>
-											</div>
+											<CardTitle className="font-display text-3xl text-brand-ink">
+												{currentUser.nickname}
+											</CardTitle>
 											<CardDescription className="text-base">
-												{currentUserQuery.data.email}
+												{currentUser.email}
 											</CardDescription>
 										</div>
 									</div>
 								</CardHeader>
 								<CardContent className="flex flex-col gap-5">
 									<div className="grid gap-3 md:grid-cols-2">
+										<InfoCard label="개발 레벨" value={`Lv.${currentUser.level}`} />
 										<InfoCard
-											label="계정 생성 시각"
-											value={formatDateTime(currentUserQuery.data.createdAt)}
+											label="매너 온도"
+											value={`${currentUser.temperature}도`}
 										/>
-										<InfoCard
-											label="인증 완료 시각"
-											value={formatDateTime(currentUserQuery.data.verifiedAt)}
-										/>
+									</div>
+									<div className="rounded-xl border border-border/60 bg-secondary/30 p-4">
+										<p className="text-sm font-semibold text-brand-ink">소개</p>
+										<p className="mt-2 text-sm leading-6 text-muted-foreground">
+											{currentUser.description || "아직 소개가 없습니다."}
+										</p>
 									</div>
 									<Separator />
-									<div className="flex flex-col gap-3">
-										<p className="font-semibold text-brand-ink">빠른 이동</p>
-										<div className="flex flex-col gap-3 md:flex-row">
-											<Button asChild>
-												<Link to="/verify-email">
-													<MailCheck data-icon="inline-start" />
-													이메일 인증 페이지 열기
-												</Link>
-											</Button>
-											<Button asChild variant="outline">
-												<Link to="/">
-													<ArrowUpRight data-icon="inline-start" />
-													랜딩 페이지 보기
-												</Link>
-											</Button>
-										</div>
-									</div>
+									<Button asChild>
+										<Link to="/match">
+											<ArrowRight data-icon="inline-start" />
+											매칭 요청하러 가기
+										</Link>
+									</Button>
 								</CardContent>
 							</Card>
 
@@ -264,8 +318,7 @@ export function ProfileView() {
 									<CardHeader>
 										<CardTitle>내 정보 수정</CardTitle>
 										<CardDescription>
-											이메일은 고정되어 있고, 닉네임과 프로필 이미지만 수정할 수
-											있습니다.
+											닉네임, 소개, 레벨, 프로필 이미지를 수정합니다.
 										</CardDescription>
 									</CardHeader>
 									<CardContent>
@@ -273,44 +326,49 @@ export function ProfileView() {
 											className="flex flex-col gap-5"
 											onSubmit={(event) => void handleProfileSubmit(event)}
 										>
-											<div className="flex items-center gap-4 rounded-2xl border border-border/70 bg-secondary/30 p-4">
-												<Avatar className="size-16 border border-border/70">
-													<AvatarImage
-														alt={form.nickname || "프로필"}
-														src={
-															profileImagePreviewUrl ??
-															currentUserQuery.data.profileImageUrl ??
-															undefined
-														}
-													/>
-													<AvatarFallback>
-														{getProfileFallback(form.nickname || form.email)}
-													</AvatarFallback>
-												</Avatar>
+											<div className="flex items-center gap-4 rounded-xl border border-border/70 bg-secondary/30 p-4">
+												<ProfileImagePicker
+													alt={form.nickname || "프로필"}
+													fallback={getProfileFallback(form.nickname || form.email)}
+													inputId="profile-image"
+													invalid={Boolean(
+														touched.profileImage && formErrors.profileImage,
+													)}
+													onBlur={() => markTouched("profileImage")}
+													onFileChange={(file) => {
+														markTouched("profileImage");
+														setForm((current) => ({
+															...current,
+															profileImage: file,
+														}));
+													}}
+													previewUrl={
+														profileImagePreviewUrl ?? currentUser.profileImage
+													}
+												/>
 												<div className="flex flex-col gap-1">
 													<p className="font-semibold text-brand-ink">
-														{form.nickname || currentUserQuery.data.nickname}
+														{form.nickname || currentUser.nickname}
 													</p>
 													<p className="text-sm text-muted-foreground">
-														변경 사항은 저장 즉시 내 정보에 반영됩니다.
+														팀원이 처음 확인하는 이름과 이미지를 다듬어
+														보세요.
 													</p>
+													{touched.profileImage && formErrors.profileImage ? (
+														<FieldError>{formErrors.profileImage}</FieldError>
+													) : null}
 												</div>
 											</div>
 
 											<FieldGroup>
 												<Field>
-													<FieldLabel htmlFor="profile-email">
-														이메일
-													</FieldLabel>
+													<FieldLabel htmlFor="profile-email">이메일</FieldLabel>
 													<Input
 														disabled
 														id="profile-email"
 														type="email"
 														value={form.email}
 													/>
-													<FieldDescription>
-														이메일 주소는 변경할 수 없습니다.
-													</FieldDescription>
 												</Field>
 
 												<Field
@@ -339,46 +397,73 @@ export function ProfileView() {
 													/>
 													{touched.nickname && formErrors.nickname ? (
 														<FieldError>{formErrors.nickname}</FieldError>
-													) : (
-														<FieldDescription>
-															팀원에게 보여질 이름입니다.
-														</FieldDescription>
-													)}
+													) : null}
 												</Field>
 
 												<Field
 													data-invalid={Boolean(
-														touched.profileImage && formErrors.profileImage,
+														touched.description && formErrors.description,
 													)}
 												>
-													<FieldLabel htmlFor="profile-image">
-														프로필 이미지
+													<FieldLabel htmlFor="profile-description">
+														소개
 													</FieldLabel>
-													<Input
-														accept="image/*"
+													<textarea
 														aria-invalid={Boolean(
-															touched.profileImage && formErrors.profileImage,
+															touched.description && formErrors.description,
 														)}
-														id="profile-image"
-														onBlur={() => markTouched("profileImage")}
+														className="min-h-28 rounded-lg border border-input bg-white/90 px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+														id="profile-description"
+														maxLength={500}
+														onBlur={() => markTouched("description")}
 														onChange={(event) => {
-															markTouched("profileImage");
+															markTouched("description");
 															setForm((current) => ({
 																...current,
-																profileImage: event.target.files?.[0] ?? null,
+																description: event.target.value,
 															}));
 														}}
-														type="file"
+														placeholder="함께 일할 팀원에게 보여줄 소개를 입력하세요."
+														value={form.description}
 													/>
-													{touched.profileImage && formErrors.profileImage ? (
-														<FieldError>{formErrors.profileImage}</FieldError>
+													{touched.description && formErrors.description ? (
+														<FieldError>{formErrors.description}</FieldError>
 													) : (
 														<FieldDescription>
-															새 이미지를 선택하지 않으면 기존 이미지를
-															유지합니다.
+															{form.description.length}/500
 														</FieldDescription>
 													)}
 												</Field>
+
+												<Field data-invalid={Boolean(touched.level && formErrors.level)}>
+													<FieldLabel>개발 레벨</FieldLabel>
+													<div className="grid grid-cols-5 gap-2">
+														{levelOptions.map((level) => (
+															<Button
+																aria-pressed={form.level === level}
+																key={level}
+																onClick={() => {
+																	markTouched("level");
+																	setForm((current) => ({
+																		...current,
+																		level,
+																	}));
+																}}
+																type="button"
+																variant={
+																	form.level === level ? "default" : "outline"
+																}
+															>
+																Lv.{level}
+															</Button>
+														))}
+													</div>
+													<div className="flex justify-between text-xs text-muted-foreground">
+														<span>배우는 중</span>
+														<span>익숙하게 구현</span>
+													</div>
+												</Field>
+
 											</FieldGroup>
 
 											{updateCurrentUserMutation.error ? (
@@ -387,27 +472,87 @@ export function ProfileView() {
 												</FieldError>
 											) : null}
 
-											<div className="flex flex-col gap-3">
-												<Button
-													disabled={isProfileSubmitDisabled}
-													type="submit"
-												>
-													{updateCurrentUserMutation.isPending ? (
-														<LoaderCircle
-															className="animate-spin"
-															data-icon="inline-start"
-														/>
-													) : (
-														<Camera data-icon="inline-start" />
-													)}
-													변경사항 저장
-												</Button>
-												{updateCurrentUserMutation.isSuccess ? (
-													<p className="text-sm text-muted-foreground">
-														내 정보가 업데이트되었습니다.
-													</p>
-												) : null}
-											</div>
+											<Button disabled={isProfileSubmitDisabled} type="submit">
+												{updateCurrentUserMutation.isPending ? (
+													<LoaderCircle
+														className="animate-spin"
+														data-icon="inline-start"
+													/>
+												) : (
+													<Camera data-icon="inline-start" />
+												)}
+												변경사항 저장
+											</Button>
+										</form>
+									</CardContent>
+								</Card>
+
+								<Card className="border-border/60 bg-white shadow-soft">
+									<CardHeader>
+										<CardTitle>비밀번호 변경</CardTitle>
+										<CardDescription>
+											변경 후에는 다시 로그인해야 합니다.
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<form
+											className="flex flex-col gap-4"
+											onSubmit={(event) => void handlePasswordSubmit(event)}
+										>
+											<FieldGroup>
+												<Field>
+													<FieldLabel htmlFor="current-password">
+														현재 비밀번호
+													</FieldLabel>
+													<Input
+														id="current-password"
+														minLength={8}
+														onChange={(event) =>
+															setPasswordForm((current) => ({
+																...current,
+																currentPassword: event.target.value,
+															}))
+														}
+														type="password"
+														value={passwordForm.currentPassword}
+													/>
+												</Field>
+												<Field>
+													<FieldLabel htmlFor="after-password">
+														새 비밀번호
+													</FieldLabel>
+													<Input
+														id="after-password"
+														minLength={8}
+														onChange={(event) =>
+															setPasswordForm((current) => ({
+																...current,
+																afterPassword: event.target.value,
+															}))
+														}
+														type="password"
+														value={passwordForm.afterPassword}
+													/>
+												</Field>
+											</FieldGroup>
+
+											{editPasswordMutation.error ? (
+												<FieldError>
+													{getApiErrorMessage(editPasswordMutation.error)}
+												</FieldError>
+											) : null}
+
+											<Button disabled={isPasswordSubmitDisabled} type="submit">
+												{editPasswordMutation.isPending ? (
+													<LoaderCircle
+														className="animate-spin"
+														data-icon="inline-start"
+													/>
+												) : (
+													<KeyRound data-icon="inline-start" />
+												)}
+												비밀번호 변경
+											</Button>
 										</form>
 									</CardContent>
 								</Card>
@@ -416,8 +561,7 @@ export function ProfileView() {
 									<CardHeader>
 										<CardTitle>회원 탈퇴</CardTitle>
 										<CardDescription>
-											계정을 삭제하면 현재 프로필 정보는 더 이상 유지되지
-											않습니다.
+											비밀번호 확인 후 계정을 삭제합니다.
 										</CardDescription>
 									</CardHeader>
 									<CardContent>
@@ -425,35 +569,45 @@ export function ProfileView() {
 											className="flex flex-col gap-4"
 											onSubmit={(event) => void handleDeleteSubmit(event)}
 										>
-											<div className="rounded-2xl border border-destructive/15 bg-destructive/5 p-4 text-sm leading-6 text-muted-foreground">
-												탈퇴를 진행하려면 아래 입력창에{" "}
-												<strong>회원 탈퇴</strong>를 정확히 입력해 주세요.
-											</div>
-											<Field
-												data-invalid={Boolean(
-													touched.deleteConfirm && deleteConfirmError,
-												)}
-											>
-												<FieldLabel htmlFor="delete-account-confirm">
-													확인 문구
-												</FieldLabel>
-												<Input
-													aria-invalid={Boolean(
-														touched.deleteConfirm && deleteConfirmError,
-													)}
-													id="delete-account-confirm"
-													onBlur={() => markTouched("deleteConfirm")}
-													onChange={(event) => {
-														markTouched("deleteConfirm");
-														setDeleteConfirmValue(event.target.value);
-													}}
-													placeholder="회원 탈퇴"
-													value={deleteConfirmValue}
-												/>
-												{touched.deleteConfirm && deleteConfirmError ? (
-													<FieldError>{deleteConfirmError}</FieldError>
-												) : null}
-											</Field>
+											<FieldGroup>
+												<Field data-invalid={Boolean(deleteConfirmError)}>
+													<FieldLabel htmlFor="delete-account-confirm">
+														확인 문구
+													</FieldLabel>
+													<Input
+														aria-invalid={Boolean(deleteConfirmError)}
+														id="delete-account-confirm"
+														onChange={(event) =>
+															setDeleteForm((current) => ({
+																...current,
+																confirm: event.target.value,
+															}))
+														}
+														placeholder="회원 탈퇴"
+														value={deleteForm.confirm}
+													/>
+													{deleteConfirmError ? (
+														<FieldError>{deleteConfirmError}</FieldError>
+													) : null}
+												</Field>
+												<Field>
+													<FieldLabel htmlFor="delete-password">
+														비밀번호
+													</FieldLabel>
+													<Input
+														id="delete-password"
+														minLength={8}
+														onChange={(event) =>
+															setDeleteForm((current) => ({
+																...current,
+																password: event.target.value,
+															}))
+														}
+														type="password"
+														value={deleteForm.password}
+													/>
+												</Field>
+											</FieldGroup>
 
 											{deleteCurrentUserMutation.error ? (
 												<FieldError>
@@ -496,7 +650,7 @@ interface InfoCardProps {
 
 function InfoCard({ label, value }: InfoCardProps) {
 	return (
-		<div className="rounded-2xl border border-border/60 bg-white/80 px-4 py-3">
+		<div className="rounded-xl border border-border/60 bg-white/80 px-4 py-3">
 			<p className="text-sm text-muted-foreground">{label}</p>
 			<p className="mt-2 text-sm font-semibold leading-6 text-brand-ink">
 				{value}

--- a/src/features/auth/components/signup-view.tsx
+++ b/src/features/auth/components/signup-view.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
-import { ArrowRight, LoaderCircle } from "lucide-react";
+import {
+	ArrowRight,
+	CheckCircle2,
+	LoaderCircle,
+	SearchCheck,
+} from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
 	Field,
@@ -14,34 +18,47 @@ import {
 import { Input } from "@/components/ui/input";
 import { AuthShell } from "@/features/auth/components/auth-shell";
 import { getProfileFallback } from "@/features/auth/constants";
+import { ProfileImagePicker } from "@/features/auth/components/profile-image-picker";
 import {
 	hasValidationErrors,
 	validateSignupForm,
 } from "@/features/auth/lib/validation";
-import { useSignupMutation } from "@/features/auth/hooks/use-auth-queries";
+import {
+	useCheckEmailDuplicateMutation,
+	useSignupMutation,
+} from "@/features/auth/hooks/use-auth-queries";
 import { getApiErrorMessage } from "@/lib/api/client";
+
+const levelOptions = [1, 2, 3, 4, 5] as const;
 
 export function SignupView() {
 	const navigate = useNavigate();
 	const [form, setForm] = useState({
 		email: "",
+		level: 3,
 		nickname: "",
 		password: "",
+		passwordConfirm: "",
 		profileImage: null as File | null,
 	});
 	const [touched, setTouched] = useState({
 		email: false,
+		level: false,
 		nickname: false,
 		password: false,
+		passwordConfirm: false,
 		profileImage: false,
 	});
+	const [checkedEmail, setCheckedEmail] = useState<string | null>(null);
 	const [profileImagePreviewUrl, setProfileImagePreviewUrl] = useState<
 		string | null
 	>(null);
 	const signupMutation = useSignupMutation();
+	const checkEmailMutation = useCheckEmailDuplicateMutation();
 	const errors = validateSignupForm(form);
 	const isSubmitDisabled =
 		signupMutation.isPending || hasValidationErrors(errors);
+	const isEmailChecked = checkedEmail === form.email.trim().toLowerCase();
 
 	useEffect(() => {
 		if (!form.profileImage) {
@@ -69,8 +86,10 @@ export function SignupView() {
 
 		setTouched({
 			email: true,
+			level: true,
 			nickname: true,
 			password: true,
+			passwordConfirm: true,
 			profileImage: true,
 		});
 
@@ -78,36 +97,54 @@ export function SignupView() {
 			return;
 		}
 
-		const response = await signupMutation.mutateAsync(form);
+		await signupMutation.mutateAsync(form);
 
-		navigate(
-			`/verify-email?email=${encodeURIComponent(response.verification.email)}`,
-		);
+		navigate(`/login?email=${encodeURIComponent(form.email.trim())}`);
+	}
+
+	async function handleCheckEmail() {
+		markTouched("email");
+
+		if (errors.email) {
+			return;
+		}
+
+		await checkEmailMutation.mutateAsync(form.email);
+		setCheckedEmail(form.email.trim().toLowerCase());
 	}
 
 	return (
 		<AuthShell
 			badge="Signup"
-			description="이메일, 비밀번호, 닉네임으로 계정을 만들고 프로필 이미지를 더해 첫인상을 준비하세요."
-			title="첫 팀을 만들 계정을 준비하세요"
+			description="팀 매칭에 사용할 이메일, 비밀번호, 닉네임을 입력해 주세요."
+			title="회원가입"
 		>
 			<div className="mb-6 flex items-center gap-4 rounded-2xl border border-border/70 bg-secondary/35 p-4">
-				<Avatar className="size-16 border border-border/70">
-					<AvatarImage
-						alt={form.nickname || "프로필"}
-						src={profileImagePreviewUrl ?? undefined}
-					/>
-					<AvatarFallback>
-						{getProfileFallback(form.nickname || form.email)}
-					</AvatarFallback>
-				</Avatar>
+				<ProfileImagePicker
+					alt={form.nickname || "프로필"}
+					fallback={getProfileFallback(form.nickname || form.email)}
+					inputId="signup-profile-image"
+					invalid={Boolean(touched.profileImage && errors.profileImage)}
+					onBlur={() => markTouched("profileImage")}
+					onFileChange={(file) => {
+						markTouched("profileImage");
+						setForm((current) => ({
+							...current,
+							profileImage: file,
+						}));
+					}}
+					previewUrl={profileImagePreviewUrl}
+				/>
 				<div className="flex flex-col gap-1">
 					<p className="font-semibold text-brand-ink">
 						{form.nickname || "닉네임 미리보기"}
 					</p>
 					<p className="text-sm text-muted-foreground">
-						가입 전에 프로필 인상이 어떻게 보일지 확인할 수 있습니다.
+						팀원에게 보일 프로필을 미리 확인하세요.
 					</p>
+					{touched.profileImage && errors.profileImage ? (
+						<FieldError>{errors.profileImage}</FieldError>
+					) : null}
 				</div>
 			</div>
 
@@ -118,25 +155,53 @@ export function SignupView() {
 				<FieldGroup>
 					<Field data-invalid={Boolean(touched.email && errors.email)}>
 						<FieldLabel htmlFor="signup-email">이메일</FieldLabel>
-						<Input
-							aria-invalid={Boolean(touched.email && errors.email)}
-							autoComplete="email"
-							id="signup-email"
-							onBlur={() => markTouched("email")}
-							onChange={(event) => {
-								markTouched("email");
-								setForm((current) => ({
-									...current,
-									email: event.target.value,
-								}));
-							}}
-							placeholder="you@teampo.dev"
-							required
-							type="email"
-							value={form.email}
-						/>
+						<div className="flex flex-col gap-2 sm:flex-row">
+							<Input
+								aria-invalid={Boolean(touched.email && errors.email)}
+								autoComplete="email"
+								id="signup-email"
+								onBlur={() => markTouched("email")}
+								onChange={(event) => {
+									markTouched("email");
+									setCheckedEmail(null);
+									setForm((current) => ({
+										...current,
+										email: event.target.value,
+									}));
+								}}
+								placeholder="you@teampo.dev"
+								required
+								type="email"
+								value={form.email}
+							/>
+							<Button
+								className="shrink-0"
+								disabled={checkEmailMutation.isPending || Boolean(errors.email)}
+								onClick={() => void handleCheckEmail()}
+								type="button"
+								variant="outline"
+							>
+								{checkEmailMutation.isPending ? (
+									<LoaderCircle
+										className="animate-spin"
+										data-icon="inline-start"
+									/>
+								) : isEmailChecked ? (
+									<CheckCircle2 data-icon="inline-start" />
+								) : (
+									<SearchCheck data-icon="inline-start" />
+								)}
+								중복 확인
+							</Button>
+						</div>
 						{touched.email && errors.email ? (
 							<FieldError>{errors.email}</FieldError>
+						) : checkEmailMutation.error ? (
+							<FieldError>
+								{getApiErrorMessage(checkEmailMutation.error)}
+							</FieldError>
+						) : isEmailChecked ? (
+							<FieldDescription>사용할 수 있는 이메일입니다.</FieldDescription>
 						) : null}
 					</Field>
 
@@ -162,6 +227,39 @@ export function SignupView() {
 						/>
 						{touched.password && errors.password ? (
 							<FieldError>{errors.password}</FieldError>
+						) : null}
+					</Field>
+
+					<Field
+						data-invalid={Boolean(
+							touched.passwordConfirm && errors.passwordConfirm,
+						)}
+					>
+						<FieldLabel htmlFor="signup-password-confirm">
+							비밀번호 확인
+						</FieldLabel>
+						<Input
+							aria-invalid={Boolean(
+								touched.passwordConfirm && errors.passwordConfirm,
+							)}
+							autoComplete="new-password"
+							id="signup-password-confirm"
+							minLength={8}
+							onBlur={() => markTouched("passwordConfirm")}
+							onChange={(event) => {
+								markTouched("passwordConfirm");
+								setForm((current) => ({
+									...current,
+									passwordConfirm: event.target.value,
+								}));
+							}}
+							placeholder="비밀번호를 한 번 더 입력하세요"
+							required
+							type="password"
+							value={form.passwordConfirm}
+						/>
+						{touched.passwordConfirm && errors.passwordConfirm ? (
+							<FieldError>{errors.passwordConfirm}</FieldError>
 						) : null}
 					</Field>
 
@@ -193,36 +291,40 @@ export function SignupView() {
 						)}
 					</Field>
 
-					<Field
-						data-invalid={Boolean(touched.profileImage && errors.profileImage)}
-					>
-						<FieldLabel htmlFor="signup-profile-image">
-							프로필 이미지
-						</FieldLabel>
-						<Input
-							accept="image/*"
-							aria-invalid={Boolean(
-								touched.profileImage && errors.profileImage,
-							)}
-							id="signup-profile-image"
-							onBlur={() => markTouched("profileImage")}
-							onChange={(event) => {
-								markTouched("profileImage");
-								setForm((current) => ({
-									...current,
-									profileImage: event.target.files?.[0] ?? null,
-								}));
-							}}
-							type="file"
-						/>
-						{touched.profileImage && errors.profileImage ? (
-							<FieldError>{errors.profileImage}</FieldError>
+					<Field data-invalid={Boolean(touched.level && errors.level)}>
+						<FieldLabel>개발 레벨</FieldLabel>
+						<div className="grid grid-cols-5 gap-2">
+							{levelOptions.map((level) => (
+								<Button
+									aria-pressed={form.level === level}
+									key={level}
+									onClick={() => {
+										markTouched("level");
+										setForm((current) => ({
+											...current,
+											level,
+										}));
+									}}
+									type="button"
+									variant={form.level === level ? "default" : "outline"}
+								>
+									Lv.{level}
+								</Button>
+							))}
+						</div>
+						<div className="flex justify-between text-xs text-muted-foreground">
+							<span>배우는 중</span>
+							<span>익숙하게 구현</span>
+						</div>
+						{touched.level && errors.level ? (
+							<FieldError>{errors.level}</FieldError>
 						) : (
 							<FieldDescription>
-								PNG, JPG 같은 이미지 파일을 선택할 수 있습니다.
+								현재 경험치에 가까운 레벨을 선택해 주세요.
 							</FieldDescription>
 						)}
 					</Field>
+
 				</FieldGroup>
 
 				{signupMutation.error ? (

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -83,10 +83,15 @@ export function useUpdateCurrentUserMutation() {
 }
 
 export function useEditPasswordMutation() {
+	const queryClient = useQueryClient();
+
 	return useMutation({
 		mutationFn: (payload: EditPasswordRequest) => editPassword(payload),
 		onSuccess: () => {
 			clearAuthSession();
+			queryClient.removeQueries({
+				queryKey: authQueryKeys.currentUser,
+			});
 		},
 	});
 }

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -1,19 +1,26 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { login, resendEmailVerification, verifyEmail } from "@/lib/api/auth";
+import { login } from "@/lib/api/auth";
 import {
+	clearAuthSession,
+	getAuthSession,
+	setAuthSession,
+} from "@/lib/api/auth-session";
+import {
+	checkEmailDuplicate,
 	createUser,
 	deleteCurrentUser,
+	editPassword,
 	getCurrentUser,
 	updateCurrentUser,
 } from "@/lib/api/users";
+import type { CreateUserRequest, LoginRequest } from "@/lib/types/auth";
 import type {
-	CreateUserRequest,
-	LoginRequest,
-	ResendEmailVerificationRequest,
-	VerifyEmailRequest,
-} from "@/lib/types/auth";
-import type { UpdateCurrentUserRequest, UserProfile } from "@/lib/types/user";
+	DeleteCurrentUserRequest,
+	EditPasswordRequest,
+	UpdateCurrentUserRequest,
+	UserProfile,
+} from "@/lib/types/user";
 
 const authQueryKeys = {
 	currentUser: ["users", "me"] as const,
@@ -21,10 +28,8 @@ const authQueryKeys = {
 
 export function useCurrentUserQuery() {
 	return useQuery({
-		queryFn: async () => {
-			const response = await getCurrentUser();
-			return response.user;
-		},
+		enabled: Boolean(getAuthSession()),
+		queryFn: () => getCurrentUser(),
 		queryKey: authQueryKeys.currentUser,
 	});
 }
@@ -35,10 +40,8 @@ export function useLoginMutation() {
 	return useMutation({
 		mutationFn: (payload: LoginRequest) => login(payload),
 		onSuccess: (response) => {
-			queryClient.setQueryData<UserProfile>(
-				authQueryKeys.currentUser,
-				response.user,
-			);
+			setAuthSession(response);
+			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
 		},
 	});
 }
@@ -49,24 +52,9 @@ export function useSignupMutation() {
 	});
 }
 
-export function useVerifyEmailMutation() {
-	const queryClient = useQueryClient();
-
+export function useCheckEmailDuplicateMutation() {
 	return useMutation({
-		mutationFn: (payload: VerifyEmailRequest) => verifyEmail(payload),
-		onSuccess: (response) => {
-			queryClient.setQueryData<UserProfile>(
-				authQueryKeys.currentUser,
-				response.user,
-			);
-		},
-	});
-}
-
-export function useResendEmailVerificationMutation() {
-	return useMutation({
-		mutationFn: (payload: ResendEmailVerificationRequest) =>
-			resendEmailVerification(payload),
+		mutationFn: (email: string) => checkEmailDuplicate(email),
 	});
 }
 
@@ -76,11 +64,29 @@ export function useUpdateCurrentUserMutation() {
 	return useMutation({
 		mutationFn: (payload: UpdateCurrentUserRequest) =>
 			updateCurrentUser(payload),
-		onSuccess: (response) => {
-			queryClient.setQueryData<UserProfile>(
+		onSuccess: (_, payload) => {
+			queryClient.setQueryData<UserProfile | undefined>(
 				authQueryKeys.currentUser,
-				response.user,
+				(current) =>
+					current
+						? {
+								...current,
+								description: payload.description.trim() || null,
+								level: payload.level,
+								nickname: payload.nickname.trim(),
+							}
+						: current,
 			);
+			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
+		},
+	});
+}
+
+export function useEditPasswordMutation() {
+	return useMutation({
+		mutationFn: (payload: EditPasswordRequest) => editPassword(payload),
+		onSuccess: () => {
+			clearAuthSession();
 		},
 	});
 }
@@ -89,8 +95,10 @@ export function useDeleteCurrentUserMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: () => deleteCurrentUser(),
+		mutationFn: (payload: DeleteCurrentUserRequest) =>
+			deleteCurrentUser(payload),
 		onSuccess: () => {
+			clearAuthSession();
 			queryClient.removeQueries({
 				queryKey: authQueryKeys.currentUser,
 			});

--- a/src/features/auth/lib/validation.ts
+++ b/src/features/auth/lib/validation.ts
@@ -5,8 +5,10 @@ export interface LoginFormValues {
 
 export interface SignupFormValues {
 	email: string;
+	level: number;
 	nickname: string;
 	password: string;
+	passwordConfirm: string;
 	profileImage: File | null;
 }
 
@@ -16,6 +18,8 @@ export interface VerifyEmailFormValues {
 }
 
 export interface ProfileEditFormValues {
+	description: string;
+	level: number;
 	nickname: string;
 	profileImage: File | null;
 }
@@ -27,6 +31,7 @@ const minimumPasswordLength = 8;
 const minimumNicknameLength = 2;
 const maximumNicknameLength = 24;
 const maximumProfileImageSize = 5 * 1024 * 1024;
+const maximumDescriptionLength = 500;
 
 export function validateLoginForm(
 	values: LoginFormValues,
@@ -42,8 +47,13 @@ export function validateSignupForm(
 ): FormErrors<SignupFormValues> {
 	return {
 		email: getEmailError(values.email),
+		level: getLevelError(values.level),
 		nickname: getNicknameError(values.nickname),
 		password: getPasswordError(values.password),
+		passwordConfirm: getPasswordConfirmError(
+			values.password,
+			values.passwordConfirm,
+		),
 		profileImage: getProfileImageError(values.profileImage),
 	};
 }
@@ -61,6 +71,8 @@ export function validateProfileEditForm(
 	values: ProfileEditFormValues,
 ): FormErrors<ProfileEditFormValues> {
 	return {
+		description: getDescriptionError(values.description),
+		level: getLevelError(values.level),
 		nickname: getNicknameError(values.nickname),
 		profileImage: getProfileImageError(values.profileImage),
 	};
@@ -96,6 +108,18 @@ function getPasswordError(value: string) {
 	return undefined;
 }
 
+function getPasswordConfirmError(password: string, passwordConfirm: string) {
+	if (!passwordConfirm) {
+		return "비밀번호 확인을 입력해 주세요.";
+	}
+
+	if (password !== passwordConfirm) {
+		return "비밀번호가 일치하지 않아요.";
+	}
+
+	return undefined;
+}
+
 function getNicknameError(value: string) {
 	const trimmedValue = value.trim();
 
@@ -125,6 +149,26 @@ function getProfileImageError(file: File | null) {
 
 	if (file.size > maximumProfileImageSize) {
 		return "프로필 이미지는 5MB 이하만 업로드할 수 있어요.";
+	}
+
+	return undefined;
+}
+
+function getLevelError(value: number) {
+	if (!Number.isInteger(value)) {
+		return "레벨을 선택해 주세요.";
+	}
+
+	if (value < 1 || value > 5) {
+		return "레벨은 1부터 5까지 선택할 수 있어요.";
+	}
+
+	return undefined;
+}
+
+function getDescriptionError(value: string) {
+	if (value.length > maximumDescriptionLength) {
+		return "소개는 500자 이하여야 해요.";
 	}
 
 	return undefined;

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -1,0 +1,416 @@
+import { useState } from "react";
+import {
+	ArrowRight,
+	Clock3,
+	LoaderCircle,
+	RefreshCcw,
+	Send,
+	Square,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { SiteFooter } from "@/components/site-footer";
+import { SiteHeader } from "@/components/site-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
+import {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldGroup,
+	FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+	useCancelProjectRequestMutation,
+	useCreateProjectRequestMutation,
+	useProjectRequestStatusQuery,
+} from "@/features/match/hooks/use-match-queries";
+import { getAuthSession } from "@/lib/api/auth-session";
+import { ApiError, getApiErrorMessage } from "@/lib/api/client";
+import type { MatchRole, MatchStatus } from "@/lib/types/match";
+import { cn } from "@/lib/utils";
+
+const roleOptions: Array<{
+	description: string;
+	label: string;
+	value: MatchRole;
+}> = [
+	{
+		description: "인증, 저장, 배포처럼 서비스의 기반을 맡습니다.",
+		label: "Backend",
+		value: "BE",
+	},
+	{
+		description: "화면, 상태 관리, 사용자 흐름을 구현합니다.",
+		label: "Frontend",
+		value: "FE",
+	},
+	{
+		description: "문제 정의, UX, 시각 시스템을 정리합니다.",
+		label: "Design",
+		value: "DESIGN",
+	},
+];
+
+const statusMeta: Record<
+	MatchStatus,
+	{ description: string; label: string; tone: string }
+> = {
+	CANCELED: {
+		description: "요청이 취소되었습니다. 새 요청을 다시 보낼 수 있습니다.",
+		label: "취소됨",
+		tone: "border-muted-foreground/20 bg-secondary text-muted-foreground",
+	},
+	MATCHED: {
+		description: "팀 구성이 완료된 상태입니다.",
+		label: "매칭 완료",
+		tone: "border-emerald-500/25 bg-emerald-500/10 text-emerald-700",
+	},
+	MATCHING: {
+		description: "조건에 맞는 팀원을 찾고 있습니다.",
+		label: "매칭 중",
+		tone: "border-primary/25 bg-primary/10 text-primary",
+	},
+	WAITING: {
+		description: "요청이 접수되어 대기열에 올라갔습니다.",
+		label: "대기 중",
+		tone: "border-amber-500/25 bg-amber-500/10 text-amber-700",
+	},
+};
+
+export function MatchRequestView() {
+	const statusQuery = useProjectRequestStatusQuery();
+	const createMutation = useCreateProjectRequestMutation();
+	const cancelMutation = useCancelProjectRequestMutation();
+	const isSignedIn = Boolean(getAuthSession());
+	const [form, setForm] = useState({
+		projectDescription: "",
+		projectMvp: "",
+		projectTitle: "",
+		role: "FE" as MatchRole,
+	});
+	const noActiveRequest =
+		statusQuery.data === null ||
+		(statusQuery.error instanceof ApiError && statusQuery.error.status === 404);
+	const status = statusQuery.data?.status;
+	const canCancel = status === "WAITING" || status === "MATCHING";
+	const isSubmitDisabled =
+		!isSignedIn || createMutation.isPending || Boolean(status && canCancel);
+
+	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+
+		if (isSubmitDisabled) {
+			return;
+		}
+
+		await createMutation.mutateAsync({
+			projectDescription: emptyToNull(form.projectDescription),
+			projectMvp: emptyToNull(form.projectMvp),
+			projectTitle: emptyToNull(form.projectTitle),
+			role: form.role,
+		});
+	}
+
+	return (
+		<div className="flex min-h-screen flex-col bg-secondary/20">
+			<SiteHeader />
+			<main className="flex-1 py-10 md:py-16">
+				<Container className="flex flex-col gap-6">
+					<section className="overflow-hidden rounded-[2rem] border border-border/60 bg-white p-8 shadow-panel">
+						<div className="flex flex-col gap-4">
+							<Badge className="w-fit" variant="brand">
+								Matching
+							</Badge>
+							<div className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-end">
+								<div className="flex flex-col gap-4">
+									<h1 className="font-display text-4xl text-brand-ink md:text-5xl">
+										프로젝트 매칭을 요청하세요
+									</h1>
+									<p className="max-w-3xl text-base leading-7 text-muted-foreground md:text-lg">
+										내 역할과 만들고 싶은 프로젝트 방향을 남기면 대기열에
+										등록됩니다.
+									</p>
+								</div>
+								<Button asChild variant="outline">
+									<Link to="/me">
+										<ArrowRight data-icon="inline-start" />
+										내 프로필 확인
+									</Link>
+								</Button>
+							</div>
+						</div>
+					</section>
+
+					{!isSignedIn ? (
+						<Card className="border-border/60 bg-white/90 shadow-soft">
+							<CardHeader>
+								<CardTitle>로그인이 필요합니다</CardTitle>
+								<CardDescription>
+									매칭 요청은 로그인한 사용자만 등록할 수 있습니다.
+								</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<Button asChild>
+									<Link to="/login">
+										<ArrowRight data-icon="inline-start" />
+										로그인
+									</Link>
+								</Button>
+							</CardContent>
+						</Card>
+					) : null}
+
+					<div className="grid gap-6 lg:grid-cols-[0.82fr_1.18fr]">
+						<Card className="border-border/60 bg-white shadow-soft">
+							<CardHeader>
+								<CardTitle>현재 매칭 상태</CardTitle>
+								<CardDescription>
+									진행 중인 요청이 있으면 여기에서 확인하고 취소할 수
+									있습니다.
+								</CardDescription>
+							</CardHeader>
+							<CardContent className="flex flex-col gap-4">
+								{statusQuery.isLoading ? (
+									<StatusPanel
+										description="내 요청이 대기 중인지 확인하고 있습니다."
+										icon={<LoaderCircle className="animate-spin" />}
+										label="조회 중"
+									/>
+								) : status ? (
+									<StatusPanel
+										description={statusMeta[status].description}
+										label={statusMeta[status].label}
+										tone={statusMeta[status].tone}
+									/>
+								) : noActiveRequest || !isSignedIn ? (
+									<StatusPanel
+										description="진행 중인 매칭 요청이 없습니다."
+										icon={<Square />}
+										label="요청 없음"
+									/>
+								) : statusQuery.isError ? (
+									<StatusPanel
+										description={getApiErrorMessage(statusQuery.error)}
+										label="조회 실패"
+										tone="border-destructive/25 bg-destructive/10 text-destructive"
+									/>
+								) : null}
+
+								<div className="flex flex-col gap-3 sm:flex-row">
+									<Button
+										disabled={!isSignedIn || statusQuery.isFetching}
+										onClick={() => void statusQuery.refetch()}
+										type="button"
+										variant="outline"
+									>
+										<RefreshCcw data-icon="inline-start" />
+										상태 새로고침
+									</Button>
+									<Button
+										disabled={!canCancel || cancelMutation.isPending}
+										onClick={() => void cancelMutation.mutateAsync()}
+										type="button"
+										variant="outline"
+									>
+										{cancelMutation.isPending ? (
+											<LoaderCircle
+												className="animate-spin"
+												data-icon="inline-start"
+											/>
+										) : (
+											<Square data-icon="inline-start" />
+										)}
+										요청 취소
+									</Button>
+								</div>
+
+								{cancelMutation.error ? (
+									<FieldError>
+										{getApiErrorMessage(cancelMutation.error)}
+									</FieldError>
+								) : null}
+							</CardContent>
+						</Card>
+
+						<Card className="border-border/60 bg-white shadow-panel">
+							<CardHeader>
+								<CardTitle>매칭 요청 작성</CardTitle>
+								<CardDescription>
+									역할만 선택해도 요청할 수 있고, 프로젝트 정보는 나중에 채워도 됩니다.
+								</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<form
+									className="flex flex-col gap-6"
+									onSubmit={(event) => void handleSubmit(event)}
+								>
+									<FieldGroup>
+										<Field>
+											<FieldLabel>
+												참여 역할
+												<Badge className="ml-2 font-display" variant="brand">
+													필수
+												</Badge>
+											</FieldLabel>
+											<div className="grid gap-3 md:grid-cols-3">
+												{roleOptions.map((role) => (
+													<button
+														aria-pressed={form.role === role.value}
+														className={cn(
+															"min-h-28 rounded-xl border bg-white p-4 text-left transition-all hover:-translate-y-0.5 hover:shadow-soft",
+															form.role === role.value
+																? "border-primary bg-primary/5 shadow-soft"
+																: "border-border/70",
+														)}
+														key={role.value}
+														onClick={() =>
+															setForm((current) => ({
+																...current,
+																role: role.value,
+															}))
+														}
+														type="button"
+													>
+														<span className="text-sm font-semibold text-brand-ink">
+															{role.label}
+														</span>
+														<span className="mt-2 block text-sm leading-6 text-muted-foreground">
+															{role.description}
+														</span>
+													</button>
+												))}
+											</div>
+										</Field>
+
+										<Field>
+											<FieldLabel htmlFor="project-title">
+												프로젝트 제목
+												<Badge className="ml-2 font-display" variant="neutral">
+													선택
+												</Badge>
+											</FieldLabel>
+											<Input
+												id="project-title"
+												onChange={(event) =>
+													setForm((current) => ({
+														...current,
+														projectTitle: event.target.value,
+													}))
+												}
+												placeholder="선택 입력: 예: 개발자 사이드 프로젝트 팀빌딩 서비스"
+												value={form.projectTitle}
+											/>
+										</Field>
+
+										<Field>
+											<FieldLabel htmlFor="project-description">
+												프로젝트 설명
+												<Badge className="ml-2 font-display" variant="neutral">
+													선택
+												</Badge>
+											</FieldLabel>
+											<textarea
+												className="min-h-28 rounded-lg border border-input bg-white/90 px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+												id="project-description"
+												onChange={(event) =>
+													setForm((current) => ({
+														...current,
+														projectDescription: event.target.value,
+													}))
+												}
+												placeholder="선택 입력: 어떤 문제를 해결하고 싶은지 간단히 적어주세요."
+												value={form.projectDescription}
+											/>
+										</Field>
+
+										<Field>
+											<FieldLabel htmlFor="project-mvp">
+												MVP 범위
+												<Badge className="ml-2 font-display" variant="neutral">
+													선택
+												</Badge>
+											</FieldLabel>
+											<textarea
+												className="min-h-24 rounded-lg border border-input bg-white/90 px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+												id="project-mvp"
+												onChange={(event) =>
+													setForm((current) => ({
+														...current,
+														projectMvp: event.target.value,
+													}))
+												}
+												placeholder="선택 입력: 첫 버전에서 꼭 만들고 싶은 기능을 적어주세요."
+												value={form.projectMvp}
+											/>
+											<FieldDescription>
+												프로젝트 정보 3개는 모두 비워도 됩니다. 역할 정보만으로 매칭 요청이 등록됩니다.
+											</FieldDescription>
+										</Field>
+									</FieldGroup>
+
+									{createMutation.error ? (
+										<FieldError>
+											{getApiErrorMessage(createMutation.error)}
+										</FieldError>
+									) : null}
+
+									<Button disabled={isSubmitDisabled} size="lg" type="submit">
+										{createMutation.isPending ? (
+											<LoaderCircle
+												className="animate-spin"
+												data-icon="inline-start"
+											/>
+										) : (
+											<Send data-icon="inline-start" />
+										)}
+										매칭 요청 보내기
+									</Button>
+								</form>
+							</CardContent>
+						</Card>
+					</div>
+				</Container>
+			</main>
+			<SiteFooter />
+		</div>
+	);
+}
+
+function emptyToNull(value: string) {
+	const trimmedValue = value.trim();
+	return trimmedValue ? trimmedValue : null;
+}
+
+interface StatusPanelProps {
+	description: string;
+	icon?: React.ReactNode;
+	label: string;
+	tone?: string;
+}
+
+function StatusPanel({
+	description,
+	icon = <Clock3 />,
+	label,
+	tone = "border-border/70 bg-secondary/40 text-brand-ink",
+}: StatusPanelProps) {
+	return (
+		<div className={cn("rounded-xl border p-4", tone)}>
+			<div className="flex items-center gap-2 font-semibold">
+				<span className="[&_svg]:size-4">{icon}</span>
+				{label}
+			</div>
+			<p className="mt-2 text-sm leading-6 opacity-80">{description}</p>
+		</div>
+	);
+}

--- a/src/features/match/hooks/use-match-queries.ts
+++ b/src/features/match/hooks/use-match-queries.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+	cancelProjectRequest,
+	createProjectRequest,
+	getProjectRequestStatus,
+} from "@/lib/api/match";
+import { getAuthSession } from "@/lib/api/auth-session";
+import type {
+	ProjectRequestPayload,
+	ProjectRequestStatusResponse,
+} from "@/lib/types/match";
+
+export const matchQueryKeys = {
+	status: ["match", "status"] as const,
+};
+
+export function useProjectRequestStatusQuery() {
+	return useQuery<ProjectRequestStatusResponse | null>({
+		enabled: Boolean(getAuthSession()),
+		queryFn: () => getProjectRequestStatus(),
+		queryKey: matchQueryKeys.status,
+		retry: false,
+	});
+}
+
+export function useCreateProjectRequestMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: ProjectRequestPayload) =>
+			createProjectRequest(payload),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
+		},
+	});
+}
+
+export function useCancelProjectRequestMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => cancelProjectRequest(),
+		onSuccess: () => {
+			queryClient.setQueryData<ProjectRequestStatusResponse | null>(
+				matchQueryKeys.status,
+				null,
+			);
+			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
+		},
+	});
+}

--- a/src/lib/api/auth-session.ts
+++ b/src/lib/api/auth-session.ts
@@ -1,0 +1,42 @@
+export interface AuthSession {
+	accessToken: string;
+	expiresAt: string;
+	refreshToken: string;
+}
+
+const authSessionStorageKey = "team-po.auth-session";
+
+export function getAuthSession() {
+	if (typeof window === "undefined") {
+		return null;
+	}
+
+	const rawValue = window.localStorage.getItem(authSessionStorageKey);
+
+	if (!rawValue) {
+		return null;
+	}
+
+	try {
+		return JSON.parse(rawValue) as AuthSession;
+	} catch {
+		window.localStorage.removeItem(authSessionStorageKey);
+		return null;
+	}
+}
+
+export function setAuthSession(session: AuthSession) {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	window.localStorage.setItem(authSessionStorageKey, JSON.stringify(session));
+}
+
+export function clearAuthSession() {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	window.localStorage.removeItem(authSessionStorageKey);
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,35 +1,10 @@
 import { apiRequest } from "@/lib/api/client";
-import type {
-	LoginRequest,
-	LoginResponse,
-	ResendEmailVerificationRequest,
-	ResendEmailVerificationResponse,
-	VerifyEmailRequest,
-	VerifyEmailResponse,
-} from "@/lib/types/auth";
+import type { LoginRequest, LoginResponse } from "@/lib/types/auth";
 
 export function login(payload: LoginRequest) {
-	return apiRequest<LoginResponse>("/auth/login", {
+	return apiRequest<LoginResponse>("/users/sign-in", {
 		json: payload,
 		method: "POST",
-	});
-}
-
-export function resendEmailVerification(
-	payload: ResendEmailVerificationRequest,
-) {
-	return apiRequest<ResendEmailVerificationResponse>(
-		"/auth/email-verifications",
-		{
-			json: payload,
-			method: "POST",
-		},
-	);
-}
-
-export function verifyEmail(payload: VerifyEmailRequest) {
-	return apiRequest<VerifyEmailResponse>("/auth/email-verifications/confirm", {
-		json: payload,
-		method: "POST",
+		skipAuth: true,
 	});
 }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,9 +1,16 @@
 import { apiConfig } from "@/lib/api/config";
+import {
+	clearAuthSession,
+	getAuthSession,
+	setAuthSession,
+} from "@/lib/api/auth-session";
 import type { ApiErrorResponse } from "@/lib/types/api";
 
 interface ApiRequestOptions extends Omit<RequestInit, "body"> {
 	body?: BodyInit | null;
 	json?: unknown;
+	skipAuth?: boolean;
+	skipRefresh?: boolean;
 }
 
 export class ApiError extends Error {
@@ -23,17 +30,29 @@ export class ApiError extends Error {
 
 export async function apiRequest<T>(
 	path: string,
-	{ body, json, headers, ...init }: ApiRequestOptions = {},
+	{
+		body,
+		json,
+		headers,
+		skipAuth = false,
+		skipRefresh = false,
+		...init
+	}: ApiRequestOptions = {},
 ) {
-	const response = await fetch(`${apiConfig.baseUrl}${path}`, {
-		...init,
-		body: body ?? (json ? JSON.stringify(json) : undefined),
-		headers: {
-			Accept: "application/json",
-			...(json && !body ? { "Content-Type": "application/json" } : {}),
-			...headers,
-		},
-	});
+	const requestInit = buildRequestInit({ body, headers, init, json, skipAuth });
+	let response = await fetch(`${apiConfig.baseUrl}${path}`, requestInit);
+
+	if (response.status === 401 && !skipRefresh && !skipAuth) {
+		const refreshed = await refreshAccessToken();
+
+		if (refreshed) {
+			response = await fetch(
+				`${apiConfig.baseUrl}${path}`,
+				buildRequestInit({ body, headers, init, json, skipAuth }),
+			);
+		}
+	}
+
 	const text = await response.text();
 	const data = text ? safeJsonParse(text) : null;
 
@@ -45,6 +64,68 @@ export async function apiRequest<T>(
 	}
 
 	return data as T;
+}
+
+function buildRequestInit({
+	body,
+	headers,
+	init,
+	json,
+	skipAuth,
+}: {
+	body?: BodyInit | null;
+	headers?: HeadersInit;
+	init: Omit<ApiRequestOptions, "body" | "json" | "headers" | "skipAuth">;
+	json?: unknown;
+	skipAuth: boolean;
+}): RequestInit {
+	const session = skipAuth ? null : getAuthSession();
+
+	return {
+		...init,
+		body: body ?? (json ? JSON.stringify(json) : undefined),
+		headers: {
+			Accept: "application/json",
+			...(json && !body ? { "Content-Type": "application/json" } : {}),
+			...(session ? { Authorization: `Bearer ${session.accessToken}` } : {}),
+			...headers,
+		},
+	};
+}
+
+async function refreshAccessToken() {
+	const session = getAuthSession();
+
+	if (!session?.refreshToken) {
+		return false;
+	}
+
+	const response = await fetch(`${apiConfig.baseUrl}/users/refresh-token`, {
+		body: JSON.stringify({ refreshToken: session.refreshToken }),
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json",
+		},
+		method: "POST",
+	});
+
+	if (!response.ok) {
+		clearAuthSession();
+		return false;
+	}
+
+	const data = (await response.json()) as {
+		accessToken: string;
+		expiresAt: string;
+	};
+
+	setAuthSession({
+		...session,
+		accessToken: data.accessToken,
+		expiresAt: data.expiresAt,
+	});
+
+	return true;
 }
 
 export function getApiErrorMessage(

--- a/src/lib/api/match.ts
+++ b/src/lib/api/match.ts
@@ -1,0 +1,22 @@
+import { apiRequest } from "@/lib/api/client";
+import type {
+	ProjectRequestPayload,
+	ProjectRequestStatusResponse,
+} from "@/lib/types/match";
+
+export function createProjectRequest(payload: ProjectRequestPayload) {
+	return apiRequest<void>("/match/request", {
+		json: payload,
+		method: "POST",
+	});
+}
+
+export function cancelProjectRequest() {
+	return apiRequest<void>("/match/cancel", {
+		method: "PATCH",
+	});
+}
+
+export function getProjectRequestStatus() {
+	return apiRequest<ProjectRequestStatusResponse>("/match/status");
+}

--- a/src/lib/api/mocks/auth-preview.ts
+++ b/src/lib/api/mocks/auth-preview.ts
@@ -4,22 +4,19 @@ export const previewAuthSeed = {
 	email: "preview@teampo.dev",
 	nickname: "queue_runner",
 	password: "teampo123!",
-	profileImageUrl: "https://i.pravatar.cc/240?img=12",
-	userId: "user_preview_001",
-	verificationToken: "TEAMPO-2026",
+	profileImage: "https://i.pravatar.cc/240?img=12",
 };
 
 export function createPreviewUser(
 	overrides: Partial<UserProfile> = {},
 ): UserProfile {
 	return {
-		createdAt: "2026-03-08T09:00:00.000Z",
+		description: "빠르게 실험하고, 팀원과 맥락을 맞추는 일을 좋아합니다.",
 		email: previewAuthSeed.email,
-		emailVerified: false,
-		id: previewAuthSeed.userId,
+		level: 3,
 		nickname: previewAuthSeed.nickname,
-		profileImageUrl: previewAuthSeed.profileImageUrl,
-		verifiedAt: null,
+		profileImage: previewAuthSeed.profileImage,
+		temperature: 50,
 		...overrides,
 	};
 }

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -1,21 +1,20 @@
 import { delay, http, HttpResponse } from "msw";
 
 import { apiConfig } from "@/lib/api/config";
-import {
-	createPreviewUser,
-	previewAuthSeed,
-} from "@/lib/api/mocks/auth-preview";
-import type {
-	CreateUserRequest,
-	LoginRequest,
-	ResendEmailVerificationRequest,
-	VerifyEmailRequest,
-} from "@/lib/types/auth";
+import { createPreviewUser, previewAuthSeed } from "@/lib/api/mocks/auth-preview";
+import type { CreateUserRequest, LoginRequest } from "@/lib/types/auth";
 import type { ApiErrorResponse } from "@/lib/types/api";
-import type { UpdateCurrentUserRequest, UserProfile } from "@/lib/types/user";
+import type { MatchStatus, ProjectRequestPayload } from "@/lib/types/match";
+import type {
+	DeleteCurrentUserRequest,
+	EditPasswordRequest,
+	UpdateCurrentUserRequest,
+	UserProfile,
+} from "@/lib/types/user";
 
 let currentUser: UserProfile | null = createPreviewUser();
 let currentPassword = previewAuthSeed.password;
+let matchStatus: MatchStatus | null = null;
 
 function buildErrorResponse(
 	status: number,
@@ -44,56 +43,29 @@ function isValidEmail(value: string) {
 	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
 
-async function readCreateUserFormData(request: Request) {
-	const formData = await request.formData();
-	const profileImageValue = formData.get("profileImage");
-
-	return {
-		email: String(formData.get("email") ?? ""),
-		nickname: String(formData.get("nickname") ?? ""),
-		password: String(formData.get("password") ?? ""),
-		profileImage: profileImageValue instanceof File ? profileImageValue : null,
-	};
-}
-
-async function readUpdateUserFormData(
-	request: Request,
-): Promise<UpdateCurrentUserRequest> {
-	const formData = await request.formData();
-	const profileImageValue = formData.get("profileImage");
-
-	return {
-		nickname: String(formData.get("nickname") ?? ""),
-		profileImage: profileImageValue instanceof File ? profileImageValue : null,
-	};
-}
-
-async function fileToDataUrl(file: File) {
-	const buffer = await file.arrayBuffer();
-	const bytes = new Uint8Array(buffer);
-	let binary = "";
-
-	for (const byte of bytes) {
-		binary += String.fromCharCode(byte);
-	}
-
-	return `data:${file.type};base64,${btoa(binary)}`;
+function isSupportedImageType(value: string) {
+	return ["image/jpeg", "image/png", "image/gif", "image/webp"].includes(
+		value.trim().toLowerCase(),
+	);
 }
 
 function buildSession() {
 	return {
 		accessToken: "mock-access-token",
-		expiresAt: "2026-03-09T09:00:00.000Z",
+		expiresAt: "2026-04-20T12:00:00.000Z",
 		refreshToken: "mock-refresh-token",
-		tokenType: "Bearer" as const,
 	};
 }
 
+function imageUrlFromKey(objectKey: string | undefined) {
+	return objectKey ? `https://images.teampo.dev/${objectKey}` : null;
+}
+
 export const handlers = [
-	http.post(getPath("/auth/login"), async ({ request }) => {
+	http.post(getPath("/users/sign-in"), async ({ request }) => {
 		const body = (await request.json()) as LoginRequest;
 
-		await delay(500);
+		await delay(400);
 
 		if (isServerErrorTrigger(body.email)) {
 			return buildErrorResponse(
@@ -106,7 +78,7 @@ export const handlers = [
 		if (!currentUser) {
 			return buildErrorResponse(
 				401,
-				"가입된 계정을 찾지 못했거나 비밀번호가 일치하지 않습니다.",
+				"이메일 또는 비밀번호가 올바르지 않습니다.",
 				"invalid_credentials",
 			);
 		}
@@ -114,38 +86,91 @@ export const handlers = [
 		if (!isValidEmail(body.email) || body.password.length < 8) {
 			return buildErrorResponse(
 				400,
-				"이메일 또는 비밀번호 형식이 올바르지 않습니다.",
+				"입력값이 올바르지 않습니다.",
 				"validation_error",
-				{
-					email: !isValidEmail(body.email)
-						? ["유효한 이메일을 입력해 주세요."]
-						: [],
-					password:
-						body.password.length < 8
-							? ["비밀번호는 8자 이상이어야 합니다."]
-							: [],
-				},
 			);
 		}
 
 		if (body.email !== currentUser.email || body.password !== currentPassword) {
 			return buildErrorResponse(
 				401,
-				"가입된 계정을 찾지 못했거나 비밀번호가 일치하지 않습니다.",
+				"이메일 또는 비밀번호가 올바르지 않습니다.",
 				"invalid_credentials",
 			);
 		}
 
+		return HttpResponse.json(buildSession());
+	}),
+
+	http.post(getPath("/users/refresh-token"), async ({ request }) => {
+		const body = (await request.json()) as { refreshToken: string };
+
+		await delay(150);
+
+		if (body.refreshToken !== "mock-refresh-token") {
+			return buildErrorResponse(
+				401,
+				"유효하지 않은 리프레시 토큰입니다.",
+				"invalid_token",
+			);
+		}
+
 		return HttpResponse.json({
-			session: buildSession(),
-			user: currentUser,
+			accessToken: "mock-access-token-refreshed",
+			expiresAt: "2026-04-20T13:00:00.000Z",
 		});
 	}),
 
-	http.post(getPath("/users"), async ({ request }) => {
-		const body = (await readCreateUserFormData(request)) as CreateUserRequest;
+	http.get(getPath("/users/check-email"), ({ request }) => {
+		const url = new URL(request.url);
+		const email = url.searchParams.get("email") ?? "";
 
-		await delay(700);
+		if (email.trim() === "taken@teampo.dev") {
+			return buildErrorResponse(
+				409,
+				"중복된 이메일이 존재합니다.",
+				"email_already_exists",
+			);
+		}
+
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.post(getPath("/users/profile-image/upload-url"), async ({ request }) => {
+		const body = (await request.json()) as { contentType: string };
+
+		if (!isSupportedImageType(body.contentType)) {
+			return buildErrorResponse(
+				400,
+				"지원하지 않는 이미지 형식입니다.",
+				"invalid_image_content_type",
+			);
+		}
+
+		const extension = body.contentType.split("/")[1]?.replace("jpeg", "jpg");
+		const objectKey = `images/sign-up/${crypto.randomUUID()}.${extension}`;
+
+		return HttpResponse.json({
+			contentType: body.contentType,
+			expiresAt: "2026-04-20T12:05:00.000Z",
+			formFields: {
+				"Content-Type": body.contentType,
+				key: objectKey,
+				Policy: "mock-policy",
+				"X-Amz-Signature": "mock-signature",
+			},
+			maxFileSizeBytes: 5_242_880,
+			objectKey,
+			uploadUrl: getPath("/mock/profile-image-upload"),
+		});
+	}),
+
+	http.post(getPath("/users/sign-up"), async ({ request }) => {
+		const body = (await request.json()) as CreateUserRequest & {
+			profileImageKey?: string;
+		};
+
+		await delay(600);
 
 		if (isServerErrorTrigger(body.email)) {
 			return buildErrorResponse(
@@ -158,11 +183,8 @@ export const handlers = [
 		if (body.email.trim() === "taken@teampo.dev") {
 			return buildErrorResponse(
 				409,
-				"이미 사용 중인 이메일입니다.",
+				"중복된 이메일이 존재합니다.",
 				"email_already_exists",
-				{
-					email: ["다른 이메일 주소를 입력해 주세요."],
-				},
 			);
 		}
 
@@ -170,66 +192,161 @@ export const handlers = [
 			!isValidEmail(body.email) ||
 			body.password.length < 8 ||
 			body.nickname.trim().length < 2 ||
-			(body.profileImage !== null &&
-				(!body.profileImage.type.startsWith("image/") ||
-					body.profileImage.size > 5 * 1024 * 1024))
+			body.level < 1 ||
+			body.level > 5
 		) {
 			return buildErrorResponse(
 				400,
-				"입력값을 다시 확인해 주세요.",
+				"입력값이 올바르지 않습니다.",
 				"validation_error",
-				{
-					email: !isValidEmail(body.email)
-						? ["유효한 이메일을 입력해 주세요."]
-						: [],
-					nickname:
-						body.nickname.trim().length < 2
-							? ["닉네임은 2자 이상이어야 합니다."]
-							: [],
-					password:
-						body.password.length < 8
-							? ["비밀번호는 8자 이상이어야 합니다."]
-							: [],
-					profileImage:
-						body.profileImage !== null &&
-						(!body.profileImage.type.startsWith("image/") ||
-							body.profileImage.size > 5 * 1024 * 1024)
-							? ["이미지 파일만 5MB 이하로 업로드할 수 있습니다."]
-							: [],
-				},
 			);
 		}
 
-		const profileImageUrl = body.profileImage
-			? await fileToDataUrl(body.profileImage)
-			: null;
-
-		currentUser = createPreviewUser({
-			createdAt: new Date().toISOString(),
+		currentUser = {
+			description: null,
 			email: body.email.trim(),
-			emailVerified: false,
-			id: "user_signup_preview",
+			level: body.level,
 			nickname: body.nickname.trim(),
-			profileImageUrl,
-			verifiedAt: null,
-		});
+			profileImage: imageUrlFromKey(body.profileImageKey),
+			temperature: 50,
+		};
 		currentPassword = body.password;
 
-		return HttpResponse.json(
-			{
-				user: currentUser,
-				verification: {
-					deliveryStatus: "queued",
-					email: currentUser.email,
-					resendAfterSeconds: 60,
-				},
-			},
-			{ status: 201 },
-		);
+		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.patch(getPath("/users/me"), async ({ request }) => {
-		const body = await readUpdateUserFormData(request);
+	http.get(getPath("/users/me"), async () => {
+		await delay(250);
+
+		if (!currentUser) {
+			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+		}
+
+		return HttpResponse.json(currentUser);
+	}),
+
+	http.post(getPath("/users/me/profile-image/upload-url"), async ({ request }) => {
+		const body = (await request.json()) as { contentType: string };
+
+		if (!isSupportedImageType(body.contentType)) {
+			return buildErrorResponse(
+				400,
+				"지원하지 않는 이미지 형식입니다.",
+				"invalid_image_content_type",
+			);
+		}
+
+		const extension = body.contentType.split("/")[1]?.replace("jpeg", "jpg");
+		const objectKey = `images/users/1/${crypto.randomUUID()}.${extension}`;
+
+		return HttpResponse.json({
+			contentType: body.contentType,
+			expiresAt: "2026-04-20T12:05:00.000Z",
+			formFields: {
+				"Content-Type": body.contentType,
+				key: objectKey,
+				Policy: "mock-policy",
+				"X-Amz-Signature": "mock-signature",
+			},
+			maxFileSizeBytes: 5_242_880,
+			objectKey,
+			uploadUrl: getPath("/mock/profile-image-upload"),
+		});
+	}),
+
+	http.post(getPath("/mock/profile-image-upload"), async () => {
+		await delay(200);
+		return new HttpResponse(null, { status: 204 });
+	}),
+
+	http.put(getPath("/users/me"), async ({ request }) => {
+		const body = (await request.json()) as UpdateCurrentUserRequest & {
+			profileImageKey?: string;
+		};
+
+		await delay(450);
+
+		if (!currentUser) {
+			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+		}
+
+		if (body.nickname.trim().length < 2 || body.level < 1 || body.level > 5) {
+			return buildErrorResponse(
+				400,
+				"입력값이 올바르지 않습니다.",
+				"validation_error",
+			);
+		}
+
+		currentUser = {
+			...currentUser,
+			description: body.description?.trim() || null,
+			level: body.level,
+			nickname: body.nickname.trim(),
+			profileImage: body.profileImageKey
+				? imageUrlFromKey(body.profileImageKey)
+				: currentUser.profileImage,
+		};
+
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.put(getPath("/users/me/password"), async ({ request }) => {
+		const body = (await request.json()) as EditPasswordRequest;
+
+		await delay(350);
+
+		if (body.currentPassword !== currentPassword) {
+			return buildErrorResponse(
+				401,
+				"현재 비밀번호와 동일하지 않습니다.",
+				"unmatched_password",
+			);
+		}
+
+		currentPassword = body.afterPassword;
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.delete(getPath("/users/me"), async ({ request }) => {
+		const body = (await request.json()) as DeleteCurrentUserRequest;
+
+		await delay(350);
+
+		if (body.password !== currentPassword) {
+			return buildErrorResponse(
+				401,
+				"현재 비밀번호와 동일하지 않습니다.",
+				"unmatched_password",
+			);
+		}
+
+		currentUser = null;
+		matchStatus = null;
+
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.get(getPath("/match/status"), async () => {
+		await delay(250);
+
+		if (!currentUser) {
+			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+		}
+
+		if (!matchStatus) {
+			return buildErrorResponse(
+				404,
+				"진행 중인 매칭 요청이 없습니다.",
+				"project_request_not_found",
+			);
+		}
+
+		return HttpResponse.json({ status: matchStatus });
+	}),
+
+	http.post(getPath("/match/request"), async ({ request }) => {
+		const body = (await request.json()) as ProjectRequestPayload;
 
 		await delay(500);
 
@@ -237,138 +354,44 @@ export const handlers = [
 			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
 		}
 
-		if (
-			body.nickname.trim().length < 2 ||
-			body.nickname.trim().length > 24 ||
-			(body.profileImage !== null &&
-				(!body.profileImage.type.startsWith("image/") ||
-					body.profileImage.size > 5 * 1024 * 1024))
-		) {
+		if (matchStatus === "WAITING" || matchStatus === "MATCHING") {
+			return buildErrorResponse(
+				409,
+				"이미 진행 중인 매칭 요청이 있습니다.",
+				"project_request_already_exists",
+			);
+		}
+
+		if (!["BE", "FE", "DESIGN"].includes(body.role)) {
 			return buildErrorResponse(
 				400,
-				"입력값을 다시 확인해 주세요.",
+				"입력값이 올바르지 않습니다.",
 				"validation_error",
-				{
-					nickname:
-						body.nickname.trim().length < 2 || body.nickname.trim().length > 24
-							? ["닉네임은 2자 이상 24자 이하로 입력해 주세요."]
-							: [],
-					profileImage:
-						body.profileImage !== null &&
-						(!body.profileImage.type.startsWith("image/") ||
-							body.profileImage.size > 5 * 1024 * 1024)
-							? ["이미지 파일만 5MB 이하로 업로드할 수 있습니다."]
-							: [],
-				},
 			);
 		}
 
-		const profileImageUrl = body.profileImage
-			? await fileToDataUrl(body.profileImage)
-			: currentUser.profileImageUrl;
+		matchStatus = "WAITING";
 
-		currentUser = {
-			...currentUser,
-			nickname: body.nickname.trim(),
-			profileImageUrl,
-		};
-
-		return HttpResponse.json({
-			user: currentUser,
-		});
+		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.post(getPath("/auth/email-verifications"), async ({ request }) => {
-		const body = (await request.json()) as ResendEmailVerificationRequest;
-
-		await delay(450);
-
-		if (isServerErrorTrigger(body.email)) {
-			return buildErrorResponse(
-				500,
-				"인증 메일 재전송에 실패했습니다.",
-				"internal_server_error",
-			);
-		}
-
-		if (!currentUser || body.email.trim() !== currentUser.email) {
-			return buildErrorResponse(
-				404,
-				"인증 대상을 찾지 못했습니다.",
-				"user_not_found",
-			);
-		}
-
-		return HttpResponse.json({
-			deliveryStatus: "queued",
-			email: body.email.trim(),
-			resendAfterSeconds: 60,
-		});
-	}),
-
-	http.post(
-		getPath("/auth/email-verifications/confirm"),
-		async ({ request }) => {
-			const body = (await request.json()) as VerifyEmailRequest;
-
-			await delay(500);
-
-			if (body.token.trim() === "SERVER-ERROR-TOKEN") {
-				return buildErrorResponse(
-					500,
-					"이메일 인증 처리 중 서버 오류가 발생했습니다.",
-					"internal_server_error",
-				);
-			}
-
-			if (!currentUser || body.email.trim() !== currentUser.email) {
-				return buildErrorResponse(
-					404,
-					"인증 대상 이메일을 찾지 못했습니다.",
-					"user_not_found",
-				);
-			}
-
-			if (body.token.trim() !== previewAuthSeed.verificationToken) {
-				return buildErrorResponse(
-					400,
-					"인증 토큰이 올바르지 않습니다.",
-					"invalid_verification_token",
-				);
-			}
-
-			currentUser = {
-				...currentUser,
-				emailVerified: true,
-				verifiedAt: new Date().toISOString(),
-			};
-
-			return HttpResponse.json({
-				user: currentUser,
-				verifiedAt: currentUser.verifiedAt,
-			});
-		},
-	),
-
-	http.get(getPath("/users/me"), async () => {
+	http.patch(getPath("/match/cancel"), async () => {
 		await delay(350);
 
 		if (!currentUser) {
 			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
 		}
 
-		return HttpResponse.json({ user: currentUser });
-	}),
-
-	http.delete(getPath("/users/me"), async () => {
-		await delay(450);
-
-		if (!currentUser) {
-			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+		if (matchStatus !== "WAITING" && matchStatus !== "MATCHING") {
+			return buildErrorResponse(
+				404,
+				"취소할 수 있는 매칭 요청이 없습니다.",
+				"project_request_not_found",
+			);
 		}
 
-		currentUser = null;
+		matchStatus = null;
 
-		return new HttpResponse(null, { status: 204 });
+		return new HttpResponse(null, { status: 200 });
 	}),
 ];

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -1,49 +1,127 @@
 import { apiRequest } from "@/lib/api/client";
-import type { CreateUserRequest, CreateUserResponse } from "@/lib/types/auth";
 import type {
-	CurrentUserResponse,
+	CreateUserRequest,
+	ProfileImageUploadUrlResponse,
+	SignUpRequest,
+} from "@/lib/types/auth";
+import type {
+	DeleteCurrentUserRequest,
+	EditPasswordRequest,
 	UpdateCurrentUserRequest,
-	UpdateCurrentUserResponse,
+	UserProfile,
 } from "@/lib/types/user";
 
-export function createUser(payload: CreateUserRequest) {
-	const formData = new FormData();
+export async function createUser(payload: CreateUserRequest) {
+	const profileImageKey = payload.profileImage
+		? await uploadProfileImageForSignUp(payload.profileImage)
+		: undefined;
 
-	formData.append("email", payload.email);
-	formData.append("password", payload.password);
-	formData.append("nickname", payload.nickname);
-
-	if (payload.profileImage) {
-		formData.append("profileImage", payload.profileImage);
-	}
-
-	return apiRequest<CreateUserResponse>("/users", {
-		body: formData,
+	return apiRequest<void>("/users/sign-up", {
+		json: {
+			email: payload.email.trim(),
+			level: payload.level,
+			nickname: payload.nickname.trim(),
+			password: payload.password,
+			profileImageKey,
+		} satisfies SignUpRequest,
 		method: "POST",
+		skipAuth: true,
 	});
 }
 
 export function getCurrentUser() {
-	return apiRequest<CurrentUserResponse>("/users/me");
+	return apiRequest<UserProfile>("/users/me");
 }
 
-export function updateCurrentUser(payload: UpdateCurrentUserRequest) {
-	const formData = new FormData();
+export async function updateCurrentUser(payload: UpdateCurrentUserRequest) {
+	const profileImageKey = payload.profileImage
+		? await uploadProfileImageForProfile(payload.profileImage)
+		: undefined;
 
-	formData.append("nickname", payload.nickname);
-
-	if (payload.profileImage) {
-		formData.append("profileImage", payload.profileImage);
-	}
-
-	return apiRequest<UpdateCurrentUserResponse>("/users/me", {
-		body: formData,
-		method: "PATCH",
+	return apiRequest<void>("/users/me", {
+		json: {
+			description: payload.description.trim() || null,
+			level: payload.level,
+			nickname: payload.nickname.trim(),
+			profileImageKey,
+		},
+		method: "PUT",
 	});
 }
 
-export function deleteCurrentUser() {
+export function editPassword(payload: EditPasswordRequest) {
+	return apiRequest<void>("/users/me/password", {
+		json: payload,
+		method: "PUT",
+	});
+}
+
+export function deleteCurrentUser(payload: DeleteCurrentUserRequest) {
 	return apiRequest<void>("/users/me", {
+		json: payload,
 		method: "DELETE",
 	});
+}
+
+export function checkEmailDuplicate(email: string) {
+	const query = new URLSearchParams({ email: email.trim() });
+
+	return apiRequest<void>(`/users/check-email?${query.toString()}`, {
+		skipAuth: true,
+	});
+}
+
+async function uploadProfileImageForSignUp(file: File) {
+	const presignedPost = await createSignUpProfileImageUploadUrl(file.type);
+	await uploadProfileImage(file, presignedPost);
+	return presignedPost.objectKey;
+}
+
+async function uploadProfileImageForProfile(file: File) {
+	const presignedPost = await createProfileImageUploadUrl(file.type);
+	await uploadProfileImage(file, presignedPost);
+	return presignedPost.objectKey;
+}
+
+function createSignUpProfileImageUploadUrl(contentType: string) {
+	return apiRequest<ProfileImageUploadUrlResponse>(
+		"/users/profile-image/upload-url",
+		{
+			json: { contentType },
+			method: "POST",
+			skipAuth: true,
+		},
+	);
+}
+
+function createProfileImageUploadUrl(contentType: string) {
+	return apiRequest<ProfileImageUploadUrlResponse>(
+		"/users/me/profile-image/upload-url",
+		{
+			json: { contentType },
+			method: "POST",
+		},
+	);
+}
+
+async function uploadProfileImage(
+	file: File,
+	presignedPost: ProfileImageUploadUrlResponse,
+) {
+	const formData = new FormData();
+
+	for (const [key, value] of Object.entries(presignedPost.formFields)) {
+		formData.append(key, value);
+	}
+
+	formData.append("file", file);
+
+	const response = await fetch(presignedPost.uploadUrl, {
+		body: formData,
+		method: "POST",
+	});
+
+	if (!response.ok) {
+		throw new Error("프로필 이미지 업로드에 실패했습니다.");
+	}
 }

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -1,5 +1,3 @@
-import type { UserProfile } from "@/lib/types/user";
-
 export interface LoginRequest {
 	email: string;
 	password: string;
@@ -9,50 +7,45 @@ export interface SessionPayload {
 	accessToken: string;
 	expiresAt: string;
 	refreshToken: string;
-	tokenType: "Bearer";
 }
 
-export type VerificationDeliveryStatus = "queued" | "sent" | "throttled";
-
-export interface VerificationDelivery {
-	deliveryStatus: VerificationDeliveryStatus;
-	email: string;
-	resendAfterSeconds: number;
-}
-
-export interface LoginResponse {
-	session: SessionPayload;
-	user: UserProfile;
-}
+export type LoginResponse = SessionPayload;
 
 export interface CreateUserRequest {
 	email: string;
+	level: number;
 	nickname: string;
 	password: string;
+	passwordConfirm: string;
 	profileImage: File | null;
 }
 
-export interface CreateUserResponse {
-	user: UserProfile;
-	verification: VerificationDelivery;
-}
-
-export interface ResendEmailVerificationRequest {
+export interface SignUpRequest {
 	email: string;
+	level: number;
+	nickname: string;
+	password: string;
+	profileImageKey?: string;
 }
 
-export interface ResendEmailVerificationResponse {
-	deliveryStatus: VerificationDeliveryStatus;
-	email: string;
-	resendAfterSeconds: number;
+export interface ProfileImageUploadUrlRequest {
+	contentType: string;
 }
 
-export interface VerifyEmailRequest {
-	email: string;
-	token: string;
+export interface ProfileImageUploadUrlResponse {
+	contentType: string;
+	expiresAt: string;
+	formFields: Record<string, string>;
+	maxFileSizeBytes: number;
+	objectKey: string;
+	uploadUrl: string;
 }
 
-export interface VerifyEmailResponse {
-	user: UserProfile;
-	verifiedAt: string | null;
+export interface RefreshTokenRequest {
+	refreshToken: string;
+}
+
+export interface RefreshTokenResponse {
+	accessToken: string;
+	expiresAt: string;
 }

--- a/src/lib/types/match.ts
+++ b/src/lib/types/match.ts
@@ -1,0 +1,14 @@
+export type MatchRole = "DESIGN" | "BE" | "FE";
+
+export type MatchStatus = "WAITING" | "MATCHING" | "MATCHED" | "CANCELED";
+
+export interface ProjectRequestPayload {
+	projectDescription: string | null;
+	projectMvp: string | null;
+	projectTitle: string | null;
+	role: MatchRole;
+}
+
+export interface ProjectRequestStatusResponse {
+	status: MatchStatus;
+}

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -1,22 +1,24 @@
 export interface UserProfile {
-	createdAt: string;
+	description: string | null;
 	email: string;
-	emailVerified: boolean;
-	id: string;
+	level: number;
 	nickname: string;
-	profileImageUrl: string | null;
-	verifiedAt: string | null;
-}
-
-export interface CurrentUserResponse {
-	user: UserProfile;
+	profileImage: string | null;
+	temperature: number;
 }
 
 export interface UpdateCurrentUserRequest {
+	description: string;
+	level: number;
 	nickname: string;
 	profileImage: File | null;
 }
 
-export interface UpdateCurrentUserResponse {
-	user: UserProfile;
+export interface EditPasswordRequest {
+	afterPassword: string;
+	currentPassword: string;
+}
+
+export interface DeleteCurrentUserRequest {
+	password: string;
 }

--- a/src/pages/match-page.tsx
+++ b/src/pages/match-page.tsx
@@ -1,0 +1,5 @@
+import { MatchRequestView } from "@/features/match/components/match-request-view";
+
+export function MatchPage() {
+	return <MatchRequestView />;
+}


### PR DESCRIPTION
## Summary
- Complete auth/session API integration and profile management UI updates.
- Add matching request page, API hooks, mocks, and immediate cancel-state UI refresh.
- Add email verification template and related auth flow refinements.

## Validation
- `pnpm tsc --noEmit`: pass
- `pnpm biome lint .`: pass
- `pnpm build`: pass (Vite chunk-size warning only)

Closes #26
