### PR TITLE
Align client with server API contract

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -24,3 +24,6 @@
 
 ## 2026-04-07
 - Local PDF inspection skill: `.agents/skills/pdf-reading` documents a fallback workflow for reading PDFs in restricted environments, preferring text extraction first and Ghostscript rendering to temporary images with mandatory cleanup when visual inspection is required
+
+## 2026-05-05
+- API contract alignment: `openapi/openapi.yaml`, API clients, hooks, and MSW mocks now mirror the current Spring server controllers for signup email auth, user profile/account APIs, matching sessions, and project-group admin permission endpoints without adding new dependencies.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,78 +1,61 @@
 openapi: 3.1.0
 info:
-  title: Team-po User API
-  version: 0.1.0
-  summary: Authentication and current-user endpoints for the Team-po frontend MVP.
-  description: |
-    Initial contract for the user-facing authentication flow used by the frontend
-    routes `/login`, `/signup`, `/verify-email`, and `/me`.
+  title: Team-po Server API
+  version: 0.2.0
+  summary: Client-facing contract mirrored from the current Spring controllers.
 servers:
   - url: /api
-    description: Local API base path
+    description: API base path
 tags:
   - name: Auth
-    description: Authentication and email verification
   - name: Users
-    description: User account resources
+  - name: Match
+  - name: ProjectGroups
 paths:
-  /users/sign-in:
+  /signup/email:
     post:
-      tags:
-        - Auth
-      operationId: signInWithEmailPassword
-      summary: Log in with email and password
-      description: Issues a session token pair for the authenticated user.
+      tags: [Auth]
+      summary: Send a signup email auth number
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LoginRequest'
-            examples:
-              default:
-                value:
-                  email: preview@teampo.dev
-                  password: teampo123!
+              $ref: '#/components/schemas/SendEmailRequest'
       responses:
         '200':
-          description: Login completed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoginResponse'
-              examples:
-                success:
-                  value:
-                    accessToken: mq_access_demo_token
-                    refreshToken: mq_refresh_demo_token
-                    expiresAt: '2026-03-08T18:30:00Z'
+          description: Auth number sent
         '400':
           $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /users/sign-up:
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+  /signup/number-validation:
     post:
-      tags:
-        - Users
-      operationId: createUser
-      summary: Sign up a new user
-      description: Creates a user account with email/password authentication and an optional uploaded profile image key.
+      tags: [Auth]
+      summary: Validate a signup email auth number
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateUserRequest'
-            examples:
-              default:
-                value:
-                  email: new.dev@teampo.dev
-                  password: teampo123!
-                  nickname: sprintmaker
-                  level: 3
-                  profileImageKey: images/sign-up/avatar.png
+              $ref: '#/components/schemas/ValidateAuthNumberRequest'
+      responses:
+        '200':
+          description: Auth number validated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /users/sign-up:
+    post:
+      tags: [Users]
+      summary: Sign up after email auth validation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignUpRequest'
       responses:
         '200':
           description: User created
@@ -80,217 +63,441 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '409':
           $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /auth/email-verifications:
+  /users/profile-image/upload-url:
     post:
-      tags:
-        - Auth
-      operationId: resendEmailVerification
-      summary: Resend a verification email
-      description: Reissues a verification message for an existing user account.
+      tags: [Users]
+      summary: Create a signup profile image POST upload URL
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResendEmailVerificationRequest'
-            examples:
-              default:
-                value:
-                  email: new.dev@teampo.dev
+              $ref: '#/components/schemas/ProfileImageUploadUrlRequest'
       responses:
         '200':
-          description: Verification email queued
+          description: Upload URL issued
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResendEmailVerificationResponse'
-              examples:
-                success:
-                  value:
-                    email: new.dev@teampo.dev
-                    deliveryStatus: queued
-                    resendAfterSeconds: 60
+                $ref: '#/components/schemas/ProfileImageUploadUrlResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /auth/email-verifications/confirm:
+  /users/check-email:
+    get:
+      tags: [Users]
+      summary: Check whether an email is available
+      parameters:
+        - in: query
+          name: email
+          required: true
+          schema:
+            type: string
+            format: email
+      responses:
+        '200':
+          description: Email is available
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /users/sign-in:
     post:
-      tags:
-        - Auth
-      operationId: confirmEmailVerification
-      summary: Confirm an email verification token
-      description: Marks the user email as verified when a valid token is submitted.
+      tags: [Auth]
+      summary: Sign in with email and password
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ConfirmEmailVerificationRequest'
-            examples:
-              default:
-                value:
-                  email: new.dev@teampo.dev
-                  token: TEAMPO-2026
+              $ref: '#/components/schemas/SignInRequest'
       responses:
         '200':
-          description: Email confirmed
+          description: Signed in
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConfirmEmailVerificationResponse'
-              examples:
-                success:
-                  value:
-                    user:
-                      email: new.dev@teampo.dev
-                      nickname: sprintmaker
-                      profileImage: https://images.teampo.dev/profiles/sprintmaker.png
-                      description: null
-                      level: 3
-                      temperature: 50
-                    verifiedAt: '2026-03-08T07:03:00Z'
+                $ref: '#/components/schemas/SignInResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /users/refresh-token:
+    post:
+      tags: [Auth]
+      summary: Refresh an access token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenRequest'
+      responses:
+        '200':
+          description: Access token refreshed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefreshTokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /users/me:
     get:
-      tags:
-        - Users
-      operationId: getCurrentUser
-      summary: Get the current user profile
-      description: Returns the authenticated user's profile for the `/me` page.
+      tags: [Users]
       security:
         - bearerAuth: []
+      summary: Get the current user's profile
       responses:
         '200':
           description: Current user profile
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                success:
-                  value:
-                    email: preview@teampo.dev
-                    nickname: queue_runner
-                    profileImage: https://images.teampo.dev/profiles/preview.png
-                    description: 빠르게 실험하고, 팀원과 맥락을 맞추는 일을 좋아합니다.
-                    level: 3
-                    temperature: 50
+                $ref: '#/components/schemas/UserProfile'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
     put:
-      tags:
-        - Users
-      operationId: updateCurrentUser
-      summary: Update the current user profile
-      description: Updates the nickname, level, description, and optional uploaded profile image key for the signed-in user. Email cannot be changed.
+      tags: [Users]
       security:
         - bearerAuth: []
+      summary: Update the current user's profile
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateCurrentUserRequest'
-            examples:
-              default:
-                value:
-                  nickname: sprintmaker_v2
-                  level: 4
-                  description: 협업 속도를 높이는 프론트엔드 개발자입니다.
-                  profileImageKey: images/users/1/avatar.png
+              $ref: '#/components/schemas/EditProfileRequest'
       responses:
         '200':
-          description: Current user updated
+          description: Profile updated
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
     delete:
-      tags:
-        - Users
-      operationId: deleteCurrentUser
-      summary: Delete the current user account
-      description: Deletes the signed-in user's account.
+      tags: [Users]
       security:
         - bearerAuth: []
+      summary: Soft-delete the current user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteUserRequest'
       responses:
-        '204':
-          description: Account deleted
+        '200':
+          description: User deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /users/me/profile-image/upload-url:
+    post:
+      tags: [Users]
+      security:
+        - bearerAuth: []
+      summary: Create a profile update image POST upload URL
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProfileImageUploadUrlRequest'
+      responses:
+        '200':
+          description: Upload URL issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfileImageUploadUrlResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /users/me/password:
+    put:
+      tags: [Users]
+      security:
+        - bearerAuth: []
+      summary: Change the current user's password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditPasswordRequest'
+      responses:
+        '200':
+          description: Password changed
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /match/request:
+    post:
+      tags: [Match]
+      security:
+        - bearerAuth: []
+      summary: Create a project matching request
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRequest'
+      responses:
+        '200':
+          description: Request created
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /match/status:
+    get:
+      tags: [Match]
+      security:
+        - bearerAuth: []
+      summary: Get the current user's active match request status
+      responses:
+        '200':
+          description: Active status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectRequestStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /match/{matchId}/members:
+    get:
+      tags: [Match]
+      security:
+        - bearerAuth: []
+      summary: Get members in a match session
+      parameters:
+        - $ref: '#/components/parameters/MatchId'
+      responses:
+        '200':
+          description: Match members
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MatchMemberResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /match/{matchId}/project:
+    get:
+      tags: [Match]
+      security:
+        - bearerAuth: []
+      summary: Get the host project details for a match session
+      parameters:
+        - $ref: '#/components/parameters/MatchId'
+      responses:
+        '200':
+          description: Match project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MatchProjectResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /match/{matchId}/accept:
+    post:
+      tags: [Match]
+      security:
+        - bearerAuth: []
+      summary: Accept a match session
+      parameters:
+        - $ref: '#/components/parameters/MatchId'
+      responses:
+        '200':
+          description: Match accepted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /match/{matchId}/reject:
+    post:
+      tags: [Match]
+      security:
+        - bearerAuth: []
+      summary: Reject a match session
+      parameters:
+        - $ref: '#/components/parameters/MatchId'
+      responses:
+        '200':
+          description: Match rejected
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /match/cancel:
+    post:
+      tags: [Match]
+      security:
+        - bearerAuth: []
+      summary: Cancel the current user's waiting or matching request
+      responses:
+        '200':
+          description: Match request canceled
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /project-groups/{projectGroupId}/admins/{targetUserId}:
+    patch:
+      tags: [ProjectGroups]
+      security:
+        - bearerAuth: []
+      summary: Grant admin permission to a project group member
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/TargetUserId'
+      responses:
+        '200':
+          description: Admin permission granted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [ProjectGroups]
+      security:
+        - bearerAuth: []
+      summary: Revoke admin permission from a project group member
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/TargetUserId'
+      responses:
+        '200':
+          description: Admin permission revoked
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
 components:
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  parameters:
+    MatchId:
+      in: path
+      name: matchId
+      required: true
+      schema:
+        type: integer
+        format: int64
+    ProjectGroupId:
+      in: path
+      name: projectGroupId
+      required: true
+      schema:
+        type: integer
+        format: int64
+    TargetUserId:
+      in: path
+      name: targetUserId
+      required: true
+      schema:
+        type: integer
+        format: int64
   schemas:
-    User:
+    ApiError:
       type: object
       additionalProperties: false
-      required:
-        - email
-        - nickname
-        - profileImage
-        - description
-        - level
-        - temperature
+      required: [message]
+      properties:
+        code:
+          type: string
+          examples: [INVALID_INPUT_FIELD]
+        message:
+          type: string
+        fieldErrors:
+          type:
+            - object
+            - 'null'
+          additionalProperties:
+            type: string
+    SendEmailRequest:
+      type: object
+      additionalProperties: false
+      required: [email]
       properties:
         email:
           type: string
           format: email
-          examples:
-            - preview@teampo.dev
+    ValidateAuthNumberRequest:
+      type: object
+      additionalProperties: false
+      required: [email, authNumber]
+      properties:
+        email:
+          type: string
+          format: email
+        authNumber:
+          type: integer
+          minimum: 100000
+          maximum: 999999
+    SignUpRequest:
+      type: object
+      additionalProperties: false
+      required: [email, password, nickname, level]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
         nickname:
           type: string
-          minLength: 2
-          maxLength: 24
-          examples:
-            - queue_runner
-        profileImage:
-          type:
-            - string
-            - 'null'
-          format: uri
-          examples:
-            - https://images.teampo.dev/profiles/preview.png
-        description:
-          type:
-            - string
-            - 'null'
-          examples:
-            - 빠르게 실험하고, 팀원과 맥락을 맞추는 일을 좋아합니다.
         level:
           type: integer
           minimum: 1
           maximum: 5
-        temperature:
-          type: integer
-          minimum: 0
-          maximum: 100
-    Session:
+        profileImageKey:
+          type:
+            - string
+            - 'null'
+          pattern: '^images/(sign-up|users/\d+)/[A-Za-z0-9-]+\.(jpg|png|gif|webp)$'
+    SignInRequest:
       type: object
       additionalProperties: false
-      required:
-        - accessToken
-        - refreshToken
-        - expiresAt
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+    SignInResponse:
+      type: object
+      additionalProperties: false
+      required: [accessToken, refreshToken, expiresAt]
       properties:
         accessToken:
           type: string
@@ -299,235 +506,245 @@ components:
         expiresAt:
           type: string
           format: date-time
-    LoginRequest:
+    RefreshTokenRequest:
       type: object
       additionalProperties: false
-      required:
-        - email
-        - password
+      required: [refreshToken]
+      properties:
+        refreshToken:
+          type: string
+    RefreshTokenResponse:
+      type: object
+      additionalProperties: false
+      required: [accessToken, expiresAt]
+      properties:
+        accessToken:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+    UserProfile:
+      type: object
+      additionalProperties: false
+      required: [email, profileImage, description, nickname, temperature, level]
       properties:
         email:
           type: string
           format: email
-        password:
-          type: string
-          minLength: 8
-          maxLength: 128
-    LoginResponse:
-      $ref: '#/components/schemas/Session'
-    CreateUserRequest:
-      type: object
-      additionalProperties: false
-      required:
-        - email
-        - password
-        - nickname
-        - level
-      properties:
-        email:
-          type: string
-          format: email
-        password:
-          type: string
-          minLength: 8
-          maxLength: 128
-        nickname:
-          type: string
-          minLength: 2
-          maxLength: 24
-        level:
-          type: integer
-          minimum: 1
-          maximum: 5
-        profileImageKey:
+        profileImage:
           type:
             - string
             - 'null'
-          description: Object key returned by the profile image upload-url endpoint.
-    VerificationDeliveryStatus:
-      type: string
-      enum:
-        - queued
-        - sent
-        - throttled
-    VerificationDelivery:
-      type: object
-      additionalProperties: false
-      required:
-        - email
-        - deliveryStatus
-        - resendAfterSeconds
-      properties:
-        email:
-          type: string
-          format: email
-        deliveryStatus:
-          $ref: '#/components/schemas/VerificationDeliveryStatus'
-        resendAfterSeconds:
-          type: integer
-          minimum: 0
-    CreateUserResponse:
-      type: object
-      additionalProperties: false
-      required:
-        - user
-        - verification
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-        verification:
-          $ref: '#/components/schemas/VerificationDelivery'
-    ResendEmailVerificationRequest:
-      type: object
-      additionalProperties: false
-      required:
-        - email
-      properties:
-        email:
-          type: string
-          format: email
-    ResendEmailVerificationResponse:
-      $ref: '#/components/schemas/VerificationDelivery'
-    ConfirmEmailVerificationRequest:
-      type: object
-      additionalProperties: false
-      required:
-        - email
-        - token
-      properties:
-        email:
-          type: string
-          format: email
-        token:
-          type: string
-          minLength: 6
-          maxLength: 128
-    ConfirmEmailVerificationResponse:
-      type: object
-      additionalProperties: false
-      required:
-        - user
-        - verifiedAt
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-        verifiedAt:
-          type: string
-          format: date-time
-    GetCurrentUserResponse:
-      $ref: '#/components/schemas/User'
-    UpdateCurrentUserRequest:
-      type: object
-      additionalProperties: false
-      required:
-        - nickname
-        - level
-        - description
-      properties:
-        nickname:
-          type: string
-          minLength: 2
-          maxLength: 24
-        level:
-          type: integer
-          minimum: 1
-          maximum: 5
         description:
           type:
             - string
             - 'null'
+        nickname:
+          type: string
+        temperature:
+          type: integer
+        level:
+          type: integer
+          minimum: 1
+          maximum: 5
+    EditProfileRequest:
+      type: object
+      additionalProperties: false
+      required: [description, nickname, level]
+      properties:
+        description:
+          type:
+            - string
+            - 'null'
+        nickname:
+          type: string
+        level:
+          type: integer
+          minimum: 1
+          maximum: 5
         profileImageKey:
           type:
             - string
             - 'null'
-          description: Object key returned by the profile image upload-url endpoint.
-    UpdateCurrentUserResponse:
-      $ref: '#/components/schemas/User'
-    ApiError:
+    EditPasswordRequest:
       type: object
       additionalProperties: false
-      required:
-        - code
-        - message
+      required: [currentPassword, afterPassword]
       properties:
-        code:
+        currentPassword:
           type: string
-          examples:
-            - invalid_credentials
-        message:
+          minLength: 8
+        afterPassword:
           type: string
-          examples:
-            - Email or password is incorrect.
-        fieldErrors:
+          minLength: 8
+    DeleteUserRequest:
+      type: object
+      additionalProperties: false
+      required: [password]
+      properties:
+        password:
+          type: string
+          minLength: 8
+    ProfileImageUploadUrlRequest:
+      type: object
+      additionalProperties: false
+      required: [contentType]
+      properties:
+        contentType:
+          type: string
+          enum: [image/jpeg, image/png, image/gif, image/webp]
+    ProfileImageUploadUrlResponse:
+      type: object
+      additionalProperties: false
+      required: [uploadUrl, formFields, objectKey, contentType, maxFileSizeBytes, expiresAt]
+      properties:
+        uploadUrl:
+          type: string
+          format: uri
+        formFields:
           type: object
           additionalProperties:
-            type: array
-            items:
-              type: string
-          examples:
-            email:
-              - Enter a valid email address.
-            password:
-              - Password must be at least 8 characters long.
+            type: string
+        objectKey:
+          type: string
+        contentType:
+          type: string
+        maxFileSizeBytes:
+          type: integer
+          format: int64
+        expiresAt:
+          type: string
+          format: date-time
+    MatchRole:
+      type: string
+      enum: [DESIGN, BACKEND, FRONTEND]
+    MatchStatus:
+      type: string
+      enum: [WAITING, MATCHING, MATCHED, CANCELED]
+    ProjectRequest:
+      type: object
+      additionalProperties: false
+      required: [role]
+      properties:
+        role:
+          $ref: '#/components/schemas/MatchRole'
+        projectTitle:
+          type:
+            - string
+            - 'null'
+        projectDescription:
+          type:
+            - string
+            - 'null'
+        projectMvp:
+          type:
+            - string
+            - 'null'
+      description: If any project field is filled, projectTitle, projectDescription, and projectMvp must all be filled.
+    ProjectRequestStatus:
+      type: object
+      additionalProperties: false
+      required: [status, matchId]
+      properties:
+        status:
+          $ref: '#/components/schemas/MatchStatus'
+        matchId:
+          type:
+            - integer
+            - 'null'
+          format: int64
+    MatchMemberResponse:
+      type: object
+      additionalProperties: false
+      required: [matchId, members]
+      properties:
+        matchId:
+          type: integer
+          format: int64
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/MatchMember'
+    MatchMember:
+      type: object
+      additionalProperties: false
+      required: [userId, nickname, role, level, temperature, profileImageKey, isHost, isAccepted]
+      properties:
+        userId:
+          type: integer
+          format: int64
+        nickname:
+          type: string
+        role:
+          $ref: '#/components/schemas/MatchRole'
+        level:
+          type: integer
+        temperature:
+          type: integer
+        profileImageKey:
+          type:
+            - string
+            - 'null'
+        isHost:
+          type: boolean
+        isAccepted:
+          type:
+            - boolean
+            - 'null'
+    MatchProjectResponse:
+      type: object
+      additionalProperties: false
+      required: [matchId, projectTitle, projectDescription, projectMvp]
+      properties:
+        matchId:
+          type: integer
+          format: int64
+        projectTitle:
+          type: string
+        projectDescription:
+          type: string
+        projectMvp:
+          type: string
   responses:
     BadRequest:
-      description: Validation failed or the request payload was malformed
+      description: Validation failed or business rule rejected the request
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiError'
-          examples:
-            invalidPayload:
-              value:
-                code: validation_failed
-                message: Request validation failed.
-                fieldErrors:
-                  email:
-                    - Enter a valid email address.
     Unauthorized:
       description: Authentication failed or the caller is not signed in
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiError'
-          examples:
-            invalidCredentials:
-              value:
-                code: invalid_credentials
-                message: Email or password is incorrect.
+    Forbidden:
+      description: The caller lacks permission for this operation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
     Conflict:
       description: Resource state conflicts with the request
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiError'
-          examples:
-            duplicateEmail:
-              value:
-                code: email_already_exists
-                message: An account with this email already exists.
-                fieldErrors:
-                  email:
-                    - Use a different email address.
     NotFound:
-      description: The requested user or verification request was not found
+      description: Requested resource was not found
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiError'
-          examples:
-            missingUser:
-              value:
-                code: user_not_found
-                message: No user account matches the provided email.
+    BadGateway:
+      description: Upstream email delivery failed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
     InternalServerError:
-      description: Unexpected backend failure
+      description: Server data consistency error
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiError'
-          examples:
-            generic:
-              value:
-                code: internal_server_error
-                message: Something went wrong while processing the request.

--- a/src/features/auth/components/signup-view.tsx
+++ b/src/features/auth/components/signup-view.tsx
@@ -3,7 +3,9 @@ import {
 	ArrowRight,
 	CheckCircle2,
 	LoaderCircle,
+	MailCheck,
 	SearchCheck,
+	ShieldCheck,
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 
@@ -22,18 +24,23 @@ import { ProfileImagePicker } from "@/features/auth/components/profile-image-pic
 import {
 	hasValidationErrors,
 	validateSignupForm,
+	validateVerifyEmailForm,
 } from "@/features/auth/lib/validation";
 import {
 	useCheckEmailDuplicateMutation,
+	useSendSignupEmailMutation,
 	useSignupMutation,
+	useValidateSignupAuthNumberMutation,
 } from "@/features/auth/hooks/use-auth-queries";
 import { getApiErrorMessage } from "@/lib/api/client";
 
 const levelOptions = [1, 2, 3, 4, 5] as const;
+const emailVerificationCooldownSeconds = 60;
 
 export function SignupView() {
 	const navigate = useNavigate();
 	const [form, setForm] = useState({
+		authNumber: "",
 		email: "",
 		level: 3,
 		nickname: "",
@@ -42,6 +49,7 @@ export function SignupView() {
 		profileImage: null as File | null,
 	});
 	const [touched, setTouched] = useState({
+		authNumber: false,
 		email: false,
 		level: false,
 		nickname: false,
@@ -50,15 +58,38 @@ export function SignupView() {
 		profileImage: false,
 	});
 	const [checkedEmail, setCheckedEmail] = useState<string | null>(null);
+	const [verificationSentEmail, setVerificationSentEmail] = useState<
+		string | null
+	>(null);
+	const [verifiedEmail, setVerifiedEmail] = useState<string | null>(null);
+	const [verificationCooldownEndsAt, setVerificationCooldownEndsAt] = useState<
+		number | null
+	>(null);
+	const [currentTime, setCurrentTime] = useState(() => Date.now());
 	const [profileImagePreviewUrl, setProfileImagePreviewUrl] = useState<
 		string | null
 	>(null);
 	const signupMutation = useSignupMutation();
 	const checkEmailMutation = useCheckEmailDuplicateMutation();
+	const sendSignupEmailMutation = useSendSignupEmailMutation();
+	const validateSignupAuthNumberMutation =
+		useValidateSignupAuthNumberMutation();
 	const errors = validateSignupForm(form);
+	const verificationErrors = validateVerifyEmailForm({
+		authNumber: form.authNumber,
+		email: form.email,
+	});
+	const normalizedEmail = form.email.trim().toLowerCase();
+	const isEmailChecked = checkedEmail === normalizedEmail;
+	const isVerificationSent = verificationSentEmail === normalizedEmail;
+	const isEmailVerified = verifiedEmail === normalizedEmail;
+	const verificationCooldownRemainingSeconds = verificationCooldownEndsAt
+		? Math.max(0, Math.ceil((verificationCooldownEndsAt - currentTime) / 1000))
+		: 0;
+	const isVerificationCooldownActive =
+		verificationCooldownRemainingSeconds > 0;
 	const isSubmitDisabled =
-		signupMutation.isPending || hasValidationErrors(errors);
-	const isEmailChecked = checkedEmail === form.email.trim().toLowerCase();
+		signupMutation.isPending || hasValidationErrors(errors) || !isEmailVerified;
 
 	useEffect(() => {
 		if (!form.profileImage) {
@@ -74,6 +105,20 @@ export function SignupView() {
 		};
 	}, [form.profileImage]);
 
+	useEffect(() => {
+		if (!isVerificationCooldownActive) {
+			return;
+		}
+
+		const intervalId = window.setInterval(() => {
+			setCurrentTime(Date.now());
+		}, 1000);
+
+		return () => {
+			window.clearInterval(intervalId);
+		};
+	}, [isVerificationCooldownActive]);
+
 	function markTouched(field: keyof typeof touched) {
 		setTouched((current) => ({
 			...current,
@@ -85,6 +130,7 @@ export function SignupView() {
 		event.preventDefault();
 
 		setTouched({
+			authNumber: true,
 			email: true,
 			level: true,
 			nickname: true,
@@ -93,7 +139,7 @@ export function SignupView() {
 			profileImage: true,
 		});
 
-		if (hasValidationErrors(errors)) {
+		if (hasValidationErrors(errors) || !isEmailVerified) {
 			return;
 		}
 
@@ -110,7 +156,38 @@ export function SignupView() {
 		}
 
 		await checkEmailMutation.mutateAsync(form.email);
-		setCheckedEmail(form.email.trim().toLowerCase());
+		setCheckedEmail(normalizedEmail);
+	}
+
+	async function handleSendVerificationEmail() {
+		markTouched("email");
+
+		if (errors.email) {
+			return;
+		}
+
+		await sendSignupEmailMutation.mutateAsync({ email: form.email });
+		setCheckedEmail(normalizedEmail);
+		setVerificationSentEmail(normalizedEmail);
+		setVerifiedEmail(null);
+		setCurrentTime(Date.now());
+		setVerificationCooldownEndsAt(
+			Date.now() + emailVerificationCooldownSeconds * 1000,
+		);
+	}
+
+	async function handleValidateAuthNumber() {
+		markTouched("authNumber");
+
+		if (!isVerificationSent || verificationErrors.authNumber) {
+			return;
+		}
+
+		await validateSignupAuthNumberMutation.mutateAsync({
+			authNumber: Number(form.authNumber.trim()),
+			email: form.email,
+		});
+		setVerifiedEmail(normalizedEmail);
 	}
 
 	return (
@@ -164,8 +241,12 @@ export function SignupView() {
 								onChange={(event) => {
 									markTouched("email");
 									setCheckedEmail(null);
+									setVerificationSentEmail(null);
+									setVerifiedEmail(null);
+									setVerificationCooldownEndsAt(null);
 									setForm((current) => ({
 										...current,
+										authNumber: "",
 										email: event.target.value,
 									}));
 								}}
@@ -203,6 +284,107 @@ export function SignupView() {
 						) : isEmailChecked ? (
 							<FieldDescription>사용할 수 있는 이메일입니다.</FieldDescription>
 						) : null}
+					</Field>
+
+					<Field
+						data-invalid={Boolean(
+							(touched.authNumber && verificationErrors.authNumber) ||
+								sendSignupEmailMutation.error ||
+								validateSignupAuthNumberMutation.error,
+						)}
+					>
+						<FieldLabel htmlFor="signup-auth-number">
+							이메일 인증번호
+						</FieldLabel>
+						<div className="grid gap-2 sm:grid-cols-[1fr_auto_auto]">
+							<Input
+								aria-invalid={Boolean(
+									touched.authNumber && verificationErrors.authNumber,
+								)}
+								disabled={!isVerificationSent || isEmailVerified}
+								id="signup-auth-number"
+								inputMode="numeric"
+								maxLength={6}
+								onBlur={() => markTouched("authNumber")}
+								onChange={(event) => {
+									markTouched("authNumber");
+									setVerifiedEmail(null);
+									setForm((current) => ({
+										...current,
+										authNumber: event.target.value.replace(/\D/g, ""),
+									}));
+								}}
+								placeholder="6자리 숫자"
+								value={form.authNumber}
+							/>
+							<Button
+								disabled={
+									sendSignupEmailMutation.isPending ||
+									Boolean(errors.email) ||
+									isVerificationCooldownActive ||
+									isEmailVerified
+								}
+								onClick={() => void handleSendVerificationEmail()}
+								type="button"
+								variant="outline"
+							>
+								{sendSignupEmailMutation.isPending ? (
+									<LoaderCircle
+										className="animate-spin"
+										data-icon="inline-start"
+									/>
+								) : (
+									<MailCheck data-icon="inline-start" />
+								)}
+								{isVerificationCooldownActive
+									? `재발송 ${verificationCooldownRemainingSeconds}초`
+									: "번호 받기"}
+							</Button>
+							<Button
+								disabled={
+									!isVerificationSent ||
+									isEmailVerified ||
+									validateSignupAuthNumberMutation.isPending ||
+									Boolean(verificationErrors.authNumber)
+								}
+								onClick={() => void handleValidateAuthNumber()}
+								type="button"
+								variant="outline"
+							>
+								{validateSignupAuthNumberMutation.isPending ? (
+									<LoaderCircle
+										className="animate-spin"
+										data-icon="inline-start"
+									/>
+								) : isEmailVerified ? (
+									<CheckCircle2 data-icon="inline-start" />
+								) : (
+									<ShieldCheck data-icon="inline-start" />
+								)}
+								인증 확인
+							</Button>
+						</div>
+						{touched.authNumber && verificationErrors.authNumber ? (
+							<FieldError>{verificationErrors.authNumber}</FieldError>
+						) : sendSignupEmailMutation.error ? (
+							<FieldError>
+								{getApiErrorMessage(sendSignupEmailMutation.error)}
+							</FieldError>
+						) : validateSignupAuthNumberMutation.error ? (
+							<FieldError>
+								{getApiErrorMessage(validateSignupAuthNumberMutation.error)}
+							</FieldError>
+						) : isEmailVerified ? (
+							<FieldDescription>이메일 인증이 완료되었습니다.</FieldDescription>
+						) : isVerificationSent ? (
+							<FieldDescription>
+								메일로 받은 6자리 숫자를 입력해 주세요.
+							</FieldDescription>
+						) : (
+							<FieldDescription>
+								서버 회원가입은 이메일 인증 완료 후 진행됩니다.
+							</FieldDescription>
+						)}
 					</Field>
 
 					<Field data-invalid={Boolean(touched.password && errors.password)}>
@@ -324,11 +506,14 @@ export function SignupView() {
 							</FieldDescription>
 						)}
 					</Field>
-
 				</FieldGroup>
 
 				{signupMutation.error ? (
 					<FieldError>{getApiErrorMessage(signupMutation.error)}</FieldError>
+				) : touched.authNumber && !isEmailVerified ? (
+					<FieldError>
+						이메일 인증을 완료해야 회원가입할 수 있습니다.
+					</FieldError>
 				) : null}
 
 				<Button disabled={isSubmitDisabled} size="lg" type="submit">

--- a/src/features/auth/constants.ts
+++ b/src/features/auth/constants.ts
@@ -1,7 +1,7 @@
 export const previewAuth = {
+	authNumber: "123456",
 	email: "preview@teampo.dev",
 	password: "teampo123!",
-	verificationToken: "TEAMPO-2026",
 };
 
 export function getProfileFallback(value: string) {

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { login } from "@/lib/api/auth";
+import {
+	login,
+	sendSignupEmail,
+	validateSignupAuthNumber,
+} from "@/lib/api/auth";
 import {
 	clearAuthSession,
 	getAuthSession,
@@ -14,7 +18,12 @@ import {
 	getCurrentUser,
 	updateCurrentUser,
 } from "@/lib/api/users";
-import type { CreateUserRequest, LoginRequest } from "@/lib/types/auth";
+import type {
+	CreateUserRequest,
+	LoginRequest,
+	SendSignupEmailRequest,
+	ValidateSignupAuthNumberRequest,
+} from "@/lib/types/auth";
 import type {
 	DeleteCurrentUserRequest,
 	EditPasswordRequest,
@@ -55,6 +64,19 @@ export function useSignupMutation() {
 export function useCheckEmailDuplicateMutation() {
 	return useMutation({
 		mutationFn: (email: string) => checkEmailDuplicate(email),
+	});
+}
+
+export function useSendSignupEmailMutation() {
+	return useMutation({
+		mutationFn: (payload: SendSignupEmailRequest) => sendSignupEmail(payload),
+	});
+}
+
+export function useValidateSignupAuthNumberMutation() {
+	return useMutation({
+		mutationFn: (payload: ValidateSignupAuthNumberRequest) =>
+			validateSignupAuthNumber(payload),
 	});
 }
 

--- a/src/features/auth/lib/validation.ts
+++ b/src/features/auth/lib/validation.ts
@@ -13,8 +13,8 @@ export interface SignupFormValues {
 }
 
 export interface VerifyEmailFormValues {
+	authNumber: string;
 	email: string;
-	token: string;
 }
 
 export interface ProfileEditFormValues {
@@ -62,8 +62,8 @@ export function validateVerifyEmailForm(
 	values: VerifyEmailFormValues,
 ): FormErrors<VerifyEmailFormValues> {
 	return {
+		authNumber: getAuthNumberError(values.authNumber),
 		email: getEmailError(values.email),
-		token: getVerificationTokenError(values.token),
 	};
 }
 
@@ -174,15 +174,15 @@ function getDescriptionError(value: string) {
 	return undefined;
 }
 
-function getVerificationTokenError(value: string) {
+function getAuthNumberError(value: string) {
 	const trimmedValue = value.trim();
 
 	if (!trimmedValue) {
-		return "인증 정보를 입력해 주세요.";
+		return "인증번호를 입력해 주세요.";
 	}
 
-	if (trimmedValue.length < 6) {
-		return "인증 정보는 6자 이상이어야 해요.";
+	if (!/^\d{6}$/.test(trimmedValue)) {
+		return "인증번호는 6자리 숫자여야 해요.";
 	}
 
 	return undefined;

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -1,16 +1,21 @@
 import { useState } from "react";
 import {
 	ArrowRight,
+	CheckCircle2,
 	Clock3,
+	FolderKanban,
 	LoaderCircle,
 	RefreshCcw,
 	Send,
 	Square,
+	Users,
+	XCircle,
 } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -30,13 +35,23 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
+	useAcceptMatchMutation,
 	useCancelProjectRequestMutation,
 	useCreateProjectRequestMutation,
+	useMatchMembersQuery,
+	useMatchProjectQuery,
 	useProjectRequestStatusQuery,
+	useRejectMatchMutation,
 } from "@/features/match/hooks/use-match-queries";
-import { getAuthSession } from "@/lib/api/auth-session";
-import { ApiError, getApiErrorMessage } from "@/lib/api/client";
-import type { MatchRole, MatchStatus } from "@/lib/types/match";
+import { getProfileFallback } from "@/features/auth/constants";
+import { getAuthSession, getAuthSessionUserId } from "@/lib/api/auth-session";
+import { getApiErrorMessage } from "@/lib/api/client";
+import type {
+	MatchMember,
+	MatchProjectResponse,
+	MatchRole,
+	MatchStatus,
+} from "@/lib/types/match";
 import { cn } from "@/lib/utils";
 
 const roleOptions: Array<{
@@ -47,12 +62,12 @@ const roleOptions: Array<{
 	{
 		description: "인증, 저장, 배포처럼 서비스의 기반을 맡습니다.",
 		label: "Backend",
-		value: "BE",
+		value: "BACKEND",
 	},
 	{
 		description: "화면, 상태 관리, 사용자 흐름을 구현합니다.",
 		label: "Frontend",
-		value: "FE",
+		value: "FRONTEND",
 	},
 	{
 		description: "문제 정의, UX, 시각 시스템을 정리합니다.",
@@ -87,29 +102,55 @@ const statusMeta: Record<
 	},
 };
 
+const roleLabels: Record<MatchRole, string> = {
+	BACKEND: "Backend",
+	DESIGN: "Design",
+	FRONTEND: "Frontend",
+};
+
 export function MatchRequestView() {
 	const statusQuery = useProjectRequestStatusQuery();
 	const createMutation = useCreateProjectRequestMutation();
 	const cancelMutation = useCancelProjectRequestMutation();
 	const isSignedIn = Boolean(getAuthSession());
+	const currentUserId = getAuthSessionUserId();
 	const [form, setForm] = useState({
 		projectDescription: "",
 		projectMvp: "",
 		projectTitle: "",
-		role: "FE" as MatchRole,
+		role: "FRONTEND" as MatchRole,
 	});
-	const noActiveRequest =
-		statusQuery.data === null ||
-		(statusQuery.error instanceof ApiError && statusQuery.error.status === 404);
+	const projectInfoError = getProjectInfoError(form);
+	const noActiveRequest = statusQuery.data === null;
 	const status = statusQuery.data?.status;
+	const activeMatchId =
+		statusQuery.data?.status === "MATCHING" ? statusQuery.data.matchId : null;
+	const matchMembersQuery = useMatchMembersQuery(activeMatchId);
+	const matchProjectQuery = useMatchProjectQuery(activeMatchId);
+	const acceptMutation = useAcceptMatchMutation(activeMatchId);
+	const rejectMutation = useRejectMatchMutation(activeMatchId);
+	const currentMatchMember =
+		currentUserId && matchMembersQuery.data
+			? matchMembersQuery.data.members.find(
+					(member) => member.userId === currentUserId,
+				)
+			: undefined;
 	const canCancel = status === "WAITING" || status === "MATCHING";
+	const canRespondToMatch = Boolean(
+		activeMatchId &&
+			(!currentMatchMember ||
+				(!currentMatchMember.isHost && currentMatchMember.isAccepted !== true)),
+	);
 	const isSubmitDisabled =
-		!isSignedIn || createMutation.isPending || Boolean(status && canCancel);
+		!isSignedIn ||
+		createMutation.isPending ||
+		Boolean(status && canCancel) ||
+		Boolean(projectInfoError);
 
 	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 
-		if (isSubmitDisabled) {
+		if (isSubmitDisabled || projectInfoError) {
 			return;
 		}
 
@@ -143,8 +184,7 @@ export function MatchRequestView() {
 								</div>
 								<Button asChild variant="outline">
 									<Link to="/me">
-										<ArrowRight data-icon="inline-start" />
-										내 프로필 확인
+										<ArrowRight data-icon="inline-start" />내 프로필 확인
 									</Link>
 								</Button>
 							</div>
@@ -175,8 +215,7 @@ export function MatchRequestView() {
 							<CardHeader>
 								<CardTitle>현재 매칭 상태</CardTitle>
 								<CardDescription>
-									진행 중인 요청이 있으면 여기에서 확인하고 취소할 수
-									있습니다.
+									진행 중인 요청이 있으면 여기에서 확인하고 취소할 수 있습니다.
 								</CardDescription>
 							</CardHeader>
 							<CardContent className="flex flex-col gap-4">
@@ -246,7 +285,8 @@ export function MatchRequestView() {
 							<CardHeader>
 								<CardTitle>매칭 요청 작성</CardTitle>
 								<CardDescription>
-									역할만 선택해도 요청할 수 있고, 프로젝트 정보는 나중에 채워도 됩니다.
+									역할만 선택해도 요청할 수 있고, 프로젝트 정보는 세 항목을 함께
+									입력하면 호스트 요청이 됩니다.
 								</CardDescription>
 							</CardHeader>
 							<CardContent>
@@ -353,8 +393,12 @@ export function MatchRequestView() {
 												value={form.projectMvp}
 											/>
 											<FieldDescription>
-												프로젝트 정보 3개는 모두 비워도 됩니다. 역할 정보만으로 매칭 요청이 등록됩니다.
+												프로젝트 정보는 모두 비우거나 제목, 설명, MVP를 모두
+												입력해 주세요.
 											</FieldDescription>
+											{projectInfoError ? (
+												<FieldError>{projectInfoError}</FieldError>
+											) : null}
 										</Field>
 									</FieldGroup>
 
@@ -379,6 +423,26 @@ export function MatchRequestView() {
 							</CardContent>
 						</Card>
 					</div>
+
+					{activeMatchId ? (
+						<MatchSessionCard
+							canRespond={canRespondToMatch}
+							currentMember={currentMatchMember}
+							matchId={activeMatchId}
+							members={matchMembersQuery.data?.members}
+							membersError={matchMembersQuery.error}
+							membersLoading={matchMembersQuery.isLoading}
+							onAccept={() => void acceptMutation.mutateAsync()}
+							onReject={() => void rejectMutation.mutateAsync()}
+							project={matchProjectQuery.data}
+							projectError={matchProjectQuery.error}
+							projectLoading={matchProjectQuery.isLoading}
+							responseError={acceptMutation.error ?? rejectMutation.error}
+							responsePending={
+								acceptMutation.isPending || rejectMutation.isPending
+							}
+						/>
+					) : null}
 				</Container>
 			</main>
 			<SiteFooter />
@@ -389,6 +453,221 @@ export function MatchRequestView() {
 function emptyToNull(value: string) {
 	const trimmedValue = value.trim();
 	return trimmedValue ? trimmedValue : null;
+}
+
+function getProjectInfoError(values: {
+	projectDescription: string;
+	projectMvp: string;
+	projectTitle: string;
+}) {
+	const projectFields = [
+		values.projectTitle.trim(),
+		values.projectDescription.trim(),
+		values.projectMvp.trim(),
+	];
+	const hasAnyProjectInfo = projectFields.some(Boolean);
+	const hasCompleteProjectInfo = projectFields.every(Boolean);
+
+	if (hasAnyProjectInfo && !hasCompleteProjectInfo) {
+		return "프로젝트 정보를 입력할 때는 제목, 설명, MVP를 모두 작성해야 합니다.";
+	}
+
+	return null;
+}
+
+interface MatchSessionCardProps {
+	canRespond: boolean;
+	currentMember?: MatchMember;
+	matchId: number;
+	members?: MatchMember[];
+	membersError: unknown;
+	membersLoading: boolean;
+	onAccept: () => void;
+	onReject: () => void;
+	project?: MatchProjectResponse;
+	projectError: unknown;
+	projectLoading: boolean;
+	responseError: unknown;
+	responsePending: boolean;
+}
+
+function MatchSessionCard({
+	canRespond,
+	currentMember,
+	matchId,
+	members,
+	membersError,
+	membersLoading,
+	onAccept,
+	onReject,
+	project,
+	projectError,
+	projectLoading,
+	responseError,
+	responsePending,
+}: MatchSessionCardProps) {
+	return (
+		<Card className="border-primary/20 bg-white shadow-panel">
+			<CardHeader>
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+					<div className="flex flex-col gap-2">
+						<CardTitle>매칭 세션</CardTitle>
+						<CardDescription>
+							팀원과 프로젝트 정보를 확인한 뒤 수락 또는 거절할 수 있습니다.
+						</CardDescription>
+					</div>
+					<Badge className="w-fit" variant="brand">
+						#{matchId}
+					</Badge>
+				</div>
+			</CardHeader>
+			<CardContent className="grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
+				<div className="rounded-xl border border-border/60 bg-secondary/25 p-5">
+					<div className="flex items-center gap-2 font-semibold text-brand-ink">
+						<FolderKanban className="size-4" />
+						프로젝트
+					</div>
+					{projectLoading ? (
+						<p className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
+							<LoaderCircle className="size-4 animate-spin" />
+							프로젝트 정보를 불러오는 중입니다.
+						</p>
+					) : project ? (
+						<div className="mt-4 flex flex-col gap-3">
+							<p className="font-display text-2xl text-brand-ink">
+								{project.projectTitle}
+							</p>
+							<p className="text-sm leading-6 text-muted-foreground">
+								{project.projectDescription}
+							</p>
+							<div className="rounded-lg border border-border/60 bg-white/80 p-3">
+								<p className="text-xs font-semibold uppercase text-muted-foreground">
+									MVP
+								</p>
+								<p className="mt-1 text-sm leading-6 text-brand-ink">
+									{project.projectMvp}
+								</p>
+							</div>
+						</div>
+					) : projectError ? (
+						<FieldError>{getApiErrorMessage(projectError)}</FieldError>
+					) : null}
+				</div>
+
+				<div className="flex flex-col gap-4 rounded-xl border border-border/60 bg-white p-5">
+					<div className="flex items-center gap-2 font-semibold text-brand-ink">
+						<Users className="size-4" />
+						팀원
+					</div>
+					{membersLoading ? (
+						<p className="flex items-center gap-2 text-sm text-muted-foreground">
+							<LoaderCircle className="size-4 animate-spin" />
+							팀원 정보를 불러오는 중입니다.
+						</p>
+					) : members ? (
+						<div className="grid gap-3 md:grid-cols-2">
+							{members.map((member) => (
+								<MatchMemberItem key={member.userId} member={member} />
+							))}
+						</div>
+					) : membersError ? (
+						<FieldError>{getApiErrorMessage(membersError)}</FieldError>
+					) : null}
+
+					<div className="flex flex-col gap-3 border-border/60 border-t pt-4">
+						{currentMember?.isHost ? (
+							<FieldDescription>
+								호스트는 서버에서 자동 수락 상태로 처리됩니다.
+							</FieldDescription>
+						) : currentMember?.isAccepted === true ? (
+							<FieldDescription>이미 이 매칭을 수락했습니다.</FieldDescription>
+						) : null}
+						<div className="flex flex-col gap-3 sm:flex-row">
+							<Button
+								disabled={!canRespond || responsePending}
+								onClick={onAccept}
+								type="button"
+							>
+								{responsePending ? (
+									<LoaderCircle
+										className="animate-spin"
+										data-icon="inline-start"
+									/>
+								) : (
+									<CheckCircle2 data-icon="inline-start" />
+								)}
+								매칭 수락
+							</Button>
+							<Button
+								disabled={!canRespond || responsePending}
+								onClick={onReject}
+								type="button"
+								variant="outline"
+							>
+								<XCircle data-icon="inline-start" />
+								매칭 거절
+							</Button>
+						</div>
+						{responseError ? (
+							<FieldError>{getApiErrorMessage(responseError)}</FieldError>
+						) : null}
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function MatchMemberItem({ member }: { member: MatchMember }) {
+	const acceptedLabel = getAcceptedLabel(member);
+
+	return (
+		<div className="flex min-h-24 items-center gap-3 rounded-lg border border-border/60 bg-secondary/20 p-3">
+			<Avatar className="size-12 border border-border/70">
+				<AvatarImage
+					alt={member.nickname}
+					src={getMemberImageSrc(member.profileImageKey)}
+				/>
+				<AvatarFallback>{getProfileFallback(member.nickname)}</AvatarFallback>
+			</Avatar>
+			<div className="min-w-0 flex-1">
+				<div className="flex flex-wrap items-center gap-2">
+					<p className="truncate font-semibold text-brand-ink">
+						{member.nickname}
+					</p>
+					{member.isHost ? <Badge variant="warm">Host</Badge> : null}
+				</div>
+				<p className="mt-1 text-sm text-muted-foreground">
+					{roleLabels[member.role]} · Lv.{member.level} · {member.temperature}도
+				</p>
+				<p className="mt-1 text-xs text-muted-foreground">{acceptedLabel}</p>
+			</div>
+		</div>
+	);
+}
+
+function getMemberImageSrc(profileImageKey: string | null) {
+	if (!profileImageKey?.startsWith("http")) {
+		return undefined;
+	}
+
+	return profileImageKey;
+}
+
+function getAcceptedLabel(member: MatchMember) {
+	if (member.isHost) {
+		return "호스트 자동 수락";
+	}
+
+	if (member.isAccepted === true) {
+		return "수락 완료";
+	}
+
+	if (member.isAccepted === false) {
+		return "거절";
+	}
+
+	return "응답 대기";
 }
 
 interface StatusPanelProps {

--- a/src/features/match/hooks/use-match-queries.ts
+++ b/src/features/match/hooks/use-match-queries.ts
@@ -1,25 +1,66 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+	acceptMatch,
 	cancelProjectRequest,
 	createProjectRequest,
+	getMatchMembers,
+	getMatchProject,
 	getProjectRequestStatus,
+	rejectMatch,
 } from "@/lib/api/match";
 import { getAuthSession } from "@/lib/api/auth-session";
+import { ApiError } from "@/lib/api/client";
 import type {
+	MatchMemberResponse,
+	MatchProjectResponse,
 	ProjectRequestPayload,
 	ProjectRequestStatusResponse,
 } from "@/lib/types/match";
 
 export const matchQueryKeys = {
+	members: (matchId: number) => ["match", matchId, "members"] as const,
+	project: (matchId: number) => ["match", matchId, "project"] as const,
 	status: ["match", "status"] as const,
 };
 
 export function useProjectRequestStatusQuery() {
 	return useQuery<ProjectRequestStatusResponse | null>({
 		enabled: Boolean(getAuthSession()),
-		queryFn: () => getProjectRequestStatus(),
+		queryFn: async () => {
+			try {
+				return await getProjectRequestStatus();
+			} catch (error) {
+				if (error instanceof ApiError && error.status === 404) {
+					return null;
+				}
+
+				throw error;
+			}
+		},
 		queryKey: matchQueryKeys.status,
+		retry: false,
+	});
+}
+
+export function useMatchMembersQuery(matchId: number | null | undefined) {
+	return useQuery<MatchMemberResponse>({
+		enabled: Boolean(getAuthSession() && matchId),
+		queryFn: () => getMatchMembers(matchId as number),
+		queryKey: matchId
+			? matchQueryKeys.members(matchId)
+			: ["match", "members", "idle"],
+		retry: false,
+	});
+}
+
+export function useMatchProjectQuery(matchId: number | null | undefined) {
+	return useQuery<MatchProjectResponse>({
+		enabled: Boolean(getAuthSession() && matchId),
+		queryFn: () => getMatchProject(matchId as number),
+		queryKey: matchId
+			? matchQueryKeys.project(matchId)
+			: ["match", "project", "idle"],
 		retry: false,
 	});
 }
@@ -47,6 +88,38 @@ export function useCancelProjectRequestMutation() {
 				null,
 			);
 			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
+		},
+	});
+}
+
+export function useAcceptMatchMutation(matchId: number | null | undefined) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => acceptMatch(matchId as number),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
+			if (matchId) {
+				queryClient.invalidateQueries({
+					queryKey: matchQueryKeys.members(matchId),
+				});
+			}
+		},
+	});
+}
+
+export function useRejectMatchMutation(matchId: number | null | undefined) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => rejectMatch(matchId as number),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
+			if (matchId) {
+				queryClient.invalidateQueries({
+					queryKey: matchQueryKeys.members(matchId),
+				});
+			}
 		},
 	});
 }

--- a/src/features/project-groups/hooks/use-project-group-queries.ts
+++ b/src/features/project-groups/hooks/use-project-group-queries.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+	grantProjectGroupAdminPermission,
+	revokeProjectGroupAdminPermission,
+} from "@/lib/api/project-groups";
+import type { ProjectGroupAdminPermissionRequest } from "@/lib/types/project-group";
+
+export const projectGroupQueryKeys = {
+	all: ["project-groups"] as const,
+};
+
+export function useGrantProjectGroupAdminPermissionMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: ProjectGroupAdminPermissionRequest) =>
+			grantProjectGroupAdminPermission(payload),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: projectGroupQueryKeys.all });
+		},
+	});
+}
+
+export function useRevokeProjectGroupAdminPermissionMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: ProjectGroupAdminPermissionRequest) =>
+			revokeProjectGroupAdminPermission(payload),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: projectGroupQueryKeys.all });
+		},
+	});
+}

--- a/src/lib/api/auth-session.ts
+++ b/src/lib/api/auth-session.ts
@@ -40,3 +40,43 @@ export function clearAuthSession() {
 
 	window.localStorage.removeItem(authSessionStorageKey);
 }
+
+export function getAuthSessionUserId() {
+	const session = getAuthSession();
+
+	if (!session) {
+		return null;
+	}
+
+	return getUserIdFromAccessToken(session.accessToken);
+}
+
+function getUserIdFromAccessToken(accessToken: string) {
+	const [, payload] = accessToken.split(".");
+
+	if (!payload) {
+		return null;
+	}
+
+	try {
+		const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/");
+		const paddedPayload = normalizedPayload.padEnd(
+			Math.ceil(normalizedPayload.length / 4) * 4,
+			"=",
+		);
+		const parsedPayload = JSON.parse(window.atob(paddedPayload)) as unknown;
+
+		if (
+			typeof parsedPayload === "object" &&
+			parsedPayload !== null &&
+			"userId" in parsedPayload
+		) {
+			const userId = parsedPayload.userId;
+			return typeof userId === "number" ? userId : null;
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,9 +1,35 @@
 import { apiRequest } from "@/lib/api/client";
-import type { LoginRequest, LoginResponse } from "@/lib/types/auth";
+import type {
+	LoginRequest,
+	LoginResponse,
+	SendSignupEmailRequest,
+	ValidateSignupAuthNumberRequest,
+} from "@/lib/types/auth";
 
 export function login(payload: LoginRequest) {
 	return apiRequest<LoginResponse>("/users/sign-in", {
 		json: payload,
+		method: "POST",
+		skipAuth: true,
+	});
+}
+
+export function sendSignupEmail(payload: SendSignupEmailRequest) {
+	return apiRequest<void>("/signup/email", {
+		json: { email: payload.email.trim() },
+		method: "POST",
+		skipAuth: true,
+	});
+}
+
+export function validateSignupAuthNumber(
+	payload: ValidateSignupAuthNumberRequest,
+) {
+	return apiRequest<void>("/signup/number-validation", {
+		json: {
+			authNumber: payload.authNumber,
+			email: payload.email.trim(),
+		},
 		method: "POST",
 		skipAuth: true,
 	});

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -15,7 +15,7 @@ interface ApiRequestOptions extends Omit<RequestInit, "body"> {
 
 export class ApiError extends Error {
 	code?: string;
-	fieldErrors?: Record<string, string[]>;
+	fieldErrors?: Record<string, string>;
 	status: number;
 
 	constructor(status: number, payload: ApiErrorResponse) {

--- a/src/lib/api/match.ts
+++ b/src/lib/api/match.ts
@@ -1,5 +1,7 @@
 import { apiRequest } from "@/lib/api/client";
 import type {
+	MatchMemberResponse,
+	MatchProjectResponse,
 	ProjectRequestPayload,
 	ProjectRequestStatusResponse,
 } from "@/lib/types/match";
@@ -13,10 +15,30 @@ export function createProjectRequest(payload: ProjectRequestPayload) {
 
 export function cancelProjectRequest() {
 	return apiRequest<void>("/match/cancel", {
-		method: "PATCH",
+		method: "POST",
 	});
 }
 
 export function getProjectRequestStatus() {
 	return apiRequest<ProjectRequestStatusResponse>("/match/status");
+}
+
+export function getMatchMembers(matchId: number) {
+	return apiRequest<MatchMemberResponse>(`/match/${matchId}/members`);
+}
+
+export function getMatchProject(matchId: number) {
+	return apiRequest<MatchProjectResponse>(`/match/${matchId}/project`);
+}
+
+export function acceptMatch(matchId: number) {
+	return apiRequest<void>(`/match/${matchId}/accept`, {
+		method: "POST",
+	});
+}
+
+export function rejectMatch(matchId: number) {
+	return apiRequest<void>(`/match/${matchId}/reject`, {
+		method: "POST",
+	});
 }

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -1,10 +1,24 @@
 import { delay, http, HttpResponse } from "msw";
 
 import { apiConfig } from "@/lib/api/config";
-import { createPreviewUser, previewAuthSeed } from "@/lib/api/mocks/auth-preview";
-import type { CreateUserRequest, LoginRequest } from "@/lib/types/auth";
+import {
+	createPreviewUser,
+	previewAuthSeed,
+} from "@/lib/api/mocks/auth-preview";
+import type {
+	CreateUserRequest,
+	LoginRequest,
+	SendSignupEmailRequest,
+	ValidateSignupAuthNumberRequest,
+} from "@/lib/types/auth";
 import type { ApiErrorResponse } from "@/lib/types/api";
-import type { MatchStatus, ProjectRequestPayload } from "@/lib/types/match";
+import type {
+	MatchMemberResponse,
+	MatchProjectResponse,
+	MatchRole,
+	MatchStatus,
+	ProjectRequestPayload,
+} from "@/lib/types/match";
 import type {
 	DeleteCurrentUserRequest,
 	EditPasswordRequest,
@@ -13,14 +27,19 @@ import type {
 } from "@/lib/types/user";
 
 let currentUser: UserProfile | null = createPreviewUser();
+let currentUserId = 1;
 let currentPassword = previewAuthSeed.password;
 let matchStatus: MatchStatus | null = null;
+let activeMatchId: number | null = null;
+let activeMatchMembers: MatchMemberResponse["members"] = [];
+let activeMatchProject: MatchProjectResponse | null = null;
+const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
 
 function buildErrorResponse(
 	status: number,
 	message: string,
 	code: string,
-	fieldErrors?: Record<string, string[]>,
+	fieldErrors?: Record<string, string>,
 ) {
 	const payload: ApiErrorResponse = {
 		code,
@@ -39,6 +58,10 @@ function isServerErrorTrigger(value: string) {
 	return value.trim() === "server-error@teampo.dev";
 }
 
+function normalizeEmail(value: string) {
+	return value.trim().toLowerCase();
+}
+
 function isValidEmail(value: string) {
 	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
@@ -51,14 +74,109 @@ function isSupportedImageType(value: string) {
 
 function buildSession() {
 	return {
-		accessToken: "mock-access-token",
+		accessToken: createMockJwt(currentUserId, currentUser?.email ?? ""),
 		expiresAt: "2026-04-20T12:00:00.000Z",
 		refreshToken: "mock-refresh-token",
 	};
 }
 
+function createMockJwt(userId: number, email: string) {
+	const header = base64UrlEncode(JSON.stringify({ alg: "none", typ: "JWT" }));
+	const payload = base64UrlEncode(
+		JSON.stringify({
+			sub: email,
+			tokenType: "access",
+			userId,
+		}),
+	);
+
+	return `${header}.${payload}.mock-signature`;
+}
+
+function base64UrlEncode(value: string) {
+	return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
 function imageUrlFromKey(objectKey: string | undefined) {
 	return objectKey ? `https://images.teampo.dev/${objectKey}` : null;
+}
+
+function isValidMatchRole(value: string): value is MatchRole {
+	return ["BACKEND", "FRONTEND", "DESIGN"].includes(value);
+}
+
+function hasCompleteProjectInfo(body: ProjectRequestPayload) {
+	return Boolean(
+		body.projectTitle?.trim() &&
+			body.projectDescription?.trim() &&
+			body.projectMvp?.trim(),
+	);
+}
+
+function hasPartialProjectInfo(body: ProjectRequestPayload) {
+	const fields = [
+		body.projectTitle?.trim(),
+		body.projectDescription?.trim(),
+		body.projectMvp?.trim(),
+	];
+
+	return fields.some(Boolean) && !fields.every(Boolean);
+}
+
+function createMockMatchSession(body: ProjectRequestPayload) {
+	activeMatchId = 42;
+	activeMatchProject = {
+		matchId: activeMatchId,
+		projectDescription:
+			body.projectDescription ??
+			"개발자 사이드 프로젝트 팀을 빠르게 구성하는 서비스를 만듭니다.",
+		projectMvp:
+			body.projectMvp ??
+			"프로필 기반 매칭 요청, 팀원 응답, 팀 스페이스 생성까지 연결합니다.",
+		projectTitle: body.projectTitle ?? "Team-po 매칭 실험",
+	};
+	activeMatchMembers = [
+		{
+			isAccepted: hasCompleteProjectInfo(body) ? true : null,
+			isHost: hasCompleteProjectInfo(body),
+			level: currentUser?.level ?? 3,
+			nickname: currentUser?.nickname ?? "preview",
+			profileImageKey: currentUser?.profileImage ?? null,
+			role: body.role,
+			temperature: currentUser?.temperature ?? 50,
+			userId: currentUserId,
+		},
+		{
+			isAccepted: true,
+			isHost: !hasCompleteProjectInfo(body),
+			level: 4,
+			nickname: "api_builder",
+			profileImageKey: null,
+			role: "BACKEND",
+			temperature: 53,
+			userId: 2,
+		},
+		{
+			isAccepted: null,
+			isHost: false,
+			level: 3,
+			nickname: "pixel_runner",
+			profileImageKey: null,
+			role: "FRONTEND",
+			temperature: 49,
+			userId: 3,
+		},
+		{
+			isAccepted: null,
+			isHost: false,
+			level: 2,
+			nickname: "flow_designer",
+			profileImageKey: null,
+			role: "DESIGN",
+			temperature: 51,
+			userId: 4,
+		},
+	];
 }
 
 export const handlers = [
@@ -71,7 +189,7 @@ export const handlers = [
 			return buildErrorResponse(
 				500,
 				"로그인 처리 중 서버 오류가 발생했습니다.",
-				"internal_server_error",
+				"MATCH_DATA_ERROR",
 			);
 		}
 
@@ -79,7 +197,7 @@ export const handlers = [
 			return buildErrorResponse(
 				401,
 				"이메일 또는 비밀번호가 올바르지 않습니다.",
-				"invalid_credentials",
+				"INVALID_CREDENTIALS",
 			);
 		}
 
@@ -87,15 +205,18 @@ export const handlers = [
 			return buildErrorResponse(
 				400,
 				"입력값이 올바르지 않습니다.",
-				"validation_error",
+				"INVALID_INPUT_FIELD",
 			);
 		}
 
-		if (body.email !== currentUser.email || body.password !== currentPassword) {
+		if (
+			normalizeEmail(body.email) !== currentUser.email ||
+			body.password !== currentPassword
+		) {
 			return buildErrorResponse(
 				401,
 				"이메일 또는 비밀번호가 올바르지 않습니다.",
-				"invalid_credentials",
+				"INVALID_CREDENTIALS",
 			);
 		}
 
@@ -111,12 +232,12 @@ export const handlers = [
 			return buildErrorResponse(
 				401,
 				"유효하지 않은 리프레시 토큰입니다.",
-				"invalid_token",
+				"INVALID_TOKEN",
 			);
 		}
 
 		return HttpResponse.json({
-			accessToken: "mock-access-token-refreshed",
+			accessToken: createMockJwt(currentUserId, currentUser?.email ?? ""),
 			expiresAt: "2026-04-20T13:00:00.000Z",
 		});
 	}),
@@ -129,10 +250,76 @@ export const handlers = [
 			return buildErrorResponse(
 				409,
 				"중복된 이메일이 존재합니다.",
-				"email_already_exists",
+				"EMAIL_ALREADY_EXISTS",
 			);
 		}
 
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.post(getPath("/signup/email"), async ({ request }) => {
+		const body = (await request.json()) as SendSignupEmailRequest;
+		const email = normalizeEmail(body.email);
+
+		await delay(350);
+
+		if (isServerErrorTrigger(email)) {
+			return buildErrorResponse(
+				502,
+				"인증번호 이메일 발송에 실패했습니다.",
+				"EMAIL_SEND_FAILED",
+			);
+		}
+
+		if (!isValidEmail(email)) {
+			return buildErrorResponse(
+				400,
+				"입력값이 올바르지 않습니다.",
+				"INVALID_INPUT_FIELD",
+				{
+					email: "이메일 형식이 아닙니다.",
+				},
+			);
+		}
+
+		if (email === "taken@teampo.dev") {
+			return buildErrorResponse(
+				409,
+				"중복된 이메일이 존재합니다.",
+				"EMAIL_ALREADY_EXISTS",
+			);
+		}
+
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.post(getPath("/signup/number-validation"), async ({ request }) => {
+		const body = (await request.json()) as ValidateSignupAuthNumberRequest;
+		const email = normalizeEmail(body.email);
+
+		await delay(250);
+
+		if (
+			!isValidEmail(email) ||
+			body.authNumber < 100000 ||
+			body.authNumber > 999999
+		) {
+			return buildErrorResponse(
+				400,
+				"입력값이 올바르지 않습니다.",
+				"INVALID_INPUT_FIELD",
+			);
+		}
+
+		if (body.authNumber !== 123456) {
+			return buildErrorResponse(
+				400,
+				"인증번호가 만료되었거나 올바르지 않습니다.",
+				"INVALID_EMAIL_AUTH_CODE",
+			);
+		}
+
+		verifiedSignupEmails.add(email);
 		return new HttpResponse(null, { status: 200 });
 	}),
 
@@ -143,7 +330,7 @@ export const handlers = [
 			return buildErrorResponse(
 				400,
 				"지원하지 않는 이미지 형식입니다.",
-				"invalid_image_content_type",
+				"INVALID_IMAGE_CONTENT_TYPE",
 			);
 		}
 
@@ -176,7 +363,7 @@ export const handlers = [
 			return buildErrorResponse(
 				500,
 				"회원가입 처리 중 서버 오류가 발생했습니다.",
-				"internal_server_error",
+				"MATCH_DATA_ERROR",
 			);
 		}
 
@@ -184,7 +371,15 @@ export const handlers = [
 			return buildErrorResponse(
 				409,
 				"중복된 이메일이 존재합니다.",
-				"email_already_exists",
+				"EMAIL_ALREADY_EXISTS",
+			);
+		}
+
+		if (!verifiedSignupEmails.has(normalizeEmail(body.email))) {
+			return buildErrorResponse(
+				400,
+				"이메일 인증이 필요합니다.",
+				"EMAIL_NOT_VERIFIED",
 			);
 		}
 
@@ -198,13 +393,14 @@ export const handlers = [
 			return buildErrorResponse(
 				400,
 				"입력값이 올바르지 않습니다.",
-				"validation_error",
+				"INVALID_INPUT_FIELD",
 			);
 		}
 
+		currentUserId += 1;
 		currentUser = {
 			description: null,
-			email: body.email.trim(),
+			email: normalizeEmail(body.email),
 			level: body.level,
 			nickname: body.nickname.trim(),
 			profileImage: imageUrlFromKey(body.profileImageKey),
@@ -219,40 +415,47 @@ export const handlers = [
 		await delay(250);
 
 		if (!currentUser) {
-			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
 		}
 
 		return HttpResponse.json(currentUser);
 	}),
 
-	http.post(getPath("/users/me/profile-image/upload-url"), async ({ request }) => {
-		const body = (await request.json()) as { contentType: string };
+	http.post(
+		getPath("/users/me/profile-image/upload-url"),
+		async ({ request }) => {
+			const body = (await request.json()) as { contentType: string };
 
-		if (!isSupportedImageType(body.contentType)) {
-			return buildErrorResponse(
-				400,
-				"지원하지 않는 이미지 형식입니다.",
-				"invalid_image_content_type",
-			);
-		}
+			if (!isSupportedImageType(body.contentType)) {
+				return buildErrorResponse(
+					400,
+					"지원하지 않는 이미지 형식입니다.",
+					"INVALID_IMAGE_CONTENT_TYPE",
+				);
+			}
 
-		const extension = body.contentType.split("/")[1]?.replace("jpeg", "jpg");
-		const objectKey = `images/users/1/${crypto.randomUUID()}.${extension}`;
+			const extension = body.contentType.split("/")[1]?.replace("jpeg", "jpg");
+			const objectKey = `images/users/1/${crypto.randomUUID()}.${extension}`;
 
-		return HttpResponse.json({
-			contentType: body.contentType,
-			expiresAt: "2026-04-20T12:05:00.000Z",
-			formFields: {
-				"Content-Type": body.contentType,
-				key: objectKey,
-				Policy: "mock-policy",
-				"X-Amz-Signature": "mock-signature",
-			},
-			maxFileSizeBytes: 5_242_880,
-			objectKey,
-			uploadUrl: getPath("/mock/profile-image-upload"),
-		});
-	}),
+			return HttpResponse.json({
+				contentType: body.contentType,
+				expiresAt: "2026-04-20T12:05:00.000Z",
+				formFields: {
+					"Content-Type": body.contentType,
+					key: objectKey,
+					Policy: "mock-policy",
+					"X-Amz-Signature": "mock-signature",
+				},
+				maxFileSizeBytes: 5_242_880,
+				objectKey,
+				uploadUrl: getPath("/mock/profile-image-upload"),
+			});
+		},
+	),
 
 	http.post(getPath("/mock/profile-image-upload"), async () => {
 		await delay(200);
@@ -267,14 +470,18 @@ export const handlers = [
 		await delay(450);
 
 		if (!currentUser) {
-			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
 		}
 
 		if (body.nickname.trim().length < 2 || body.level < 1 || body.level > 5) {
 			return buildErrorResponse(
 				400,
 				"입력값이 올바르지 않습니다.",
-				"validation_error",
+				"INVALID_INPUT_FIELD",
 			);
 		}
 
@@ -300,7 +507,7 @@ export const handlers = [
 			return buildErrorResponse(
 				401,
 				"현재 비밀번호와 동일하지 않습니다.",
-				"unmatched_password",
+				"UNMATCHED_PASSWORD",
 			);
 		}
 
@@ -317,12 +524,15 @@ export const handlers = [
 			return buildErrorResponse(
 				401,
 				"현재 비밀번호와 동일하지 않습니다.",
-				"unmatched_password",
+				"UNMATCHED_PASSWORD",
 			);
 		}
 
 		currentUser = null;
 		matchStatus = null;
+		activeMatchId = null;
+		activeMatchMembers = [];
+		activeMatchProject = null;
 
 		return new HttpResponse(null, { status: 200 });
 	}),
@@ -331,18 +541,25 @@ export const handlers = [
 		await delay(250);
 
 		if (!currentUser) {
-			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
 		}
 
 		if (!matchStatus) {
 			return buildErrorResponse(
 				404,
 				"진행 중인 매칭 요청이 없습니다.",
-				"project_request_not_found",
+				"PROJECT_REQUEST_NOT_FOUND",
 			);
 		}
 
-		return HttpResponse.json({ status: matchStatus });
+		return HttpResponse.json({
+			matchId: matchStatus === "MATCHING" ? activeMatchId : null,
+			status: matchStatus,
+		});
 	}),
 
 	http.post(getPath("/match/request"), async ({ request }) => {
@@ -351,47 +568,216 @@ export const handlers = [
 		await delay(500);
 
 		if (!currentUser) {
-			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
 		}
 
 		if (matchStatus === "WAITING" || matchStatus === "MATCHING") {
 			return buildErrorResponse(
 				409,
 				"이미 진행 중인 매칭 요청이 있습니다.",
-				"project_request_already_exists",
+				"PROJECT_REQUEST_ALREADY_EXISTS",
 			);
 		}
 
-		if (!["BE", "FE", "DESIGN"].includes(body.role)) {
+		if (!isValidMatchRole(body.role) || hasPartialProjectInfo(body)) {
 			return buildErrorResponse(
 				400,
 				"입력값이 올바르지 않습니다.",
-				"validation_error",
+				"INVALID_INPUT_FIELD",
 			);
 		}
 
-		matchStatus = "WAITING";
+		if (hasCompleteProjectInfo(body)) {
+			matchStatus = "MATCHING";
+			createMockMatchSession(body);
+		} else {
+			matchStatus = "WAITING";
+			activeMatchId = null;
+			activeMatchMembers = [];
+			activeMatchProject = null;
+		}
 
 		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.patch(getPath("/match/cancel"), async () => {
+	http.post(getPath("/match/cancel"), async () => {
 		await delay(350);
 
 		if (!currentUser) {
-			return buildErrorResponse(401, "로그인이 필요합니다.", "unauthorized");
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
 		}
 
 		if (matchStatus !== "WAITING" && matchStatus !== "MATCHING") {
 			return buildErrorResponse(
 				404,
 				"취소할 수 있는 매칭 요청이 없습니다.",
-				"project_request_not_found",
+				"PROJECT_REQUEST_NOT_FOUND",
 			);
 		}
 
 		matchStatus = null;
+		activeMatchId = null;
+		activeMatchMembers = [];
+		activeMatchProject = null;
 
 		return new HttpResponse(null, { status: 200 });
 	}),
+
+	http.get(getPath("/match/:matchId/members"), ({ params }) => {
+		const matchId = Number(params.matchId);
+
+		if (!currentUser) {
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
+		}
+
+		if (!activeMatchId || matchId !== activeMatchId) {
+			return buildErrorResponse(
+				404,
+				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
+				"MATCH_NOT_FOUND",
+			);
+		}
+
+		return HttpResponse.json({
+			matchId: activeMatchId,
+			members: activeMatchMembers,
+		} satisfies MatchMemberResponse);
+	}),
+
+	http.get(getPath("/match/:matchId/project"), ({ params }) => {
+		const matchId = Number(params.matchId);
+
+		if (!currentUser) {
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
+		}
+
+		if (!activeMatchId || matchId !== activeMatchId || !activeMatchProject) {
+			return buildErrorResponse(
+				404,
+				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
+				"MATCH_NOT_FOUND",
+			);
+		}
+
+		return HttpResponse.json(activeMatchProject);
+	}),
+
+	http.post(getPath("/match/:matchId/accept"), ({ params }) => {
+		const matchId = Number(params.matchId);
+		const member = activeMatchMembers.find(
+			(candidate) => candidate.userId === currentUserId,
+		);
+
+		if (!activeMatchId || matchId !== activeMatchId || !member) {
+			return buildErrorResponse(
+				404,
+				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
+				"MATCH_NOT_FOUND",
+			);
+		}
+
+		if (member.isHost) {
+			return buildErrorResponse(
+				400,
+				"매칭 세션 접근 권한이 없습니다.",
+				"MATCH_ACCESS_DENIED",
+			);
+		}
+
+		member.isAccepted = true;
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.post(getPath("/match/:matchId/reject"), ({ params }) => {
+		const matchId = Number(params.matchId);
+		const member = activeMatchMembers.find(
+			(candidate) => candidate.userId === currentUserId,
+		);
+
+		if (!activeMatchId || matchId !== activeMatchId || !member) {
+			return buildErrorResponse(
+				404,
+				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
+				"MATCH_NOT_FOUND",
+			);
+		}
+
+		if (member.isHost || member.isAccepted === true) {
+			return buildErrorResponse(
+				400,
+				"매칭 세션 접근 권한이 없습니다.",
+				"MATCH_ACCESS_DENIED",
+			);
+		}
+
+		member.isAccepted = false;
+		matchStatus = "WAITING";
+		activeMatchId = null;
+		activeMatchMembers = [];
+		activeMatchProject = null;
+
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.patch(
+		getPath("/project-groups/:projectGroupId/admins/:targetUserId"),
+		({ params }) => {
+			if (!currentUser) {
+				return buildErrorResponse(
+					401,
+					"인증된 유저를 찾을 수 없습니다.",
+					"NO_AUTHENTICATED_USER",
+				);
+			}
+
+			if (Number(params.targetUserId) === currentUserId) {
+				return buildErrorResponse(
+					403,
+					"방장만 관리자 권한을 변경할 수 있습니다.",
+					"PROJECT_GROUP_PERMISSION_DENIED",
+				);
+			}
+
+			return new HttpResponse(null, { status: 200 });
+		},
+	),
+
+	http.delete(
+		getPath("/project-groups/:projectGroupId/admins/:targetUserId"),
+		({ params }) => {
+			if (!currentUser) {
+				return buildErrorResponse(
+					401,
+					"인증된 유저를 찾을 수 없습니다.",
+					"NO_AUTHENTICATED_USER",
+				);
+			}
+
+			if (Number(params.targetUserId) === currentUserId) {
+				return buildErrorResponse(
+					403,
+					"방장의 관리자 권한은 회수할 수 없습니다.",
+					"PROJECT_GROUP_PERMISSION_DENIED",
+				);
+			}
+
+			return new HttpResponse(null, { status: 200 });
+		},
+	),
 ];

--- a/src/lib/api/project-groups.ts
+++ b/src/lib/api/project-groups.ts
@@ -1,0 +1,26 @@
+import { apiRequest } from "@/lib/api/client";
+import type { ProjectGroupAdminPermissionRequest } from "@/lib/types/project-group";
+
+export function grantProjectGroupAdminPermission({
+	projectGroupId,
+	targetUserId,
+}: ProjectGroupAdminPermissionRequest) {
+	return apiRequest<void>(
+		`/project-groups/${projectGroupId}/admins/${targetUserId}`,
+		{
+			method: "PATCH",
+		},
+	);
+}
+
+export function revokeProjectGroupAdminPermission({
+	projectGroupId,
+	targetUserId,
+}: ProjectGroupAdminPermissionRequest) {
+	return apiRequest<void>(
+		`/project-groups/${projectGroupId}/admins/${targetUserId}`,
+		{
+			method: "DELETE",
+		},
+	);
+}

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -1,5 +1,5 @@
 export interface ApiErrorResponse {
 	code?: string;
-	fieldErrors?: Record<string, string[]>;
+	fieldErrors?: Record<string, string>;
 	message: string;
 }

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -3,6 +3,15 @@ export interface LoginRequest {
 	password: string;
 }
 
+export interface SendSignupEmailRequest {
+	email: string;
+}
+
+export interface ValidateSignupAuthNumberRequest {
+	authNumber: number;
+	email: string;
+}
+
 export interface SessionPayload {
 	accessToken: string;
 	expiresAt: string;

--- a/src/lib/types/match.ts
+++ b/src/lib/types/match.ts
@@ -1,4 +1,4 @@
-export type MatchRole = "DESIGN" | "BE" | "FE";
+export type MatchRole = "DESIGN" | "BACKEND" | "FRONTEND";
 
 export type MatchStatus = "WAITING" | "MATCHING" | "MATCHED" | "CANCELED";
 
@@ -10,5 +10,29 @@ export interface ProjectRequestPayload {
 }
 
 export interface ProjectRequestStatusResponse {
+	matchId: number | null;
 	status: MatchStatus;
+}
+
+export interface MatchMember {
+	isAccepted: boolean | null;
+	isHost: boolean;
+	level: number;
+	nickname: string;
+	profileImageKey: string | null;
+	role: MatchRole;
+	temperature: number;
+	userId: number;
+}
+
+export interface MatchMemberResponse {
+	matchId: number;
+	members: MatchMember[];
+}
+
+export interface MatchProjectResponse {
+	matchId: number;
+	projectDescription: string;
+	projectMvp: string;
+	projectTitle: string;
 }

--- a/src/lib/types/project-group.ts
+++ b/src/lib/types/project-group.ts
@@ -1,0 +1,9 @@
+import type { MatchRole } from "@/lib/types/match";
+
+export type ProjectGroupRole = "HOST" | "MEMBER";
+export type ProjectGroupMemberRole = MatchRole;
+
+export interface ProjectGroupAdminPermissionRequest {
+	projectGroupId: number;
+	targetUserId: number;
+}


### PR DESCRIPTION
Summary
- Align OpenAPI, typed API clients, hooks, and MSW handlers with the current Spring server endpoints.
- Add signup email auth-number send/validate UI with a 60-second resend cooldown.
- Add matching session members/project fetch, accept/reject actions, and project-group admin permission API wrappers.

Validation
- pnpm tsc --noEmit
- pnpm biome lint .
- pnpm build

Closes #36