### PR TITLE
feat(api): sync Client with Server API contract

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Team-po Server API
-  version: 0.2.0
+  version: 0.3.0
   summary: Client-facing contract mirrored from the current Spring controllers.
 servers:
   - url: /api
@@ -204,15 +204,41 @@ paths:
       security:
         - bearerAuth: []
       summary: Soft-delete the current user
+      responses:
+        '200':
+          description: User deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /users/me/deletion-email:
+    post:
+      tags: [Users]
+      security:
+        - bearerAuth: []
+      summary: Send a deletion auth number to the current user's email
+      responses:
+        '200':
+          description: Deletion auth number sent
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+  /users/me/deletion-number-validation:
+    post:
+      tags: [Users]
+      security:
+        - bearerAuth: []
+      summary: Validate a deletion auth number for the current user
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteUserRequest'
+              $ref: '#/components/schemas/ValidateDeleteUserEmailRequest'
       responses:
         '200':
-          description: User deleted
+          description: Deletion auth number validated
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -384,6 +410,23 @@ paths:
       responses:
         '200':
           description: Match request canceled
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /project-groups/me:
+    get:
+      tags: [ProjectGroups]
+      security:
+        - bearerAuth: []
+      summary: Get the current user's active project group
+      responses:
+        '200':
+          description: Current user's active project group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMyProjectGroupResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -615,14 +658,15 @@ components:
         afterPassword:
           type: string
           minLength: 8
-    DeleteUserRequest:
+    ValidateDeleteUserEmailRequest:
       type: object
       additionalProperties: false
-      required: [password]
+      required: [authNumber]
       properties:
-        password:
-          type: string
-          minLength: 8
+        authNumber:
+          type: integer
+          minimum: 100000
+          maximum: 999999
     ProfileImageUploadUrlRequest:
       type: object
       additionalProperties: false
@@ -743,6 +787,73 @@ components:
           type: string
         projectMvp:
           type: string
+    GetMyProjectGroupResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - currentUserId
+        - projectGroupId
+        - projectName
+        - projectTitle
+        - projectDescription
+        - projectMvp
+        - members
+      properties:
+        currentUserId:
+          type: integer
+          format: int64
+        projectGroupId:
+          type: integer
+          format: int64
+        projectName:
+          type: string
+        projectTitle:
+          type: string
+        projectDescription:
+          type:
+            - string
+            - 'null'
+        projectMvp:
+          type:
+            - string
+            - 'null'
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectGroupMember'
+    ProjectGroupMember:
+      type: object
+      additionalProperties: false
+      required:
+        - userId
+        - nickname
+        - profileImage
+        - level
+        - temperature
+        - memberRole
+        - groupRole
+        - admin
+      properties:
+        userId:
+          type: integer
+          format: int64
+        nickname:
+          type: string
+        profileImage:
+          type:
+            - string
+            - 'null'
+        level:
+          type: integer
+        temperature:
+          type: integer
+        memberRole:
+          $ref: '#/components/schemas/MatchRole'
+        groupRole:
+          type: string
+          enum: [HOST, MEMBER]
+        admin:
+          type: boolean
   responses:
     BadRequest:
       description: Validation failed or business rule rejected the request

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -34,7 +34,9 @@ import {
 	useCurrentUserQuery,
 	useDeleteCurrentUserMutation,
 	useEditPasswordMutation,
+	useSendDeleteUserEmailMutation,
 	useUpdateCurrentUserMutation,
+	useValidateDeleteUserEmailMutation,
 } from "@/features/auth/hooks/use-auth-queries";
 import {
 	getDeleteConfirmationError,
@@ -56,6 +58,8 @@ export function ProfileView() {
 	const currentUserQuery = useCurrentUserQuery();
 	const updateCurrentUserMutation = useUpdateCurrentUserMutation();
 	const editPasswordMutation = useEditPasswordMutation();
+	const sendDeleteUserEmailMutation = useSendDeleteUserEmailMutation();
+	const validateDeleteUserEmailMutation = useValidateDeleteUserEmailMutation();
 	const deleteCurrentUserMutation = useDeleteCurrentUserMutation();
 	const [form, setForm] = useState({
 		description: "",
@@ -75,8 +79,8 @@ export function ProfileView() {
 		currentPassword: "",
 	});
 	const [deleteForm, setDeleteForm] = useState({
+		authNumber: "",
 		confirm: "",
-		password: "",
 	});
 	const [profileImagePreviewUrl, setProfileImagePreviewUrl] = useState<
 		string | null
@@ -135,9 +139,11 @@ export function ProfileView() {
 		passwordForm.currentPassword.length < 8 ||
 		passwordForm.afterPassword.length < 8;
 	const isDeleteDisabled =
+		sendDeleteUserEmailMutation.isPending ||
+		validateDeleteUserEmailMutation.isPending ||
 		deleteCurrentUserMutation.isPending ||
 		Boolean(deleteConfirmError) ||
-		deleteForm.password.length < 8;
+		!/^\d{6}$/.test(deleteForm.authNumber);
 
 	function markTouched(field: keyof typeof touched) {
 		setTouched((current) => ({
@@ -184,6 +190,10 @@ export function ProfileView() {
 		navigate("/login", { replace: true });
 	}
 
+	async function handleDeleteEmailSend() {
+		await sendDeleteUserEmailMutation.mutateAsync();
+	}
+
 	async function handleDeleteSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 
@@ -191,9 +201,10 @@ export function ProfileView() {
 			return;
 		}
 
-		await deleteCurrentUserMutation.mutateAsync({
-			password: deleteForm.password,
+		await validateDeleteUserEmailMutation.mutateAsync({
+			authNumber: Number(deleteForm.authNumber),
 		});
+		await deleteCurrentUserMutation.mutateAsync();
 		navigate("/", { replace: true });
 	}
 
@@ -395,8 +406,13 @@ export function ProfileView() {
 									deleteCurrentUserMutation={deleteCurrentUserMutation}
 									deleteForm={deleteForm}
 									isDeleteDisabled={isDeleteDisabled}
+									onSendDeleteEmail={handleDeleteEmailSend}
 									onSubmit={handleDeleteSubmit}
+									sendDeleteUserEmailMutation={sendDeleteUserEmailMutation}
 									setDeleteForm={setDeleteForm}
+									validateDeleteUserEmailMutation={
+										validateDeleteUserEmailMutation
+									}
 								/>
 							</div>
 						</div>
@@ -769,22 +785,35 @@ function DangerPanel({
 	deleteCurrentUserMutation,
 	deleteForm,
 	isDeleteDisabled,
+	onSendDeleteEmail,
 	onSubmit,
+	sendDeleteUserEmailMutation,
 	setDeleteForm,
+	validateDeleteUserEmailMutation,
 }: {
 	deleteConfirmError: string | undefined;
 	deleteCurrentUserMutation: ReturnType<typeof useDeleteCurrentUserMutation>;
-	deleteForm: { confirm: string; password: string };
+	deleteForm: { authNumber: string; confirm: string };
 	isDeleteDisabled: boolean;
+	onSendDeleteEmail: () => void;
 	onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+	sendDeleteUserEmailMutation: ReturnType<
+		typeof useSendDeleteUserEmailMutation
+	>;
 	setDeleteForm: React.Dispatch<
-		React.SetStateAction<{ confirm: string; password: string }>
+		React.SetStateAction<{ authNumber: string; confirm: string }>
+	>;
+	validateDeleteUserEmailMutation: ReturnType<
+		typeof useValidateDeleteUserEmailMutation
 	>;
 }) {
+	const deleteError =
+		validateDeleteUserEmailMutation.error ?? deleteCurrentUserMutation.error;
+
 	return (
 		<AppPanel className="border-rose-200">
 			<AppPanelHeader
-				description="비밀번호 확인 후 계정을 삭제합니다."
+				description="이메일 인증번호 확인 후 계정을 삭제합니다."
 				eyebrow="Danger zone"
 				title="회원 탈퇴"
 			/>
@@ -799,6 +828,54 @@ function DangerPanel({
 					</p>
 				</div>
 				<FieldGroup>
+					<div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+						<Field>
+							<FieldLabel htmlFor="delete-auth-number">인증번호</FieldLabel>
+							<Input
+								className="h-11 bg-white"
+								id="delete-auth-number"
+								inputMode="numeric"
+								maxLength={6}
+								onChange={(event) =>
+									setDeleteForm((current) => ({
+										...current,
+										authNumber: event.target.value
+											.replace(/\D/g, "")
+											.slice(0, 6),
+									}))
+								}
+								placeholder="123456"
+								value={deleteForm.authNumber}
+							/>
+						</Field>
+						<Button
+							className="self-end"
+							disabled={sendDeleteUserEmailMutation.isPending}
+							onClick={() => void onSendDeleteEmail()}
+							type="button"
+							variant="outline"
+						>
+							{sendDeleteUserEmailMutation.isPending ? (
+								<LoaderCircle
+									className="animate-spin"
+									data-icon="inline-start"
+								/>
+							) : (
+								<KeyRound data-icon="inline-start" />
+							)}
+							인증번호 발송
+						</Button>
+					</div>
+					{sendDeleteUserEmailMutation.error ? (
+						<FieldError>
+							{getApiErrorMessage(sendDeleteUserEmailMutation.error)}
+						</FieldError>
+					) : null}
+					{sendDeleteUserEmailMutation.isSuccess ? (
+						<p className="text-sm font-medium text-emerald-700">
+							인증번호를 이메일로 보냈습니다.
+						</p>
+					) : null}
 					<Field data-invalid={Boolean(deleteConfirmError)}>
 						<FieldLabel htmlFor="delete-account-confirm">확인 문구</FieldLabel>
 						<Input
@@ -818,28 +895,10 @@ function DangerPanel({
 							<FieldError>{deleteConfirmError}</FieldError>
 						) : null}
 					</Field>
-					<Field>
-						<FieldLabel htmlFor="delete-password">비밀번호</FieldLabel>
-						<Input
-							className="h-11 bg-white"
-							id="delete-password"
-							minLength={8}
-							onChange={(event) =>
-								setDeleteForm((current) => ({
-									...current,
-									password: event.target.value,
-								}))
-							}
-							type="password"
-							value={deleteForm.password}
-						/>
-					</Field>
 				</FieldGroup>
 
-				{deleteCurrentUserMutation.error ? (
-					<FieldError>
-						{getApiErrorMessage(deleteCurrentUserMutation.error)}
-					</FieldError>
+				{deleteError ? (
+					<FieldError>{getApiErrorMessage(deleteError)}</FieldError>
 				) : null}
 
 				<Button disabled={isDeleteDisabled} type="submit" variant="outline">

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -191,7 +191,11 @@ export function ProfileView() {
 	}
 
 	async function handleDeleteEmailSend() {
-		await sendDeleteUserEmailMutation.mutateAsync();
+		try {
+			await sendDeleteUserEmailMutation.mutateAsync();
+		} catch {
+			// The mutation error state renders the inline error message.
+		}
 	}
 
 	async function handleDeleteSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -201,11 +205,15 @@ export function ProfileView() {
 			return;
 		}
 
-		await validateDeleteUserEmailMutation.mutateAsync({
-			authNumber: Number(deleteForm.authNumber),
-		});
-		await deleteCurrentUserMutation.mutateAsync();
-		navigate("/", { replace: true });
+		try {
+			await validateDeleteUserEmailMutation.mutateAsync({
+				authNumber: Number(deleteForm.authNumber),
+			});
+			await deleteCurrentUserMutation.mutateAsync();
+			navigate("/", { replace: true });
+		} catch {
+			// The mutation error state renders the inline error message.
+		}
 	}
 
 	return (

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -17,7 +17,9 @@ import {
 	deleteCurrentUser,
 	editPassword,
 	getCurrentUser,
+	sendDeleteUserEmail,
 	updateCurrentUser,
+	validateDeleteUserEmail,
 } from "@/lib/api/users";
 import type {
 	CreateUserRequest,
@@ -27,10 +29,10 @@ import type {
 	ValidateSignupAuthNumberRequest,
 } from "@/lib/types/auth";
 import type {
-	DeleteCurrentUserRequest,
 	EditPasswordRequest,
 	UpdateCurrentUserRequest,
 	UserProfile,
+	ValidateDeleteUserEmailRequest,
 } from "@/lib/types/user";
 
 const authQueryKeys = {
@@ -133,12 +135,24 @@ export function useEditPasswordMutation() {
 	});
 }
 
+export function useSendDeleteUserEmailMutation() {
+	return useMutation({
+		mutationFn: () => sendDeleteUserEmail(),
+	});
+}
+
+export function useValidateDeleteUserEmailMutation() {
+	return useMutation({
+		mutationFn: (payload: ValidateDeleteUserEmailRequest) =>
+			validateDeleteUserEmail(payload),
+	});
+}
+
 export function useDeleteCurrentUserMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: (payload: DeleteCurrentUserRequest) =>
-			deleteCurrentUser(payload),
+		mutationFn: () => deleteCurrentUser(),
 		onSuccess: () => {
 			clearAuthSession();
 			queryClient.removeQueries({

--- a/src/features/project-groups/hooks/use-project-group-queries.ts
+++ b/src/features/project-groups/hooks/use-project-group-queries.ts
@@ -1,6 +1,7 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+	getMyProjectGroup,
 	grantProjectGroupAdminPermission,
 	revokeProjectGroupAdminPermission,
 } from "@/lib/api/project-groups";
@@ -8,7 +9,16 @@ import type { ProjectGroupAdminPermissionRequest } from "@/lib/types/project-gro
 
 export const projectGroupQueryKeys = {
 	all: ["project-groups"] as const,
+	me: ["project-groups", "me"] as const,
 };
+
+export function useMyProjectGroupQuery(enabled = true) {
+	return useQuery({
+		enabled,
+		queryFn: () => getMyProjectGroup(),
+		queryKey: projectGroupQueryKeys.me,
+	});
+}
 
 export function useGrantProjectGroupAdminPermissionMutation() {
 	const queryClient = useQueryClient();

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -6,6 +6,7 @@ import {
 	Github,
 	GitPullRequest,
 	Home,
+	LoaderCircle,
 	MessageSquareText,
 	PencilLine,
 	Plus,
@@ -33,9 +34,12 @@ import {
 } from "@/components/app-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useMyProjectGroupQuery } from "@/features/project-groups/hooks/use-project-group-queries";
 import { demoTeamSpace } from "@/features/team/lib/demo-team-space";
 import { getAuthSession } from "@/lib/api/auth-session";
+import { getApiErrorMessage } from "@/lib/api/client";
 import { apiConfig } from "@/lib/api/config";
+import type { ProjectGroupMember } from "@/lib/types/project-group";
 import type {
 	ProjectLifecycleStatus,
 	TeamChecklistItem,
@@ -104,6 +108,8 @@ export function TeamSpaceView() {
 }
 
 function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
+	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
+
 	return (
 		<AppShell
 			actions={
@@ -122,63 +128,232 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 					</Button>
 				</>
 			}
-			description="팀 생성과 팀스페이스 조회 API가 연결되면 이 화면에서 내 팀 정보를 확인할 수 있습니다."
+			description="서버에 연결된 내 팀 스페이스 정보를 확인합니다."
 			eyebrow="Team workspace"
-			title="팀 스페이스"
+			title={projectGroupQuery.data?.projectName ?? "팀 스페이스"}
 		>
 			<div className="grid gap-5">
-				<AppPanel className="border-primary/20">
-					<AppPanelHeader
-						action={<Badge variant="neutral">준비 중</Badge>}
-						description="현재 서버에는 매칭 요청, 매칭 세션 조회, 수락/거절 흐름까지만 연결되어 있습니다."
-						eyebrow="Status"
-						title="팀 스페이스를 준비하고 있습니다"
+				{!isSignedIn ? (
+					<RealTeamNotice
+						action={
+							<Button asChild className="sm:w-fit">
+								<Link to="/login">로그인</Link>
+							</Button>
+						}
+						description="로그인 후 내 팀 스페이스를 불러올 수 있습니다."
+						status="인증 필요"
+						title="로그인이 필요합니다"
 					/>
-					<div className="grid gap-4 p-5">
-						<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
-							실제 팀 데이터를 불러오는 API가 아직 없어 샘플 팀 화면은 표시하지
-							않습니다. 매칭이 완료된 뒤 팀 조회 API가 연결되면 이곳에서 내 팀
-							공간을 열 수 있습니다.
-						</div>
-						<div className="flex flex-col gap-3 sm:flex-row">
+				) : null}
+
+				{isSignedIn && projectGroupQuery.isLoading ? (
+					<RealTeamNotice
+						description="내 팀 스페이스를 불러오고 있습니다."
+						icon={<LoaderCircle className="size-4 animate-spin" />}
+						status="조회 중"
+						title="팀 정보를 확인하는 중입니다"
+					/>
+				) : null}
+
+				{isSignedIn && projectGroupQuery.error ? (
+					<RealTeamNotice
+						action={
 							<Button asChild className="sm:w-fit">
 								<Link to="/match">
 									<ArrowRight data-icon="inline-start" />
 									매칭 상태 확인
 								</Link>
 							</Button>
-							{!isSignedIn ? (
-								<Button asChild className="sm:w-fit" variant="outline">
-									<Link to="/login">로그인</Link>
-								</Button>
-							) : null}
-						</div>
-					</div>
-				</AppPanel>
+						}
+						description={getApiErrorMessage(projectGroupQuery.error)}
+						status="팀 없음"
+						title="활성 팀 스페이스가 없습니다"
+					/>
+				) : null}
 
-				<div className="grid gap-4 md:grid-cols-3">
-					<MetricCard
-						label="현재 연결"
-						tone="primary"
-						trend="요청, 세션, 응답 API"
-						value="매칭"
-					/>
-					<MetricCard
-						label="팀 조회"
-						tone="amber"
-						trend="연결 준비 중"
-						value="대기"
-					/>
-					<MetricCard
-						label="팀 운영"
-						tone="amber"
-						trend="연결 준비 중"
-						value="대기"
-					/>
-				</div>
+				{projectGroupQuery.data ? (
+					<>
+						<AppPanel className="border-primary/20">
+							<AppPanelHeader
+								action={<Badge variant="neutral">ACTIVE</Badge>}
+								description={
+									projectGroupQuery.data.projectDescription ??
+									"프로젝트 설명이 아직 없습니다."
+								}
+								eyebrow="Project"
+								title={projectGroupQuery.data.projectTitle}
+							/>
+							<div className="grid gap-4 p-5">
+								<div className="rounded-lg border border-border bg-white p-4">
+									<p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+										MVP
+									</p>
+									<p className="mt-2 text-sm leading-6 text-brand-ink">
+										{projectGroupQuery.data.projectMvp ??
+											"프로젝트 MVP가 아직 없습니다."}
+									</p>
+								</div>
+								<div className="grid gap-3 md:grid-cols-2">
+									{projectGroupQuery.data.members.map((member) => (
+										<RealProjectGroupMemberCard
+											currentUserId={projectGroupQuery.data.currentUserId}
+											key={member.userId}
+											member={member}
+										/>
+									))}
+								</div>
+							</div>
+						</AppPanel>
+
+						<div className="grid gap-4 md:grid-cols-3">
+							<MetricCard
+								label="팀 멤버"
+								tone="primary"
+								trend="ACTIVE 팀"
+								value={String(projectGroupQuery.data.members.length)}
+							/>
+							<MetricCard
+								label="관리자"
+								tone="emerald"
+								trend="권한 관리 가능"
+								value={String(
+									projectGroupQuery.data.members.filter(
+										(member) => member.admin,
+									).length,
+								)}
+							/>
+							<MetricCard
+								label="내 권한"
+								tone="amber"
+								trend="팀 스페이스"
+								value={
+									projectGroupQuery.data.members.find(
+										(member) =>
+											member.userId === projectGroupQuery.data.currentUserId,
+									)?.groupRole ?? "MEMBER"
+								}
+							/>
+						</div>
+					</>
+				) : null}
+
+				{projectGroupQuery.data ? null : (
+					<div className="grid gap-4 md:grid-cols-3">
+						<MetricCard
+							label="현재 연결"
+							tone="primary"
+							trend="서버 API"
+							value="팀 조회"
+						/>
+						<MetricCard
+							label="매칭"
+							tone="amber"
+							trend="팀 결성 전"
+							value="확인"
+						/>
+						<MetricCard
+							label="팀 운영"
+							tone="amber"
+							trend="팀 생성 후"
+							value="대기"
+						/>
+					</div>
+				)}
 			</div>
 		</AppShell>
 	);
+}
+
+function RealTeamNotice({
+	action,
+	description,
+	icon,
+	status,
+	title,
+}: {
+	action?: ReactNode;
+	description: string;
+	icon?: ReactNode;
+	status: string;
+	title: string;
+}) {
+	return (
+		<AppPanel className="border-primary/20">
+			<AppPanelHeader
+				action={<Badge variant="neutral">{status}</Badge>}
+				description={description}
+				eyebrow="Status"
+				title={title}
+			/>
+			<div className="grid gap-4 p-5">
+				<div className="flex items-center gap-2 rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
+					{icon}
+					<span>{description}</span>
+				</div>
+				{action ? (
+					<div className="flex flex-col gap-3 sm:flex-row">{action}</div>
+				) : null}
+			</div>
+		</AppPanel>
+	);
+}
+
+function RealProjectGroupMemberCard({
+	currentUserId,
+	member,
+}: {
+	currentUserId: number;
+	member: ProjectGroupMember;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-4 rounded-lg border border-border bg-white p-4 shadow-crisp">
+			<div className="flex min-w-0 items-center gap-3">
+				<div className="grid size-11 shrink-0 place-items-center overflow-hidden rounded-full bg-secondary text-sm font-bold text-brand-ink">
+					{member.profileImage ? (
+						<img
+							alt=""
+							className="size-full object-cover"
+							src={member.profileImage}
+						/>
+					) : (
+						member.nickname.slice(0, 2).toUpperCase()
+					)}
+				</div>
+				<div className="min-w-0">
+					<div className="flex flex-wrap items-center gap-2">
+						<p className="truncate text-sm font-semibold text-brand-ink">
+							{member.nickname}
+						</p>
+						{member.userId === currentUserId ? (
+							<Badge variant="brand">ME</Badge>
+						) : null}
+					</div>
+					<p className="mt-1 text-xs text-muted-foreground">
+						{formatMemberRole(member.memberRole)} · Lv.{member.level} · 온도{" "}
+						{member.temperature}
+					</p>
+				</div>
+			</div>
+			<div className="flex shrink-0 flex-col items-end gap-2">
+				<Badge variant={member.groupRole === "HOST" ? "brand" : "neutral"}>
+					{member.groupRole}
+				</Badge>
+				<Badge variant={member.admin ? "warm" : "neutral"}>
+					{member.admin ? "ADMIN" : "MEMBER"}
+				</Badge>
+			</div>
+		</div>
+	);
+}
+
+function formatMemberRole(role: ProjectGroupMember["memberRole"]) {
+	const labels: Record<ProjectGroupMember["memberRole"], string> = {
+		BACKEND: "BE",
+		DESIGN: "Design",
+		FRONTEND: "FE",
+	};
+
+	return labels[role];
 }
 
 function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -305,15 +305,17 @@ function RealProjectGroupMemberCard({
 	currentUserId: number;
 	member: ProjectGroupMember;
 }) {
+	const profileImageSrc = getProjectGroupMemberImageSrc(member.profileImage);
+
 	return (
 		<div className="flex items-center justify-between gap-4 rounded-lg border border-border bg-white p-4 shadow-crisp">
 			<div className="flex min-w-0 items-center gap-3">
 				<div className="grid size-11 shrink-0 place-items-center overflow-hidden rounded-full bg-secondary text-sm font-bold text-brand-ink">
-					{member.profileImage ? (
+					{profileImageSrc ? (
 						<img
 							alt=""
 							className="size-full object-cover"
-							src={member.profileImage}
+							src={profileImageSrc}
 						/>
 					) : (
 						member.nickname.slice(0, 2).toUpperCase()
@@ -344,6 +346,14 @@ function RealProjectGroupMemberCard({
 			</div>
 		</div>
 	);
+}
+
+function getProjectGroupMemberImageSrc(profileImage: string | null) {
+	if (!profileImage?.startsWith("http")) {
+		return undefined;
+	}
+
+	return profileImage;
 }
 
 function formatMemberRole(role: ProjectGroupMember["memberRole"]) {

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -155,7 +155,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 					/>
 				) : null}
 
-				{isSignedIn && projectGroupQuery.error ? (
+				{isSignedIn && projectGroupQuery.error && !projectGroupQuery.data ? (
 					<RealTeamNotice
 						action={
 							<Button asChild className="sm:w-fit">

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -35,6 +35,7 @@ let activeMatchId: number | null = null;
 let activeMatchMembers: MatchMemberResponse["members"] = [];
 let activeMatchProject: MatchProjectResponse | null = null;
 let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
+let deleteEmailAuthSentUserId: number | null = null;
 let deleteEmailVerifiedUserId: number | null = null;
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
 
@@ -102,6 +103,11 @@ function base64UrlEncode(value: string) {
 
 function imageUrlFromKey(objectKey: string | undefined) {
 	return objectKey ? `https://images.teampo.dev/${objectKey}` : null;
+}
+
+function resetDeleteEmailState() {
+	deleteEmailAuthSentUserId = null;
+	deleteEmailVerifiedUserId = null;
 }
 
 function isValidMatchRole(value: string): value is MatchRole {
@@ -300,6 +306,7 @@ export const handlers = [
 				profileImage: "https://i.pravatar.cc/240?img=32",
 			});
 			currentUserId = 5;
+			resetDeleteEmailState();
 
 			return HttpResponse.json(buildSession());
 		}
@@ -322,6 +329,7 @@ export const handlers = [
 				profileImage: "https://i.pravatar.cc/240?img=47",
 			});
 			currentUserId = 6;
+			resetDeleteEmailState();
 
 			return HttpResponse.json(buildSession());
 		}
@@ -517,6 +525,7 @@ export const handlers = [
 			temperature: 50,
 		};
 		currentPassword = body.password;
+		resetDeleteEmailState();
 
 		return new HttpResponse(null, { status: 200 });
 	}),
@@ -636,6 +645,7 @@ export const handlers = [
 			);
 		}
 
+		deleteEmailAuthSentUserId = currentUserId;
 		deleteEmailVerifiedUserId = null;
 		return new HttpResponse(null, { status: 200 });
 	}),
@@ -655,7 +665,10 @@ export const handlers = [
 				);
 			}
 
-			if (body.authNumber !== 123456) {
+			if (
+				deleteEmailAuthSentUserId !== currentUserId ||
+				body.authNumber !== 123456
+			) {
 				return buildErrorResponse(
 					400,
 					"인증번호가 만료되었거나 올바르지 않습니다.",
@@ -663,6 +676,7 @@ export const handlers = [
 				);
 			}
 
+			deleteEmailAuthSentUserId = null;
 			deleteEmailVerifiedUserId = currentUserId;
 			return new HttpResponse(null, { status: 200 });
 		},
@@ -688,7 +702,7 @@ export const handlers = [
 		}
 
 		currentUser = null;
-		deleteEmailVerifiedUserId = null;
+		resetDeleteEmailState();
 		matchStatus = null;
 		activeMatchId = null;
 		activeMatchMembers = [];

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -35,7 +35,7 @@ let activeMatchId: number | null = null;
 let activeMatchMembers: MatchMemberResponse["members"] = [];
 let activeMatchProject: MatchProjectResponse | null = null;
 let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
-let isDeleteEmailVerified = false;
+let deleteEmailVerifiedUserId: number | null = null;
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
 
 function buildErrorResponse(
@@ -636,7 +636,7 @@ export const handlers = [
 			);
 		}
 
-		isDeleteEmailVerified = false;
+		deleteEmailVerifiedUserId = null;
 		return new HttpResponse(null, { status: 200 });
 	}),
 
@@ -663,7 +663,7 @@ export const handlers = [
 				);
 			}
 
-			isDeleteEmailVerified = true;
+			deleteEmailVerifiedUserId = currentUserId;
 			return new HttpResponse(null, { status: 200 });
 		},
 	),
@@ -679,7 +679,7 @@ export const handlers = [
 			);
 		}
 
-		if (!isDeleteEmailVerified) {
+		if (deleteEmailVerifiedUserId !== currentUserId) {
 			return buildErrorResponse(
 				400,
 				"이메일 인증이 필요합니다.",
@@ -688,7 +688,7 @@ export const handlers = [
 		}
 
 		currentUser = null;
-		isDeleteEmailVerified = false;
+		deleteEmailVerifiedUserId = null;
 		matchStatus = null;
 		activeMatchId = null;
 		activeMatchMembers = [];

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -20,8 +20,8 @@ import type {
 	MatchStatus,
 	ProjectRequestPayload,
 } from "@/lib/types/match";
+import type { MyProjectGroup } from "@/lib/types/project-group";
 import type {
-	DeleteCurrentUserRequest,
 	EditPasswordRequest,
 	UpdateCurrentUserRequest,
 	UserProfile,
@@ -34,6 +34,8 @@ let matchStatus: MatchStatus | null = null;
 let activeMatchId: number | null = null;
 let activeMatchMembers: MatchMemberResponse["members"] = [];
 let activeMatchProject: MatchProjectResponse | null = null;
+let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
+let isDeleteEmailVerified = false;
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
 
 function buildErrorResponse(
@@ -178,6 +180,60 @@ function createMockMatchSession(body: ProjectRequestPayload) {
 			userId: 4,
 		},
 	];
+}
+
+function createMockProjectGroup(): MyProjectGroup {
+	return {
+		currentUserId,
+		members: [
+			{
+				admin: true,
+				groupRole: "HOST",
+				level: currentUser?.level ?? 3,
+				memberRole: "FRONTEND",
+				nickname: currentUser?.nickname ?? "preview",
+				profileImage: currentUser?.profileImage ?? null,
+				temperature: currentUser?.temperature ?? 50,
+				userId: currentUserId,
+			},
+			{
+				admin: false,
+				groupRole: "MEMBER",
+				level: 4,
+				memberRole: "BACKEND",
+				nickname: "api_builder",
+				profileImage: null,
+				temperature: 53,
+				userId: 2,
+			},
+			{
+				admin: false,
+				groupRole: "MEMBER",
+				level: 3,
+				memberRole: "FRONTEND",
+				nickname: "pixel_runner",
+				profileImage: null,
+				temperature: 49,
+				userId: 3,
+			},
+			{
+				admin: false,
+				groupRole: "MEMBER",
+				level: 2,
+				memberRole: "DESIGN",
+				nickname: "flow_designer",
+				profileImage: null,
+				temperature: 51,
+				userId: 4,
+			},
+		],
+		projectDescription:
+			"랜덤 팀 매칭 이후 팀이 바로 움직일 수 있도록 규칙과 체크리스트를 정리합니다.",
+		projectGroupId: 10,
+		projectMvp: "매칭 요청, 수락/거절, 팀 스페이스 홈, 첫 체크리스트 운영",
+		projectName: "Blue Sprint",
+		projectTitle: "Team-po 팀 운영 MVP",
+	};
 }
 
 export const handlers = [
@@ -569,24 +625,75 @@ export const handlers = [
 		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.delete(getPath("/users/me"), async ({ request }) => {
-		const body = (await request.json()) as DeleteCurrentUserRequest;
-
+	http.post(getPath("/users/me/deletion-email"), async () => {
 		await delay(350);
 
-		if (body.password !== currentPassword) {
+		if (!currentUser) {
 			return buildErrorResponse(
 				401,
-				"현재 비밀번호가 일치하지 않습니다.",
-				"UNMATCHED_PASSWORD",
+				"로그인이 필요합니다.",
+				"NO_AUTHENTICATED_USER",
+			);
+		}
+
+		isDeleteEmailVerified = false;
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.post(
+		getPath("/users/me/deletion-number-validation"),
+		async ({ request }) => {
+			const body = (await request.json()) as { authNumber: number };
+
+			await delay(250);
+
+			if (!currentUser) {
+				return buildErrorResponse(
+					401,
+					"로그인이 필요합니다.",
+					"NO_AUTHENTICATED_USER",
+				);
+			}
+
+			if (body.authNumber !== 123456) {
+				return buildErrorResponse(
+					400,
+					"인증번호가 만료되었거나 올바르지 않습니다.",
+					"INVALID_EMAIL_AUTH_CODE",
+				);
+			}
+
+			isDeleteEmailVerified = true;
+			return new HttpResponse(null, { status: 200 });
+		},
+	),
+
+	http.delete(getPath("/users/me"), async () => {
+		await delay(350);
+
+		if (!currentUser) {
+			return buildErrorResponse(
+				401,
+				"로그인이 필요합니다.",
+				"NO_AUTHENTICATED_USER",
+			);
+		}
+
+		if (!isDeleteEmailVerified) {
+			return buildErrorResponse(
+				400,
+				"이메일 인증이 필요합니다.",
+				"EMAIL_NOT_VERIFIED",
 			);
 		}
 
 		currentUser = null;
+		isDeleteEmailVerified = false;
 		matchStatus = null;
 		activeMatchId = null;
 		activeMatchMembers = [];
 		activeMatchProject = null;
+		activeProjectGroup = null;
 
 		return new HttpResponse(null, { status: 200 });
 	}),
@@ -789,6 +896,28 @@ export const handlers = [
 		return new HttpResponse(null, { status: 200 });
 	}),
 
+	http.get(getPath("/project-groups/me"), async () => {
+		await delay(250);
+
+		if (!currentUser) {
+			return buildErrorResponse(
+				401,
+				"로그인이 필요합니다.",
+				"NO_AUTHENTICATED_USER",
+			);
+		}
+
+		if (!activeProjectGroup) {
+			return buildErrorResponse(
+				404,
+				"소속된 팀 스페이스를 찾을 수 없습니다.",
+				"PROJECT_GROUP_NOT_FOUND",
+			);
+		}
+
+		return HttpResponse.json(activeProjectGroup);
+	}),
+
 	http.patch(
 		getPath("/project-groups/:projectGroupId/admins/:targetUserId"),
 		({ params }) => {
@@ -808,6 +937,19 @@ export const handlers = [
 				);
 			}
 
+			const targetMember = activeProjectGroup?.members.find(
+				(member) => member.userId === Number(params.targetUserId),
+			);
+
+			if (!activeProjectGroup || !targetMember) {
+				return buildErrorResponse(
+					404,
+					"권한을 변경할 팀 멤버를 찾을 수 없습니다.",
+					"PROJECT_GROUP_MEMBER_NOT_FOUND",
+				);
+			}
+
+			targetMember.admin = true;
 			return new HttpResponse(null, { status: 200 });
 		},
 	),
@@ -831,6 +973,27 @@ export const handlers = [
 				);
 			}
 
+			const targetMember = activeProjectGroup?.members.find(
+				(member) => member.userId === Number(params.targetUserId),
+			);
+
+			if (!activeProjectGroup || !targetMember) {
+				return buildErrorResponse(
+					404,
+					"권한을 변경할 팀 멤버를 찾을 수 없습니다.",
+					"PROJECT_GROUP_MEMBER_NOT_FOUND",
+				);
+			}
+
+			if (targetMember.groupRole === "HOST") {
+				return buildErrorResponse(
+					403,
+					"방장의 관리자 권한은 회수할 수 없습니다.",
+					"PROJECT_GROUP_PERMISSION_DENIED",
+				);
+			}
+
+			targetMember.admin = false;
 			return new HttpResponse(null, { status: 200 });
 		},
 	),

--- a/src/lib/api/project-groups.ts
+++ b/src/lib/api/project-groups.ts
@@ -1,5 +1,12 @@
 import { apiRequest } from "@/lib/api/client";
-import type { ProjectGroupAdminPermissionRequest } from "@/lib/types/project-group";
+import type {
+	MyProjectGroup,
+	ProjectGroupAdminPermissionRequest,
+} from "@/lib/types/project-group";
+
+export function getMyProjectGroup() {
+	return apiRequest<MyProjectGroup>("/project-groups/me");
+}
 
 export function grantProjectGroupAdminPermission({
 	projectGroupId,

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -5,10 +5,10 @@ import type {
 	SignUpRequest,
 } from "@/lib/types/auth";
 import type {
-	DeleteCurrentUserRequest,
 	EditPasswordRequest,
 	UpdateCurrentUserRequest,
 	UserProfile,
+	ValidateDeleteUserEmailRequest,
 } from "@/lib/types/user";
 
 export async function createUser(payload: CreateUserRequest) {
@@ -56,9 +56,23 @@ export function editPassword(payload: EditPasswordRequest) {
 	});
 }
 
-export function deleteCurrentUser(payload: DeleteCurrentUserRequest) {
-	return apiRequest<void>("/users/me", {
+export function sendDeleteUserEmail() {
+	return apiRequest<void>("/users/me/deletion-email", {
+		method: "POST",
+	});
+}
+
+export function validateDeleteUserEmail(
+	payload: ValidateDeleteUserEmailRequest,
+) {
+	return apiRequest<void>("/users/me/deletion-number-validation", {
 		json: payload,
+		method: "POST",
+	});
+}
+
+export function deleteCurrentUser() {
+	return apiRequest<void>("/users/me", {
 		method: "DELETE",
 	});
 }

--- a/src/lib/types/project-group.ts
+++ b/src/lib/types/project-group.ts
@@ -7,3 +7,24 @@ export interface ProjectGroupAdminPermissionRequest {
 	projectGroupId: number;
 	targetUserId: number;
 }
+
+export interface ProjectGroupMember {
+	admin: boolean;
+	groupRole: ProjectGroupRole;
+	level: number;
+	memberRole: ProjectGroupMemberRole;
+	nickname: string;
+	profileImage: string | null;
+	temperature: number;
+	userId: number;
+}
+
+export interface MyProjectGroup {
+	currentUserId: number;
+	members: ProjectGroupMember[];
+	projectDescription: string | null;
+	projectGroupId: number;
+	projectMvp: string | null;
+	projectName: string;
+	projectTitle: string;
+}

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -19,6 +19,6 @@ export interface EditPasswordRequest {
 	currentPassword: string;
 }
 
-export interface DeleteCurrentUserRequest {
-	password: string;
+export interface ValidateDeleteUserEmailRequest {
+	authNumber: number;
 }


### PR DESCRIPTION
<!-- codex-server-api-sync-to-client -->
## Summary
- mirror the latest Server account deletion flow with deletion email send, code validation, and bodyless user deletion
- add the current project group API contract, request wrapper, query hook, real-mode team-space rendering, and MSW handler
- update Client OpenAPI to match the latest Server controller surface

## Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build (passes; Vite warns that Node 20.15.0 is below the recommended 20.19+)

Closes #47
