### PR TITLE
feat(auth): sync Server GitHub account link API

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -143,6 +143,40 @@ paths:
                 $ref: '#/components/schemas/SignInResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /oauth/github/link-requests:
+    post:
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      summary: Start GitHub account linking for the current user
+      responses:
+        '200':
+          description: GitHub OAuth authorization URL issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GithubLinkStartResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /oauth/github/account:
+    delete:
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      summary: Unlink the current user's GitHub account
+      responses:
+        '204':
+          description: GitHub account unlinked
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
   /users/refresh-token:
@@ -587,6 +621,13 @@ components:
           type: integer
           minimum: 1
           maximum: 5
+    GithubLinkStartResponse:
+      type: object
+      additionalProperties: false
+      required: [authorizationUrl]
+      properties:
+        authorizationUrl:
+          type: string
     RefreshTokenRequest:
       type: object
       additionalProperties: false
@@ -607,7 +648,7 @@ components:
     UserProfile:
       type: object
       additionalProperties: false
-      required: [email, profileImage, description, nickname, temperature, level]
+      required: [email, profileImage, description, nickname, temperature, level, isGithubLogin, isGithubLinked, githubUsername]
       properties:
         email:
           type: string
@@ -628,6 +669,14 @@ components:
           type: integer
           minimum: 1
           maximum: 5
+        isGithubLogin:
+          type: boolean
+        isGithubLinked:
+          type: boolean
+        githubUsername:
+          type:
+            - string
+            - 'null'
     EditProfileRequest:
       type: object
       additionalProperties: false

--- a/src/features/auth/components/github-oauth-callback-view.tsx
+++ b/src/features/auth/components/github-oauth-callback-view.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ArrowRight, Github, LoaderCircle, RefreshCcw } from "lucide-react";
+import {
+	ArrowRight,
+	CircleCheck,
+	Github,
+	LoaderCircle,
+	RefreshCcw,
+	ShieldAlert,
+} from "lucide-react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -21,6 +28,14 @@ export function GithubOAuthCallbackView() {
 	const [searchParams] = useSearchParams();
 	const code = searchParams.get("code")?.trim() ?? "";
 	const onboardingRequired = searchParams.get("onboardingRequired") === "true";
+	const githubLinkedParam = searchParams.get("githubLinked");
+	const githubLinkResult =
+		githubLinkedParam === null
+			? null
+			: {
+					errorCode: searchParams.get("error"),
+					linked: githubLinkedParam === "true",
+				};
 	const [level, setLevel] = useState(3);
 	const [touchedLevel, setTouchedLevel] = useState(false);
 	const {
@@ -29,7 +44,7 @@ export function GithubOAuthCallbackView() {
 		mutateAsync: exchangeGithubOAuthCode,
 	} = useGithubOAuthTokenMutation();
 	const hasStartedExchangeRef = useRef(false);
-	const isCallbackInvalid = !code;
+	const isCallbackInvalid = !code && !githubLinkResult;
 	const levelError =
 		Number.isInteger(level) && level >= 1 && level <= 5
 			? undefined
@@ -49,6 +64,7 @@ export function GithubOAuthCallbackView() {
 	useEffect(() => {
 		if (
 			isCallbackInvalid ||
+			githubLinkResult ||
 			onboardingRequired ||
 			hasStartedExchangeRef.current
 		) {
@@ -60,7 +76,12 @@ export function GithubOAuthCallbackView() {
 		void exchangeGithubCode().catch(() => {
 			hasStartedExchangeRef.current = false;
 		});
-	}, [exchangeGithubCode, isCallbackInvalid, onboardingRequired]);
+	}, [
+		exchangeGithubCode,
+		githubLinkResult,
+		isCallbackInvalid,
+		onboardingRequired,
+	]);
 
 	async function handleOnboardingSubmit(
 		event: React.FormEvent<HTMLFormElement>,
@@ -79,13 +100,51 @@ export function GithubOAuthCallbackView() {
 		<AuthShell
 			badge="GitHub Login"
 			description={
-				onboardingRequired
-					? "GitHub 계정으로 팀 매칭에 합류하기 전에 현재 개발 레벨만 선택해 주세요."
-					: "GitHub 인증 결과를 확인하고 Team-po 세션을 준비하고 있습니다."
+				githubLinkResult
+					? githubLinkResult.linked
+						? "GitHub 계정 연동이 완료되었습니다."
+						: "GitHub 계정 연동을 완료하지 못했습니다."
+					: onboardingRequired
+						? "GitHub 계정으로 팀 매칭에 합류하기 전에 현재 개발 레벨만 선택해 주세요."
+						: "GitHub 인증 결과를 확인하고 Team-po 세션을 준비하고 있습니다."
 			}
-			title={onboardingRequired ? "거의 다 왔어요" : "GitHub 로그인 중"}
+			title={
+				githubLinkResult
+					? githubLinkResult.linked
+						? "GitHub 연동 완료"
+						: "GitHub 연동 실패"
+					: onboardingRequired
+						? "거의 다 왔어요"
+						: "GitHub 로그인 중"
+			}
 		>
-			{isCallbackInvalid ? (
+			{githubLinkResult ? (
+				<div className="flex flex-col gap-5">
+					<div className="flex items-center gap-3 rounded-xl border border-border/70 bg-secondary/35 p-4">
+						{githubLinkResult.linked ? (
+							<CircleCheck
+								className="size-5 text-emerald-600"
+								aria-hidden="true"
+							/>
+						) : (
+							<ShieldAlert
+								className="size-5 text-rose-600"
+								aria-hidden="true"
+							/>
+						)}
+						<p className="text-sm text-muted-foreground">
+							{githubLinkResult.linked
+								? "프로필에서 연결된 GitHub 계정을 확인할 수 있습니다."
+								: getGithubLinkErrorMessage(githubLinkResult.errorCode)}
+						</p>
+					</div>
+					<Button asChild size="lg">
+						<Link to="/me">
+							<ArrowRight data-icon="inline-start" />내 정보로 이동
+						</Link>
+					</Button>
+				</div>
+			) : isCallbackInvalid ? (
 				<div className="flex flex-col gap-5">
 					<FieldError>
 						GitHub 인증 정보가 없습니다. 로그인 화면에서 다시 시작해 주세요.
@@ -197,4 +256,17 @@ export function GithubOAuthCallbackView() {
 			)}
 		</AuthShell>
 	);
+}
+
+function getGithubLinkErrorMessage(errorCode: string | null) {
+	switch (errorCode) {
+		case "GITHUB_ACCOUNT_ALREADY_LINKED":
+			return "이미 GitHub 계정이 연동되어 있습니다.";
+		case "GITHUB_ACCOUNT_LINKED_TO_ANOTHER_USER":
+			return "이미 다른 사용자에게 연동된 GitHub 계정입니다.";
+		case "INVALID_GITHUB_OAUTH_LINK_STATE":
+			return "GitHub 계정 연동 요청이 만료되었거나 올바르지 않습니다.";
+		default:
+			return "GitHub 계정 연동 결과를 확인할 수 없습니다.";
+	}
 }

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -1,11 +1,13 @@
 import {
 	ArrowRight,
 	Camera,
+	Github,
 	KeyRound,
 	LoaderCircle,
 	RefreshCcw,
 	ShieldAlert,
 	Trash2,
+	Unlink,
 	UsersRound,
 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -35,6 +37,8 @@ import {
 	useDeleteCurrentUserMutation,
 	useEditPasswordMutation,
 	useSendDeleteUserEmailMutation,
+	useStartGithubAccountLinkMutation,
+	useUnlinkGithubAccountMutation,
 	useUpdateCurrentUserMutation,
 	useValidateDeleteUserEmailMutation,
 } from "@/features/auth/hooks/use-auth-queries";
@@ -47,6 +51,7 @@ import { demoTeamSpace } from "@/features/team/lib/demo-team-space";
 import { getAuthSession } from "@/lib/api/auth-session";
 import { getApiErrorMessage } from "@/lib/api/client";
 import { apiConfig } from "@/lib/api/config";
+import type { UserProfile } from "@/lib/types/user";
 import { cn } from "@/lib/utils";
 
 const levelOptions = [1, 2, 3, 4, 5] as const;
@@ -58,6 +63,8 @@ export function ProfileView() {
 	const currentUserQuery = useCurrentUserQuery();
 	const updateCurrentUserMutation = useUpdateCurrentUserMutation();
 	const editPasswordMutation = useEditPasswordMutation();
+	const startGithubAccountLinkMutation = useStartGithubAccountLinkMutation();
+	const unlinkGithubAccountMutation = useUnlinkGithubAccountMutation();
 	const sendDeleteUserEmailMutation = useSendDeleteUserEmailMutation();
 	const validateDeleteUserEmailMutation = useValidateDeleteUserEmailMutation();
 	const deleteCurrentUserMutation = useDeleteCurrentUserMutation();
@@ -188,6 +195,28 @@ export function ProfileView() {
 
 		await editPasswordMutation.mutateAsync(passwordForm);
 		navigate("/login", { replace: true });
+	}
+
+	async function handleGithubLinkStart() {
+		try {
+			const response = await startGithubAccountLinkMutation.mutateAsync();
+			if (apiConfig.useMocks && response.authorizationUrl.startsWith("/")) {
+				navigate(response.authorizationUrl);
+				return;
+			}
+
+			window.location.assign(response.authorizationUrl);
+		} catch {
+			// The mutation error state renders the inline error message.
+		}
+	}
+
+	async function handleGithubUnlink() {
+		try {
+			await unlinkGithubAccountMutation.mutateAsync();
+		} catch {
+			// The mutation error state renders the inline error message.
+		}
 	}
 
 	async function handleDeleteEmailSend() {
@@ -408,6 +437,15 @@ export function ProfileView() {
 									onSubmit={handlePasswordSubmit}
 									passwordForm={passwordForm}
 									setPasswordForm={setPasswordForm}
+								/>
+								<AccountLinksPanel
+									currentUser={currentUser}
+									onStartGithubLink={handleGithubLinkStart}
+									onUnlinkGithub={handleGithubUnlink}
+									startGithubAccountLinkMutation={
+										startGithubAccountLinkMutation
+									}
+									unlinkGithubAccountMutation={unlinkGithubAccountMutation}
 								/>
 								<DangerPanel
 									deleteConfirmError={visibleDeleteConfirmError}
@@ -784,6 +822,115 @@ function SecurityPanel({
 					비밀번호 변경
 				</Button>
 			</form>
+		</AppPanel>
+	);
+}
+
+function AccountLinksPanel({
+	currentUser,
+	onStartGithubLink,
+	onUnlinkGithub,
+	startGithubAccountLinkMutation,
+	unlinkGithubAccountMutation,
+}: {
+	currentUser: UserProfile;
+	onStartGithubLink: () => void;
+	onUnlinkGithub: () => void;
+	startGithubAccountLinkMutation: ReturnType<
+		typeof useStartGithubAccountLinkMutation
+	>;
+	unlinkGithubAccountMutation: ReturnType<
+		typeof useUnlinkGithubAccountMutation
+	>;
+}) {
+	const isBusy =
+		startGithubAccountLinkMutation.isPending ||
+		unlinkGithubAccountMutation.isPending;
+	const linkError =
+		startGithubAccountLinkMutation.error ?? unlinkGithubAccountMutation.error;
+
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				description="팀 협업에 사용할 GitHub 계정 연결 상태입니다."
+				eyebrow="Connected accounts"
+				title="GitHub 연동"
+			/>
+			<div className="grid gap-4 p-5">
+				<div className="flex flex-col gap-4 rounded-lg border border-border/70 bg-brand-warm p-4 sm:flex-row sm:items-center sm:justify-between">
+					<div className="flex min-w-0 items-center gap-3">
+						<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-zinc-950 text-white">
+							<Github className="size-5" aria-hidden="true" />
+						</div>
+						<div className="min-w-0">
+							<div className="flex flex-wrap items-center gap-2">
+								<p className="font-semibold text-brand-ink">GitHub</p>
+								<Badge
+									variant={currentUser.isGithubLinked ? "brand" : "neutral"}
+								>
+									{currentUser.isGithubLinked ? "연동됨" : "미연동"}
+								</Badge>
+							</div>
+							<p className="mt-1 truncate text-sm text-muted-foreground">
+								{currentUser.githubUsername
+									? `@${currentUser.githubUsername}`
+									: "연결된 GitHub 계정이 없습니다."}
+							</p>
+						</div>
+					</div>
+
+					{currentUser.isGithubLinked ? (
+						<Button
+							disabled={isBusy || currentUser.isGithubLogin}
+							onClick={() => void onUnlinkGithub()}
+							type="button"
+							variant="outline"
+						>
+							{unlinkGithubAccountMutation.isPending ? (
+								<LoaderCircle
+									className="animate-spin"
+									data-icon="inline-start"
+								/>
+							) : (
+								<Unlink data-icon="inline-start" />
+							)}
+							연동 해제
+						</Button>
+					) : (
+						<Button
+							disabled={isBusy}
+							onClick={() => void onStartGithubLink()}
+							type="button"
+						>
+							{startGithubAccountLinkMutation.isPending ? (
+								<LoaderCircle
+									className="animate-spin"
+									data-icon="inline-start"
+								/>
+							) : (
+								<Github data-icon="inline-start" />
+							)}
+							GitHub 연동
+						</Button>
+					)}
+				</div>
+
+				{currentUser.isGithubLogin ? (
+					<p className="text-sm leading-6 text-muted-foreground">
+						GitHub 로그인 계정은 GitHub 연동을 해제할 수 없습니다.
+					</p>
+				) : null}
+
+				{linkError ? (
+					<FieldError>{getApiErrorMessage(linkError)}</FieldError>
+				) : null}
+
+				{unlinkGithubAccountMutation.isSuccess ? (
+					<p className="text-sm font-medium text-emerald-700">
+						GitHub 연동을 해제했습니다.
+					</p>
+				) : null}
+			</div>
 		</AppPanel>
 	);
 }

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -4,6 +4,8 @@ import {
 	exchangeGithubOAuthCode,
 	login,
 	sendSignupEmail,
+	startGithubAccountLink,
+	unlinkGithubAccount,
 	validateSignupAuthNumber,
 } from "@/lib/api/auth";
 import {
@@ -67,6 +69,34 @@ export function useGithubOAuthTokenMutation() {
 			exchangeGithubOAuthCode(payload),
 		onSuccess: (response) => {
 			setAuthSession(response);
+			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
+		},
+	});
+}
+
+export function useStartGithubAccountLinkMutation() {
+	return useMutation({
+		mutationFn: () => startGithubAccountLink(),
+	});
+}
+
+export function useUnlinkGithubAccountMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => unlinkGithubAccount(),
+		onSuccess: () => {
+			queryClient.setQueryData<UserProfile | undefined>(
+				authQueryKeys.currentUser,
+				(current) =>
+					current
+						? {
+								...current,
+								githubUsername: null,
+								isGithubLinked: false,
+							}
+						: current,
+			);
 			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
 		},
 	});

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -1,7 +1,9 @@
 import {
 	ArrowRight,
 	BookOpenText,
+	Building2,
 	CheckCircle2,
+	ExternalLink,
 	GitBranch,
 	Github,
 	GitPullRequest,
@@ -12,6 +14,8 @@ import {
 	Plus,
 	Save,
 	SendHorizontal,
+	Settings2,
+	ShieldCheck,
 	Sparkles,
 	Trash2,
 } from "lucide-react";
@@ -41,6 +45,7 @@ import { getApiErrorMessage } from "@/lib/api/client";
 import { apiConfig } from "@/lib/api/config";
 import type { ProjectGroupMember } from "@/lib/types/project-group";
 import type {
+	GithubRepositorySummary,
 	ProjectLifecycleStatus,
 	TeamChecklistItem,
 	TeamMessage,
@@ -1042,112 +1047,342 @@ function ChecklistPanel({
 }
 
 function GithubPanel() {
-	const [repoUrl, setRepoUrl] = useState("");
-	const [oauthStatus, setOauthStatus] = useState(
-		demoTeamSpace.githubSummary.oauthStatus,
+	const initialSelectedRepoIds =
+		demoTeamSpace.githubSummary.connectedRepos.length > 0
+			? demoTeamSpace.githubSummary.connectedRepos.map((repo) => repo.id)
+			: [];
+	const [organization, setOrganization] = useState(
+		demoTeamSpace.githubSummary.organization,
 	);
-	const [connectedRepo, setConnectedRepo] = useState(
-		demoTeamSpace.githubSummary.connectedRepo,
+	const [installationStatus, setInstallationStatus] = useState(
+		demoTeamSpace.githubSummary.appInstallation.status,
 	);
+	const [projectGroupGithubLinked, setProjectGroupGithubLinked] = useState(
+		demoTeamSpace.githubSummary.projectGroupGithubLinked,
+	);
+	const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>(
+		initialSelectedRepoIds,
+	);
+	const [connectedRepos, setConnectedRepos] = useState(
+		demoTeamSpace.githubSummary.connectedRepos,
+	);
+	const selectedRepositories = useMemo(
+		() =>
+			demoTeamSpace.githubSummary.availableRepositories.filter((repo) =>
+				selectedRepoIds.includes(repo.id),
+			),
+		[selectedRepoIds],
+	);
+	const isGitHubAppInstalled = installationStatus === "installed";
+	const canSelectRepositories = Boolean(organization && isGitHubAppInstalled);
+	const canSaveRepositoryConnection =
+		canSelectRepositories && selectedRepoIds.length > 0;
+	const setupStatusItems = [
+		{
+			description: organization?.login ?? "Organization 필요",
+			icon: Building2,
+			label: "Organization",
+			ready: Boolean(organization),
+		},
+		{
+			description: isGitHubAppInstalled ? "TeamPo App 설치됨" : "설치 전",
+			icon: Github,
+			label: "GitHub App",
+			ready: isGitHubAppInstalled,
+		},
+		{
+			description:
+				connectedRepos.length > 0
+					? `${connectedRepos.length}개 저장소`
+					: "저장소 선택 전",
+			icon: GitBranch,
+			label: "Repository",
+			ready: connectedRepos.length > 0,
+		},
+		{
+			description: projectGroupGithubLinked ? "기여도 집계 가능" : "연동 전",
+			icon: ShieldCheck,
+			label: "TeamSpace",
+			ready: projectGroupGithubLinked,
+		},
+	];
 
-	function handleConnect(event: FormEvent<HTMLFormElement>) {
-		event.preventDefault();
+	function handleInstallationComplete() {
+		setOrganization({
+			login: "team-po-labs",
+			name: "TeamPo Labs",
+			url: "https://github.com/team-po-labs",
+		});
+		setInstallationStatus("installed");
+		setConnectedRepos([]);
+		setProjectGroupGithubLinked(false);
+		setSelectedRepoIds((current) =>
+			current.length > 0
+				? current
+				: [demoTeamSpace.githubSummary.availableRepositories[0]?.id].filter(
+						Boolean,
+					),
+		);
+	}
 
-		if (!repoUrl.trim()) {
+	function handleRepositoryToggle(repoId: string) {
+		setSelectedRepoIds((current) =>
+			current.includes(repoId)
+				? current.filter((id) => id !== repoId)
+				: [...current, repoId],
+		);
+	}
+
+	function handleSaveRepositoryConnection() {
+		if (!canSaveRepositoryConnection) {
 			return;
 		}
 
-		setConnectedRepo(parseGithubRepo(repoUrl.trim()));
+		setConnectedRepos(selectedRepositories);
+		setProjectGroupGithubLinked(true);
 	}
 
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="방장이 GitHub 계정을 연결하면 저장소 활동과 팀원별 기여 흐름을 확인할 수 있습니다."
-				eyebrow="Repository"
-				title="GitHub 운영 요약"
+				description="팀 관리자가 Organization에 TeamPo GitHub App을 설치하고 저장소를 선택하면 기여도 집계가 시작됩니다."
+				eyebrow="GitHub App"
+				title="Organization 연동"
 			/>
 			<div className="grid gap-5 p-5">
-				<div className="grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+				<div className="grid gap-3 md:grid-cols-4">
+					{setupStatusItems.map((item) => {
+						const Icon = item.icon;
+
+						return (
+							<div
+								className={cn(
+									"rounded-lg border p-4 shadow-crisp",
+									item.ready
+										? "border-primary/20 bg-primary/5"
+										: "border-border/70 bg-white",
+								)}
+								key={item.label}
+							>
+								<div className="flex items-center justify-between gap-3">
+									<Icon
+										className={cn(
+											"size-4",
+											item.ready ? "text-primary" : "text-muted-foreground",
+										)}
+										aria-hidden="true"
+									/>
+									<Badge variant={item.ready ? "brand" : "neutral"}>
+										{item.ready ? "ready" : "pending"}
+									</Badge>
+								</div>
+								<p className="mt-3 text-sm font-semibold text-brand-ink">
+									{item.label}
+								</p>
+								<p className="mt-1 text-xs leading-5 text-muted-foreground">
+									{item.description}
+								</p>
+							</div>
+						);
+					})}
+				</div>
+
+				<div className="grid gap-4 2xl:grid-cols-[0.85fr_1.15fr]">
 					<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
 						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 							<div>
 								<p className="text-sm font-semibold text-brand-ink">
-									GitHub 연결 상태
+									Organization 준비
 								</p>
 								<p className="mt-1 text-sm leading-6 text-muted-foreground">
-									현재는 프리뷰 상태입니다. 연결 후 팀 활동 요약이 이곳에
-									표시됩니다.
+									TeamSpace에 연결할 GitHub Organization이 필요합니다.
 								</p>
 							</div>
-							<Badge
-								variant={oauthStatus === "connected" ? "brand" : "neutral"}
-							>
-								{oauthStatus === "connected" ? "connected" : "preview"}
+							<Badge variant={organization ? "brand" : "neutral"}>
+								{organization ? "found" : "required"}
 							</Badge>
 						</div>
-						<Button
-							className="mt-4 w-full sm:w-auto"
-							onClick={() => setOauthStatus("connected")}
-							type="button"
-							variant={oauthStatus === "connected" ? "outline" : "default"}
-						>
-							<Github data-icon="inline-start" />
-							{oauthStatus === "connected"
-								? "GitHub 로그인 완료"
-								: "GitHub로 로그인"}
-						</Button>
-					</div>
-					<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
-						<p className="text-sm font-semibold text-brand-ink">
-							연결된 저장소
-						</p>
-						{connectedRepo ? (
-							<div className="mt-3 flex flex-col gap-2 rounded-lg border border-primary/15 bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between">
-								<div className="min-w-0">
-									<p className="truncate font-mono text-sm font-semibold text-primary">
-										{connectedRepo.owner}/{connectedRepo.name}
-									</p>
-									<p className="mt-1 text-xs text-muted-foreground">
-										{connectedRepo.visibility} · {connectedRepo.defaultBranch} ·{" "}
-										{connectedRepo.syncedAtLabel}
-									</p>
-								</div>
-								<GitBranch className="size-5 shrink-0 text-primary" />
+						{organization ? (
+							<div className="mt-4 rounded-lg border border-primary/15 bg-white p-4">
+								<p className="font-mono text-sm font-semibold text-primary">
+									{organization.login}
+								</p>
+								<p className="mt-1 text-xs text-muted-foreground">
+									{organization.name}
+								</p>
 							</div>
 						) : (
-							<p className="mt-3 text-sm leading-6 text-muted-foreground">
-								아직 저장소가 연결되지 않았습니다. 저장소를 입력하면 요약 화면을
-								미리 확인할 수 있습니다.
+							<div className="mt-4 flex flex-col gap-3 sm:flex-row">
+								<Button asChild variant="outline">
+									<a
+										href="https://github.com/account/organizations/new"
+										rel="noreferrer"
+										target="_blank"
+									>
+										<Building2 data-icon="inline-start" />
+										Organization 생성
+										<ExternalLink data-icon="inline-end" />
+									</a>
+								</Button>
+								<Button onClick={handleInstallationComplete} type="button">
+									<Github data-icon="inline-start" />
+									GitHub Organization 연결하기
+								</Button>
+							</div>
+						)}
+					</div>
+
+					<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+							<div>
+								<p className="text-sm font-semibold text-brand-ink">
+									TeamPo GitHub App
+								</p>
+								<p className="mt-1 text-sm leading-6 text-muted-foreground">
+									읽기 전용 권한으로 설치하고 필요한 저장소만 선택합니다.
+								</p>
+							</div>
+							<Badge variant={isGitHubAppInstalled ? "brand" : "neutral"}>
+								{isGitHubAppInstalled ? "installed" : "not installed"}
+							</Badge>
+						</div>
+						<div className="mt-4 grid gap-3 md:grid-cols-[1fr_auto]">
+							<div className="grid gap-2">
+								<div className="flex flex-wrap gap-2">
+									<Badge variant="warm">Only select repositories</Badge>
+									<Badge variant="neutral">read-only</Badge>
+									<Badge variant="neutral">installation_id + state</Badge>
+								</div>
+								<div className="flex flex-wrap gap-2">
+									{demoTeamSpace.githubSummary.appInstallation.permissions.map(
+										(permission) => (
+											<span
+												className="rounded-md border border-border/70 bg-secondary/35 px-2 py-1 font-mono text-[11px] text-muted-foreground"
+												key={permission}
+											>
+												{permission}
+											</span>
+										),
+									)}
+								</div>
+							</div>
+							<div className="flex flex-col gap-2 md:items-end">
+								<Button asChild variant="outline">
+									<a
+										href={demoTeamSpace.githubSummary.appInstallation.setupUrl}
+										rel="noreferrer"
+										target="_blank"
+									>
+										<Settings2 data-icon="inline-start" />
+										설치 화면 열기
+										<ExternalLink data-icon="inline-end" />
+									</a>
+								</Button>
+								{!isGitHubAppInstalled ? (
+									<Button onClick={handleInstallationComplete} type="button">
+										<ShieldCheck data-icon="inline-start" />
+										설치 완료
+									</Button>
+								) : null}
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div className="grid gap-4 2xl:grid-cols-[1.05fr_0.95fr]">
+					<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+							<div>
+								<p className="text-sm font-semibold text-brand-ink">
+									저장소 선택
+								</p>
+								<p className="mt-1 text-sm leading-6 text-muted-foreground">
+									설치된 GitHub App이 접근 가능한 저장소 중 팀 활동을 집계할
+									저장소를 선택합니다.
+								</p>
+							</div>
+							<Badge variant={canSelectRepositories ? "brand" : "neutral"}>
+								{canSelectRepositories ? "selectable" : "install first"}
+							</Badge>
+						</div>
+						<div className="mt-4 grid gap-3">
+							{demoTeamSpace.githubSummary.availableRepositories.map((repo) => (
+								<RepositoryOption
+									disabled={!canSelectRepositories}
+									key={repo.id}
+									onToggle={handleRepositoryToggle}
+									repo={repo}
+									selected={selectedRepoIds.includes(repo.id)}
+								/>
+							))}
+						</div>
+						<div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+							<p className="text-xs leading-5 text-muted-foreground">
+								{selectedRepoIds.length > 0
+									? `${selectedRepoIds.length}개 저장소 선택됨`
+									: "최소 1개 저장소를 선택해야 합니다."}
 							</p>
+							<Button
+								disabled={!canSaveRepositoryConnection}
+								onClick={handleSaveRepositoryConnection}
+								type="button"
+							>
+								<GitPullRequest data-icon="inline-start" />
+								선택 저장소 연결
+							</Button>
+						</div>
+					</div>
+
+					<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+							<div>
+								<p className="text-sm font-semibold text-brand-ink">
+									TeamSpace 연동 상태
+								</p>
+								<p className="mt-1 text-sm leading-6 text-muted-foreground">
+									프로젝트 그룹 기준으로 GitHub Organization 연동 여부를
+									확인합니다.
+								</p>
+							</div>
+							<Badge variant={projectGroupGithubLinked ? "brand" : "neutral"}>
+								{projectGroupGithubLinked ? "linked" : "not linked"}
+							</Badge>
+						</div>
+						{connectedRepos.length > 0 ? (
+							<div className="mt-4 grid gap-3">
+								{connectedRepos.map((repo) => (
+									<a
+										className="flex flex-col gap-2 rounded-lg border border-primary/15 bg-white p-4 transition-colors hover:border-primary/30 sm:flex-row sm:items-center sm:justify-between"
+										href={repo.url}
+										key={repo.id}
+										rel="noreferrer"
+										target="_blank"
+									>
+										<div className="min-w-0">
+											<p className="truncate font-mono text-sm font-semibold text-primary">
+												{repo.owner}/{repo.name}
+											</p>
+											<p className="mt-1 text-xs text-muted-foreground">
+												{repo.visibility} · {repo.defaultBranch} · pushed{" "}
+												{repo.lastPushedLabel}
+											</p>
+										</div>
+										<ExternalLink className="size-4 shrink-0 text-primary" />
+									</a>
+								))}
+							</div>
+						) : (
+							<div className="mt-4 rounded-lg border border-dashed border-border bg-white/65 p-4">
+								<p className="text-sm leading-6 text-muted-foreground">
+									GitHub App 설치와 저장소 선택이 끝나면 이 영역에서 연결된
+									저장소를 확인합니다.
+								</p>
+							</div>
 						)}
 					</div>
 				</div>
-				<form
-					className="grid gap-3 rounded-lg border border-border/70 bg-brand-warm p-4 md:grid-cols-[1fr_auto]"
-					onSubmit={handleConnect}
-				>
-					<label
-						className="grid gap-2 text-sm font-semibold text-brand-ink"
-						htmlFor="github-repo-url"
-					>
-						저장소 이름 또는 URL
-						<input
-							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
-							id="github-repo-url"
-							onChange={(event) => setRepoUrl(event.target.value)}
-							placeholder="team-po/app 또는 https://github.com/team-po/app"
-							value={repoUrl}
-						/>
-					</label>
-					<div className="flex items-end">
-						<Button disabled={!repoUrl.trim()} type="submit">
-							<GitPullRequest data-icon="inline-start" />
-							저장소 연결
-						</Button>
-					</div>
-				</form>
-				<div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+
+				<div className="grid gap-4 2xl:grid-cols-[1.1fr_0.9fr]">
 					<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
 						<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 							<div>
@@ -1158,8 +1393,11 @@ function GithubPanel() {
 									기여량이 많을수록 색과 밀도가 진해집니다.
 								</p>
 							</div>
-							<Badge variant="brand">
-								open PR {demoTeamSpace.githubSummary.openPrs}
+							<Badge variant={projectGroupGithubLinked ? "brand" : "neutral"}>
+								open PR{" "}
+								{projectGroupGithubLinked
+									? demoTeamSpace.githubSummary.openPrs
+									: "-"}
 							</Badge>
 						</div>
 						<div className="mt-5 grid grid-cols-7 gap-2">
@@ -1167,15 +1405,21 @@ function GithubPanel() {
 								<div
 									className={cn(
 										"aspect-square rounded-sm transition-transform hover:scale-110",
-										contributionLevelClass[day.level],
+										projectGroupGithubLinked
+											? contributionLevelClass[day.level]
+											: "bg-secondary/60",
 									)}
 									key={day.id}
-									title={`${day.label}: level ${day.level}`}
+									title={`${day.label}: level ${
+										projectGroupGithubLinked ? day.level : 0
+									}`}
 								/>
 							))}
 						</div>
 						<p className="mt-4 text-sm leading-6 text-muted-foreground">
-							{demoTeamSpace.githubSummary.weeklySummary}
+							{projectGroupGithubLinked
+								? demoTeamSpace.githubSummary.weeklySummary
+								: "저장소를 연결하면 커밋, PR, 리뷰, 이슈 기준으로 팀원별 기여 흐름을 집계합니다."}
 						</p>
 					</div>
 					<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
@@ -1203,13 +1447,16 @@ function GithubPanel() {
 												<span
 													className={cn(
 														"size-4 rounded-sm",
-														contributionLevelClass[contribution.level],
+														projectGroupGithubLinked
+															? contributionLevelClass[contribution.level]
+															: "bg-secondary",
 													)}
 												/>
 											</div>
 											<p className="mt-2 text-xs leading-5 text-muted-foreground">
-												커밋 {contribution.commits} · PR {contribution.prs} ·
-												리뷰 {contribution.reviews} · 이슈 {contribution.issues}
+												{projectGroupGithubLinked
+													? `커밋 ${contribution.commits} · PR ${contribution.prs} · 리뷰 ${contribution.reviews} · 이슈 ${contribution.issues}`
+													: "저장소 연결 후 기여 수치가 표시됩니다."}
 											</p>
 										</div>
 									);
@@ -1220,27 +1467,82 @@ function GithubPanel() {
 				</div>
 				<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
 					<p className="text-sm font-semibold text-brand-ink">최근 활동</p>
-					<div className="mt-4 grid gap-3 md:grid-cols-3">
-						{demoTeamSpace.githubSummary.recentActivities.map((activity) => (
-							<div
-								className="rounded-lg border border-border/70 bg-white p-4"
-								key={activity.id}
-							>
-								<p className="text-xs font-semibold uppercase tracking-[0.12em] text-primary">
-									{activity.type.replace("_", " ")}
-								</p>
-								<p className="mt-2 text-sm font-semibold leading-6 text-brand-ink">
-									{activity.label}
-								</p>
-								<p className="mt-2 text-xs text-muted-foreground">
-									{activity.memberName} · {activity.timeLabel}
-								</p>
-							</div>
-						))}
-					</div>
+					{projectGroupGithubLinked ? (
+						<div className="mt-4 grid gap-3 md:grid-cols-3">
+							{demoTeamSpace.githubSummary.recentActivities.map((activity) => (
+								<div
+									className="rounded-lg border border-border/70 bg-white p-4"
+									key={activity.id}
+								>
+									<p className="text-xs font-semibold uppercase tracking-[0.12em] text-primary">
+										{activity.type.replace("_", " ")}
+									</p>
+									<p className="mt-2 text-sm font-semibold leading-6 text-brand-ink">
+										{activity.label}
+									</p>
+									<p className="mt-2 text-xs text-muted-foreground">
+										{activity.memberName} · {activity.timeLabel}
+									</p>
+								</div>
+							))}
+						</div>
+					) : (
+						<p className="mt-4 rounded-lg border border-dashed border-border bg-white/65 p-4 text-sm leading-6 text-muted-foreground">
+							연동된 저장소 활동이 아직 없습니다.
+						</p>
+					)}
 				</div>
 			</div>
 		</AppPanel>
+	);
+}
+
+function RepositoryOption({
+	disabled,
+	onToggle,
+	repo,
+	selected,
+}: {
+	disabled: boolean;
+	onToggle: (repoId: string) => void;
+	repo: GithubRepositorySummary;
+	selected: boolean;
+}) {
+	return (
+		<label
+			className={cn(
+				"flex cursor-pointer flex-col gap-3 rounded-lg border p-4 transition-colors sm:flex-row sm:items-center sm:justify-between",
+				selected
+					? "border-primary/25 bg-primary/5"
+					: "border-border/70 bg-white hover:border-primary/20",
+				disabled ? "cursor-not-allowed opacity-60" : "",
+			)}
+		>
+			<div className="flex min-w-0 items-center gap-3">
+				<input
+					checked={selected}
+					className="size-4 rounded border-border text-primary accent-primary"
+					disabled={disabled}
+					onChange={() => onToggle(repo.id)}
+					type="checkbox"
+				/>
+				<div className="min-w-0">
+					<p className="truncate font-mono text-sm font-semibold text-brand-ink">
+						{repo.owner}/{repo.name}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						{repo.visibility} · {repo.defaultBranch} · pushed{" "}
+						{repo.lastPushedLabel}
+					</p>
+				</div>
+			</div>
+			<div className="flex shrink-0 flex-wrap items-center gap-2">
+				<Badge variant={repo.visibility === "private" ? "warm" : "neutral"}>
+					{repo.visibility}
+				</Badge>
+				<GitBranch className="size-4 text-muted-foreground" />
+			</div>
+		</label>
 	);
 }
 
@@ -1429,22 +1731,4 @@ function renderInlineCode(text: string): ReactNode[] {
 
 		return <span key={key}>{part}</span>;
 	});
-}
-
-function parseGithubRepo(input: string) {
-	const normalized = input
-		.replace("https://github.com/", "")
-		.replace("http://github.com/", "")
-		.replace(/^github.com\//, "")
-		.replace(/\.git$/, "");
-	const [owner = "team-po", name = "app"] = normalized.split("/");
-
-	return {
-		defaultBranch: "main",
-		name,
-		owner,
-		syncedAtLabel: "방금 동기화",
-		url: `https://github.com/${owner}/${name}`,
-		visibility: "private" as const,
-	};
 }

--- a/src/features/team/lib/demo-team-space.ts
+++ b/src/features/team/lib/demo-team-space.ts
@@ -71,6 +71,46 @@ export const demoTeamSpace: TeamSpace = {
 		},
 	],
 	githubSummary: {
+		appInstallation: {
+			permissions: [
+				"Metadata: read",
+				"Contents: read",
+				"Pull requests: read",
+				"Issues: read",
+			],
+			repositorySelection: null,
+			setupUrl: "https://github.com/apps/team-po/installations/new",
+			status: "not_installed",
+		},
+		availableRepositories: [
+			{
+				defaultBranch: "main",
+				id: "repo-client",
+				lastPushedLabel: "오늘 13:20",
+				name: "client",
+				owner: "team-po-labs",
+				url: "https://github.com/team-po-labs/client",
+				visibility: "private",
+			},
+			{
+				defaultBranch: "main",
+				id: "repo-server",
+				lastPushedLabel: "오늘 11:48",
+				name: "server",
+				owner: "team-po-labs",
+				url: "https://github.com/team-po-labs/server",
+				visibility: "private",
+			},
+			{
+				defaultBranch: "docs",
+				id: "repo-docs",
+				lastPushedLabel: "어제 22:10",
+				name: "product-notes",
+				owner: "team-po-labs",
+				url: "https://github.com/team-po-labs/product-notes",
+				visibility: "public",
+			},
+		],
 		contributionDays: [
 			{ id: "day-01", label: "4월 13일", level: 1 },
 			{ id: "day-02", label: "4월 14일", level: 0 },
@@ -94,7 +134,7 @@ export const demoTeamSpace: TeamSpace = {
 			{ id: "day-20", label: "5월 2일", level: 4 },
 			{ id: "day-21", label: "5월 3일", level: 2 },
 		],
-		connectedRepo: null,
+		connectedRepos: [],
 		memberContributions: [
 			{
 				commits: 18,
@@ -122,7 +162,9 @@ export const demoTeamSpace: TeamSpace = {
 			},
 		],
 		oauthStatus: "disconnected",
+		organization: null,
 		openPrs: 3,
+		projectGroupGithubLinked: false,
 		recentActivities: [
 			{
 				id: "activity-1",

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,5 +1,7 @@
 import { apiRequest } from "@/lib/api/client";
+import { resolveOAuthUrl } from "@/lib/api/config";
 import type {
+	GithubLinkStartResponse,
 	GithubOAuthTokenRequest,
 	GithubOAuthTokenResponse,
 	LoginRequest,
@@ -21,6 +23,25 @@ export function exchangeGithubOAuthCode(payload: GithubOAuthTokenRequest) {
 		json: payload,
 		method: "POST",
 		skipAuth: true,
+	});
+}
+
+export async function startGithubAccountLink() {
+	const response = await apiRequest<GithubLinkStartResponse>(
+		"/oauth/github/link-requests",
+		{
+			method: "POST",
+		},
+	);
+
+	return {
+		authorizationUrl: resolveOAuthUrl(response.authorizationUrl),
+	} satisfies GithubLinkStartResponse;
+}
+
+export function unlinkGithubAccount() {
+	return apiRequest<void>("/oauth/github/account", {
+		method: "DELETE",
 	});
 }
 

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -11,10 +11,23 @@ export const apiConfig = {
 	githubOAuthAuthorizationUrl:
 		apiMode === "mock"
 			? "/oauth/github/callback?code=mock-github-login-code&onboardingRequired=false"
-			: `${oauthBaseUrl}/oauth2/authorization/github`,
+			: resolveOAuthUrl("/oauth2/authorization/github"),
 	mode: apiMode,
 	useMocks: apiMode === "mock",
 };
+
+export function resolveOAuthUrl(pathOrUrl: string) {
+	if (/^https?:\/\//.test(pathOrUrl)) {
+		return pathOrUrl;
+	}
+
+	if (apiMode === "mock") {
+		return pathOrUrl;
+	}
+
+	const path = pathOrUrl.startsWith("/") ? pathOrUrl : `/${pathOrUrl}`;
+	return `${oauthBaseUrl}${path}`;
+}
 
 function getDefaultOAuthBaseUrl(baseUrl: string) {
 	if (baseUrl.endsWith("/api")) {

--- a/src/lib/api/mocks/auth-preview.ts
+++ b/src/lib/api/mocks/auth-preview.ts
@@ -13,6 +13,9 @@ export function createPreviewUser(
 	return {
 		description: "빠르게 실험하고, 팀원과 맥락을 맞추는 일을 좋아합니다.",
 		email: previewAuthSeed.email,
+		githubUsername: null,
+		isGithubLinked: false,
+		isGithubLogin: false,
 		level: 3,
 		nickname: previewAuthSeed.nickname,
 		profileImage: previewAuthSeed.profileImage,

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -302,6 +302,9 @@ export const handlers = [
 		if (body.code === "mock-github-login-code") {
 			currentUser = createPreviewUser({
 				email: "github.dev@teampo.dev",
+				githubUsername: "github_runner",
+				isGithubLinked: true,
+				isGithubLogin: true,
 				nickname: "github_runner",
 				profileImage: "https://i.pravatar.cc/240?img=32",
 			});
@@ -324,6 +327,9 @@ export const handlers = [
 			currentUser = createPreviewUser({
 				description: null,
 				email: "new.github.dev@teampo.dev",
+				githubUsername: "new_github_runner",
+				isGithubLinked: true,
+				isGithubLogin: true,
 				level: body.level,
 				nickname: "new_github_runner",
 				profileImage: "https://i.pravatar.cc/240?img=47",
@@ -335,10 +341,76 @@ export const handlers = [
 		}
 
 		return buildErrorResponse(
-			400,
+			401,
 			"OAuth 인가 코드가 만료되었거나 올바르지 않습니다.",
 			"INVALID_OAUTH_AUTHORIZATION_CODE",
 		);
+	}),
+
+	http.post(getPath("/oauth/github/link-requests"), async () => {
+		await delay(350);
+
+		if (!currentUser) {
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
+		}
+
+		if (currentUser.isGithubLinked) {
+			return buildErrorResponse(
+				409,
+				"이미 GitHub 계정이 연동되어 있습니다.",
+				"GITHUB_ACCOUNT_ALREADY_LINKED",
+			);
+		}
+
+		currentUser = {
+			...currentUser,
+			githubUsername: "octocat",
+			isGithubLinked: true,
+		};
+
+		return HttpResponse.json({
+			authorizationUrl: "/oauth/github/callback?githubLinked=true",
+		});
+	}),
+
+	http.delete(getPath("/oauth/github/account"), async () => {
+		await delay(350);
+
+		if (!currentUser) {
+			return buildErrorResponse(
+				401,
+				"인증된 유저를 찾을 수 없습니다.",
+				"NO_AUTHENTICATED_USER",
+			);
+		}
+
+		if (!currentUser.isGithubLinked) {
+			return buildErrorResponse(
+				404,
+				"연동된 GitHub 계정이 없습니다.",
+				"GITHUB_ACCOUNT_NOT_LINKED",
+			);
+		}
+
+		if (currentUser.isGithubLogin) {
+			return buildErrorResponse(
+				409,
+				"GitHub 로그인 계정은 GitHub 연동을 해제할 수 없습니다.",
+				"GITHUB_LOGIN_ACCOUNT_UNLINK_NOT_ALLOWED",
+			);
+		}
+
+		currentUser = {
+			...currentUser,
+			githubUsername: null,
+			isGithubLinked: false,
+		};
+
+		return new HttpResponse(null, { status: 204 });
 	}),
 
 	http.post(getPath("/users/refresh-token"), async ({ request }) => {
@@ -516,14 +588,14 @@ export const handlers = [
 		}
 
 		currentUserId += 1;
-		currentUser = {
+		currentUser = createPreviewUser({
 			description: null,
 			email: normalizeEmail(body.email),
 			level: body.level,
 			nickname: body.nickname.trim(),
 			profileImage: imageUrlFromKey(body.profileImageKey),
 			temperature: 50,
-		};
+		});
 		currentPassword = body.password;
 		resetDeleteEmailState();
 

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -8,6 +8,10 @@ export interface GithubOAuthTokenRequest {
 	level?: number;
 }
 
+export interface GithubLinkStartResponse {
+	authorizationUrl: string;
+}
+
 export interface SendSignupEmailRequest {
 	email: string;
 }

--- a/src/lib/types/team.ts
+++ b/src/lib/types/team.ts
@@ -56,22 +56,32 @@ export interface TeamMessage {
 
 export type ContributionLevel = 0 | 1 | 2 | 3 | 4;
 
+export interface GithubRepositorySummary {
+	defaultBranch: string;
+	id: string;
+	lastPushedLabel: string;
+	name: string;
+	owner: string;
+	url: string;
+	visibility: "public" | "private";
+}
+
 export interface TeamSpace {
 	checklist: TeamChecklistItem[];
 	githubSummary: {
+		appInstallation: {
+			permissions: string[];
+			repositorySelection: "selected" | "all" | null;
+			setupUrl: string;
+			status: "not_installed" | "installed";
+		};
+		availableRepositories: GithubRepositorySummary[];
 		contributionDays: Array<{
 			id: string;
 			label: string;
 			level: ContributionLevel;
 		}>;
-		connectedRepo: {
-			defaultBranch: string;
-			name: string;
-			owner: string;
-			syncedAtLabel: string;
-			url: string;
-			visibility: "public" | "private";
-		} | null;
+		connectedRepos: GithubRepositorySummary[];
 		memberContributions: Array<{
 			commits: number;
 			issues: number;
@@ -81,7 +91,13 @@ export interface TeamSpace {
 			reviews: number;
 		}>;
 		oauthStatus: "disconnected" | "connected";
+		organization: {
+			login: string;
+			name: string;
+			url: string;
+		} | null;
 		openPrs: number;
+		projectGroupGithubLinked: boolean;
 		recentActivities: Array<{
 			id: string;
 			label: string;

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -1,6 +1,9 @@
 export interface UserProfile {
 	description: string | null;
 	email: string;
+	githubUsername: string | null;
+	isGithubLinked: boolean;
+	isGithubLogin: boolean;
 	level: number;
 	nickname: string;
 	profileImage: string | null;


### PR DESCRIPTION
<!-- codex-server-api-sync-to-client -->

## Summary
- sync Client OpenAPI, types, and API request functions with Server GitHub account link/unlink endpoints
- surface GitHub linked/login state in the profile UI and callback result flow
- update MSW mock profile data and handlers for GitHub link, unlink, and OAuth token error status

## Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build
- Browser smoke check: mock GitHub link callback shows success, profile shows @octocat/연동됨, unlink returns to 미연동

Closes #51