### PR TITLE
fix: improve matching and profile account states

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -10,6 +10,7 @@ import type { ComponentType, ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
+import { useMyProjectGroupQuery } from "@/features/project-groups/hooks/use-project-group-queries";
 import { clearAuthSession, getAuthSession } from "@/lib/api/auth-session";
 import { cn } from "@/lib/utils";
 
@@ -32,10 +33,11 @@ interface AppTopBarProps {
 const navigationItems: Array<{
 	icon: ComponentType<{ className?: string }>;
 	label: string;
+	requiresNoTeam?: boolean;
 	to: string;
 }> = [
 	{ icon: UserRound, label: "내 정보", to: "/me" },
-	{ icon: Shuffle, label: "매칭", to: "/match" },
+	{ icon: Shuffle, label: "매칭", requiresNoTeam: true, to: "/match" },
 	{ icon: UsersRound, label: "팀 스페이스", to: "/team" },
 ];
 
@@ -200,6 +202,13 @@ function AppSidebar() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const isSignedIn = Boolean(getAuthSession());
+	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
+	const hasProjectGroup = Boolean(projectGroupQuery.data);
+	const flowHref = hasProjectGroup ? "/team" : "/match";
+	const flowLabel = hasProjectGroup ? "팀 스페이스 열기" : "매칭 요청하기";
+	const flowDescription = hasProjectGroup
+		? "이미 소속된 팀이 있어 팀 스페이스에서 현재 협업 흐름을 이어가세요."
+		: "프로필을 정리하고 매칭 요청을 보낸 뒤 팀 스페이스에서 바로 협업을 시작하세요.";
 
 	function handleLogout() {
 		clearAuthSession();
@@ -231,18 +240,32 @@ function AppSidebar() {
 					{navigationItems.map((item) => {
 						const Icon = item.icon;
 						const isActive = location.pathname === item.to;
+						const isDisabled = Boolean(item.requiresNoTeam && hasProjectGroup);
+						const className = cn(
+							"flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-semibold transition-colors",
+							isDisabled
+								? "cursor-not-allowed text-muted-foreground/55"
+								: isActive
+									? "bg-primary text-primary-foreground shadow-soft"
+									: "text-muted-foreground hover:bg-secondary hover:text-foreground",
+						);
+
+						if (isDisabled) {
+							return (
+								<span
+									aria-disabled="true"
+									className={className}
+									key={item.to}
+									title="이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다."
+								>
+									<Icon className="size-4" />
+									{item.label}
+								</span>
+							);
+						}
 
 						return (
-							<Link
-								className={cn(
-									"flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-semibold transition-colors",
-									isActive
-										? "bg-primary text-primary-foreground shadow-soft"
-										: "text-muted-foreground hover:bg-secondary hover:text-foreground",
-								)}
-								key={item.to}
-								to={item.to}
-							>
+							<Link className={className} key={item.to} to={item.to}>
 								<Icon className="size-4" />
 								{item.label}
 							</Link>
@@ -254,16 +277,34 @@ function AppSidebar() {
 					{navigationItems.map((item) => {
 						const Icon = item.icon;
 						const isActive = location.pathname === item.to;
+						const isDisabled = Boolean(item.requiresNoTeam && hasProjectGroup);
+						const className = cn(
+							"flex size-9 items-center justify-center rounded-lg border transition-colors",
+							isDisabled
+								? "cursor-not-allowed border-border/70 bg-secondary/40 text-muted-foreground/55"
+								: isActive
+									? "border-primary bg-primary text-primary-foreground"
+									: "border-border/70 bg-white text-muted-foreground",
+						);
+
+						if (isDisabled) {
+							return (
+								<span
+									aria-disabled="true"
+									className={className}
+									key={item.to}
+									title="이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다."
+								>
+									<Icon className="size-4" />
+									<span className="sr-only">{item.label} 비활성화</span>
+								</span>
+							);
+						}
 
 						return (
 							<Link
 								aria-label={item.label}
-								className={cn(
-									"flex size-9 items-center justify-center rounded-lg border transition-colors",
-									isActive
-										? "border-primary bg-primary text-primary-foreground"
-										: "border-border/70 bg-white text-muted-foreground",
-								)}
+								className={className}
 								key={item.to}
 								to={item.to}
 							>
@@ -281,14 +322,13 @@ function AppSidebar() {
 						오늘의 흐름
 					</div>
 					<p className="mt-2 text-sm leading-6 text-muted-foreground">
-						프로필을 정리하고 매칭 요청을 보낸 뒤 팀 스페이스에서 바로 협업을
-						시작하세요.
+						{flowDescription}
 					</p>
 					<Link
 						className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-primary"
-						to="/match"
+						to={flowHref}
 					>
-						매칭 요청하기
+						{flowLabel}
 						<ArrowUpRight className="size-3.5" />
 					</Link>
 				</div>

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -207,11 +207,17 @@ function AppSidebar() {
 	const isSignedIn = Boolean(getAuthSession());
 	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
 	const hasProjectGroup = isSignedIn && Boolean(projectGroupQuery.data);
+	const isCheckingProjectGroup = isSignedIn && projectGroupQuery.isLoading;
 	const flowHref = hasProjectGroup ? "/team" : "/match";
 	const flowLabel = hasProjectGroup ? "팀 스페이스 열기" : "매칭 요청하기";
-	const flowDescription = hasProjectGroup
-		? "이미 소속된 팀이 있어 팀 스페이스에서 현재 협업 흐름을 이어가세요."
-		: "프로필을 정리하고 매칭 요청을 보낸 뒤 팀 스페이스에서 바로 협업을 시작하세요.";
+	const flowDescription = isCheckingProjectGroup
+		? "내 팀 스페이스 상태를 확인한 뒤 가능한 다음 흐름을 안내합니다."
+		: hasProjectGroup
+			? "이미 소속된 팀이 있어 팀 스페이스에서 현재 협업 흐름을 이어가세요."
+			: "프로필을 정리하고 매칭 요청을 보낸 뒤 팀 스페이스에서 바로 협업을 시작하세요.";
+	const matchingDisabledTitle = isCheckingProjectGroup
+		? "팀 스페이스 상태를 확인하는 중입니다."
+		: "이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다.";
 
 	function handleLogout() {
 		clearAuthSession();
@@ -244,7 +250,10 @@ function AppSidebar() {
 					{navigationItems.map((item) => {
 						const Icon = item.icon;
 						const isActive = location.pathname === item.to;
-						const isDisabled = Boolean(item.requiresNoTeam && hasProjectGroup);
+						const isDisabled = Boolean(
+							item.requiresNoTeam &&
+								(hasProjectGroup || isCheckingProjectGroup),
+						);
 						const className = cn(
 							"flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-semibold transition-colors",
 							isDisabled
@@ -260,7 +269,7 @@ function AppSidebar() {
 									aria-disabled="true"
 									className={className}
 									key={item.to}
-									title="이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다."
+									title={matchingDisabledTitle}
 								>
 									<Icon className="size-4" />
 									{item.label}
@@ -281,7 +290,10 @@ function AppSidebar() {
 					{navigationItems.map((item) => {
 						const Icon = item.icon;
 						const isActive = location.pathname === item.to;
-						const isDisabled = Boolean(item.requiresNoTeam && hasProjectGroup);
+						const isDisabled = Boolean(
+							item.requiresNoTeam &&
+								(hasProjectGroup || isCheckingProjectGroup),
+						);
 						const className = cn(
 							"flex size-9 items-center justify-center rounded-lg border transition-colors",
 							isDisabled
@@ -297,7 +309,7 @@ function AppSidebar() {
 									aria-disabled="true"
 									className={className}
 									key={item.to}
-									title="이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다."
+									title={matchingDisabledTitle}
 								>
 									<Icon className="size-4" />
 									<span className="sr-only">{item.label} 비활성화</span>

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	ArrowUpRight,
 	LayoutDashboard,
@@ -10,6 +11,7 @@ import type { ComponentType, ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
+import { clearAuthScopedQueryData } from "@/features/auth/hooks/use-auth-queries";
 import { useMyProjectGroupQuery } from "@/features/project-groups/hooks/use-project-group-queries";
 import { clearAuthSession, getAuthSession } from "@/lib/api/auth-session";
 import { cn } from "@/lib/utils";
@@ -201,9 +203,10 @@ function AppTopBar({ actions, description, eyebrow, title }: AppTopBarProps) {
 function AppSidebar() {
 	const location = useLocation();
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const isSignedIn = Boolean(getAuthSession());
 	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
-	const hasProjectGroup = Boolean(projectGroupQuery.data);
+	const hasProjectGroup = isSignedIn && Boolean(projectGroupQuery.data);
 	const flowHref = hasProjectGroup ? "/team" : "/match";
 	const flowLabel = hasProjectGroup ? "팀 스페이스 열기" : "매칭 요청하기";
 	const flowDescription = hasProjectGroup
@@ -212,6 +215,7 @@ function AppSidebar() {
 
 	function handleLogout() {
 		clearAuthSession();
+		clearAuthScopedQueryData(queryClient);
 		navigate("/");
 	}
 

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -25,6 +25,11 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 	const [isSignedIn, setIsSignedIn] = useState(() => Boolean(getAuthSession()));
 	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
 	const hasProjectGroup = isSignedIn && Boolean(projectGroupQuery.data);
+	const isMatchingLinkDisabled =
+		isSignedIn && (hasProjectGroup || projectGroupQuery.isLoading);
+	const matchingDisabledTitle = projectGroupQuery.isLoading
+		? "팀 스페이스 상태를 확인하는 중입니다."
+		: "이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다.";
 
 	useEffect(() => {
 		function syncAuthState() {
@@ -70,11 +75,11 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 				<div className="flex items-center gap-2">
 					{showMyPageLink && isSignedIn ? (
 						<div className="hidden items-center gap-4 md:flex">
-							{hasProjectGroup ? (
+							{isMatchingLinkDisabled ? (
 								<span
 									aria-disabled="true"
 									className="cursor-not-allowed text-sm text-muted-foreground/55"
-									title="이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다."
+									title={matchingDisabledTitle}
 								>
 									매칭
 								</span>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,8 +1,10 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
+import { clearAuthScopedQueryData } from "@/features/auth/hooks/use-auth-queries";
 import { useMyProjectGroupQuery } from "@/features/project-groups/hooks/use-project-group-queries";
 import { clearAuthSession, getAuthSession } from "@/lib/api/auth-session";
 import { cn } from "@/lib/utils";
@@ -19,9 +21,10 @@ const authLinks = [
 export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 	const location = useLocation();
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const [isSignedIn, setIsSignedIn] = useState(() => Boolean(getAuthSession()));
 	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
-	const hasProjectGroup = Boolean(projectGroupQuery.data);
+	const hasProjectGroup = isSignedIn && Boolean(projectGroupQuery.data);
 
 	useEffect(() => {
 		function syncAuthState() {
@@ -40,6 +43,7 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 
 	function handleLogout() {
 		clearAuthSession();
+		clearAuthScopedQueryData(queryClient);
 		setIsSignedIn(false);
 		navigate("/");
 	}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
+import { useMyProjectGroupQuery } from "@/features/project-groups/hooks/use-project-group-queries";
 import { clearAuthSession, getAuthSession } from "@/lib/api/auth-session";
 import { cn } from "@/lib/utils";
 
@@ -19,6 +20,8 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const [isSignedIn, setIsSignedIn] = useState(() => Boolean(getAuthSession()));
+	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
+	const hasProjectGroup = Boolean(projectGroupQuery.data);
 
 	useEffect(() => {
 		function syncAuthState() {
@@ -63,15 +66,25 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 				<div className="flex items-center gap-2">
 					{showMyPageLink && isSignedIn ? (
 						<div className="hidden items-center gap-4 md:flex">
-							<Link
-								className={cn(
-									"text-sm text-muted-foreground transition-colors hover:text-foreground",
-									location.pathname === "/match" && "text-foreground",
-								)}
-								to="/match"
-							>
-								매칭
-							</Link>
+							{hasProjectGroup ? (
+								<span
+									aria-disabled="true"
+									className="cursor-not-allowed text-sm text-muted-foreground/55"
+									title="이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다."
+								>
+									매칭
+								</span>
+							) : (
+								<Link
+									className={cn(
+										"text-sm text-muted-foreground transition-colors hover:text-foreground",
+										location.pathname === "/match" && "text-foreground",
+									)}
+									to="/match"
+								>
+									매칭
+								</Link>
+							)}
 							<Link
 								className={cn(
 									"text-sm text-muted-foreground transition-colors hover:text-foreground",

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -141,7 +141,11 @@ export function ProfileView() {
 		deleteForm.confirm.length > 0 ? deleteConfirmError : undefined;
 	const isDeleteAuthNumberInvalid = !/^\d{6}$/.test(deleteForm.authNumber);
 	const currentUser = currentUserQuery.data;
-	const currentProjectGroup = projectGroupQuery.data ?? undefined;
+	const currentProjectGroup = isSignedIn
+		? (projectGroupQuery.data ?? undefined)
+		: undefined;
+	const projectGroupError = isSignedIn ? projectGroupQuery.error : null;
+	const isProjectGroupLoading = isSignedIn && projectGroupQuery.isLoading;
 	const hasCurrentTeam = Boolean(currentProjectGroup);
 	const showMockTeamPreview = useMockTeamSurface && hasCurrentTeam;
 	const isProfileDirty = currentUser
@@ -169,13 +173,13 @@ export function ProfileView() {
 		? demoTeamSpace.name
 		: currentProjectGroup?.projectName ||
 			getCurrentTeamName({
-				error: projectGroupQuery.error,
-				isLoading: projectGroupQuery.isLoading,
+				error: projectGroupError,
+				isLoading: isProjectGroupLoading,
 			});
 	const currentTeamMetric = getCurrentTeamMetric({
-		error: projectGroupQuery.error,
+		error: projectGroupError,
 		isMock: showMockTeamPreview,
-		isLoading: projectGroupQuery.isLoading,
+		isLoading: isProjectGroupLoading,
 		projectGroup: currentProjectGroup,
 	});
 
@@ -460,8 +464,8 @@ export function ProfileView() {
 								<MockCurrentTeamPanel />
 							) : (
 								<RealCurrentTeamPanel
-									error={projectGroupQuery.error}
-									isLoading={projectGroupQuery.isLoading}
+									error={projectGroupError}
+									isLoading={isProjectGroupLoading}
 									onRetry={() => void projectGroupQuery.refetch()}
 									projectGroup={currentProjectGroup}
 								/>

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -1,11 +1,14 @@
 import {
 	ArrowRight,
 	Camera,
+	CheckCircle2,
 	Github,
 	KeyRound,
 	LoaderCircle,
+	MailCheck,
 	RefreshCcw,
 	ShieldAlert,
+	ShieldCheck,
 	Trash2,
 	Unlink,
 	UsersRound,
@@ -48,9 +51,10 @@ import {
 	validateProfileEditForm,
 } from "@/features/auth/lib/validation";
 import { useMyProjectGroupQuery } from "@/features/project-groups/hooks/use-project-group-queries";
+import { isProjectGroupNotFoundError } from "@/features/project-groups/lib/errors";
 import { demoTeamSpace } from "@/features/team/lib/demo-team-space";
 import { getAuthSession } from "@/lib/api/auth-session";
-import { ApiError, getApiErrorMessage } from "@/lib/api/client";
+import { getApiErrorMessage } from "@/lib/api/client";
 import { apiConfig } from "@/lib/api/config";
 import type { MyProjectGroup } from "@/lib/types/project-group";
 import type { UserProfile } from "@/lib/types/user";
@@ -61,11 +65,9 @@ const levelOptions = [1, 2, 3, 4, 5] as const;
 export function ProfileView() {
 	const navigate = useNavigate();
 	const isSignedIn = Boolean(getAuthSession());
-	const showMockTeamPreview = apiConfig.useMocks;
+	const useMockTeamSurface = apiConfig.useMocks;
 	const currentUserQuery = useCurrentUserQuery();
-	const projectGroupQuery = useMyProjectGroupQuery(
-		isSignedIn && !showMockTeamPreview,
-	);
+	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
 	const updateCurrentUserMutation = useUpdateCurrentUserMutation();
 	const editPasswordMutation = useEditPasswordMutation();
 	const startGithubAccountLinkMutation = useStartGithubAccountLinkMutation();
@@ -94,6 +96,8 @@ export function ProfileView() {
 		authNumber: "",
 		confirm: "",
 	});
+	const [isDeleteEmailSent, setIsDeleteEmailSent] = useState(false);
+	const [isDeleteEmailVerified, setIsDeleteEmailVerified] = useState(false);
 	const [profileImagePreviewUrl, setProfileImagePreviewUrl] = useState<
 		string | null
 	>(null);
@@ -135,7 +139,11 @@ export function ProfileView() {
 	const deleteConfirmError = getDeleteConfirmationError(deleteForm.confirm);
 	const visibleDeleteConfirmError =
 		deleteForm.confirm.length > 0 ? deleteConfirmError : undefined;
+	const isDeleteAuthNumberInvalid = !/^\d{6}$/.test(deleteForm.authNumber);
 	const currentUser = currentUserQuery.data;
+	const currentProjectGroup = projectGroupQuery.data ?? undefined;
+	const hasCurrentTeam = Boolean(currentProjectGroup);
+	const showMockTeamPreview = useMockTeamSurface && hasCurrentTeam;
 	const isProfileDirty = currentUser
 		? form.description.trim() !== (currentUser.description ?? "") ||
 			form.level !== currentUser.level ||
@@ -154,11 +162,12 @@ export function ProfileView() {
 		sendDeleteUserEmailMutation.isPending ||
 		validateDeleteUserEmailMutation.isPending ||
 		deleteCurrentUserMutation.isPending ||
+		!isDeleteEmailVerified ||
 		Boolean(deleteConfirmError) ||
-		!/^\d{6}$/.test(deleteForm.authNumber);
+		isDeleteAuthNumberInvalid;
 	const currentTeamName = showMockTeamPreview
 		? demoTeamSpace.name
-		: projectGroupQuery.data?.projectName ||
+		: currentProjectGroup?.projectName ||
 			getCurrentTeamName({
 				error: projectGroupQuery.error,
 				isLoading: projectGroupQuery.isLoading,
@@ -167,7 +176,7 @@ export function ProfileView() {
 		error: projectGroupQuery.error,
 		isMock: showMockTeamPreview,
 		isLoading: projectGroupQuery.isLoading,
-		projectGroup: projectGroupQuery.data,
+		projectGroup: currentProjectGroup,
 	});
 
 	function markTouched(field: keyof typeof touched) {
@@ -240,9 +249,36 @@ export function ProfileView() {
 	async function handleDeleteEmailSend() {
 		try {
 			await sendDeleteUserEmailMutation.mutateAsync();
+			validateDeleteUserEmailMutation.reset();
+			setIsDeleteEmailSent(true);
+			setIsDeleteEmailVerified(false);
 		} catch {
 			// The mutation error state renders the inline error message.
 		}
+	}
+
+	async function handleDeleteAuthNumberValidate() {
+		if (!isDeleteEmailSent || isDeleteAuthNumberInvalid) {
+			return;
+		}
+
+		try {
+			await validateDeleteUserEmailMutation.mutateAsync({
+				authNumber: Number(deleteForm.authNumber),
+			});
+			setIsDeleteEmailVerified(true);
+		} catch {
+			// The mutation error state renders the inline error message.
+		}
+	}
+
+	function handleDeleteAuthNumberChange(authNumber: string) {
+		validateDeleteUserEmailMutation.reset();
+		setIsDeleteEmailVerified(false);
+		setDeleteForm((current) => ({
+			...current,
+			authNumber,
+		}));
 	}
 
 	async function handleDeleteSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -253,9 +289,6 @@ export function ProfileView() {
 		}
 
 		try {
-			await validateDeleteUserEmailMutation.mutateAsync({
-				authNumber: Number(deleteForm.authNumber),
-			});
 			await deleteCurrentUserMutation.mutateAsync();
 			navigate("/", { replace: true });
 		} catch {
@@ -267,12 +300,19 @@ export function ProfileView() {
 		<AppShell
 			actions={
 				<>
-					<Button asChild variant="outline">
-						<Link to="/match">
+					{hasCurrentTeam ? (
+						<Button disabled variant="outline">
 							<ArrowRight data-icon="inline-start" />
-							매칭 요청
-						</Link>
-					</Button>
+							매칭 잠김
+						</Button>
+					) : (
+						<Button asChild variant="outline">
+							<Link to="/match">
+								<ArrowRight data-icon="inline-start" />
+								매칭 요청
+							</Link>
+						</Button>
+					)}
 					<Button asChild>
 						<Link to="/team">
 							<UsersRound data-icon="inline-start" />팀 스페이스
@@ -423,7 +463,7 @@ export function ProfileView() {
 									error={projectGroupQuery.error}
 									isLoading={projectGroupQuery.isLoading}
 									onRetry={() => void projectGroupQuery.refetch()}
-									projectGroup={projectGroupQuery.data}
+									projectGroup={currentProjectGroup}
 								/>
 							)}
 						</div>
@@ -443,13 +483,15 @@ export function ProfileView() {
 							/>
 
 							<div className="grid gap-5">
-								<SecurityPanel
-									editPasswordMutation={editPasswordMutation}
-									isPasswordSubmitDisabled={isPasswordSubmitDisabled}
-									onSubmit={handlePasswordSubmit}
-									passwordForm={passwordForm}
-									setPasswordForm={setPasswordForm}
-								/>
+								{currentUser.isGithubLogin ? null : (
+									<SecurityPanel
+										editPasswordMutation={editPasswordMutation}
+										isPasswordSubmitDisabled={isPasswordSubmitDisabled}
+										onSubmit={handlePasswordSubmit}
+										passwordForm={passwordForm}
+										setPasswordForm={setPasswordForm}
+									/>
+								)}
 								<AccountLinksPanel
 									currentUser={currentUser}
 									onStartGithubLink={handleGithubLinkStart}
@@ -463,9 +505,14 @@ export function ProfileView() {
 									deleteConfirmError={visibleDeleteConfirmError}
 									deleteCurrentUserMutation={deleteCurrentUserMutation}
 									deleteForm={deleteForm}
+									isDeleteAuthNumberInvalid={isDeleteAuthNumberInvalid}
 									isDeleteDisabled={isDeleteDisabled}
+									isDeleteEmailSent={isDeleteEmailSent}
+									isDeleteEmailVerified={isDeleteEmailVerified}
+									onDeleteAuthNumberChange={handleDeleteAuthNumberChange}
 									onSendDeleteEmail={handleDeleteEmailSend}
 									onSubmit={handleDeleteSubmit}
+									onValidateDeleteEmail={handleDeleteAuthNumberValidate}
 									sendDeleteUserEmailMutation={sendDeleteUserEmailMutation}
 									setDeleteForm={setDeleteForm}
 									validateDeleteUserEmailMutation={
@@ -551,13 +598,6 @@ function getCurrentTeamMetric({
 		trend: "매칭 완료 후 생성",
 		value: "0",
 	};
-}
-
-function isProjectGroupNotFoundError(error: unknown) {
-	return (
-		error instanceof ApiError &&
-		(error.status === 404 || error.code === "PROJECT_GROUP_NOT_FOUND")
-	);
 }
 
 function MockCurrentTeamPanel() {
@@ -1119,9 +1159,14 @@ function DangerPanel({
 	deleteConfirmError,
 	deleteCurrentUserMutation,
 	deleteForm,
+	isDeleteAuthNumberInvalid,
 	isDeleteDisabled,
+	isDeleteEmailSent,
+	isDeleteEmailVerified,
+	onDeleteAuthNumberChange,
 	onSendDeleteEmail,
 	onSubmit,
+	onValidateDeleteEmail,
 	sendDeleteUserEmailMutation,
 	setDeleteForm,
 	validateDeleteUserEmailMutation,
@@ -1129,9 +1174,14 @@ function DangerPanel({
 	deleteConfirmError: string | undefined;
 	deleteCurrentUserMutation: ReturnType<typeof useDeleteCurrentUserMutation>;
 	deleteForm: { authNumber: string; confirm: string };
+	isDeleteAuthNumberInvalid: boolean;
 	isDeleteDisabled: boolean;
+	isDeleteEmailSent: boolean;
+	isDeleteEmailVerified: boolean;
+	onDeleteAuthNumberChange: (authNumber: string) => void;
 	onSendDeleteEmail: () => void;
 	onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+	onValidateDeleteEmail: () => void;
 	sendDeleteUserEmailMutation: ReturnType<
 		typeof useSendDeleteUserEmailMutation
 	>;
@@ -1142,8 +1192,9 @@ function DangerPanel({
 		typeof useValidateDeleteUserEmailMutation
 	>;
 }) {
-	const deleteError =
-		validateDeleteUserEmailMutation.error ?? deleteCurrentUserMutation.error;
+	const deleteError = deleteCurrentUserMutation.error;
+	const showDeleteAuthNumberError =
+		deleteForm.authNumber.length > 0 && isDeleteAuthNumberInvalid;
 
 	return (
 		<AppPanel className="border-rose-200">
@@ -1163,54 +1214,98 @@ function DangerPanel({
 					</p>
 				</div>
 				<FieldGroup>
-					<div className="grid gap-3 sm:grid-cols-[1fr_auto]">
-						<Field>
-							<FieldLabel htmlFor="delete-auth-number">인증번호</FieldLabel>
+					<Field
+						data-invalid={Boolean(
+							showDeleteAuthNumberError ||
+								sendDeleteUserEmailMutation.error ||
+								validateDeleteUserEmailMutation.error,
+						)}
+					>
+						<FieldLabel htmlFor="delete-auth-number">
+							이메일 인증번호
+						</FieldLabel>
+						<div className="grid gap-2 lg:grid-cols-[1fr_auto_auto]">
 							<Input
+								aria-invalid={showDeleteAuthNumberError}
 								className="h-11 bg-white"
+								disabled={!isDeleteEmailSent || isDeleteEmailVerified}
 								id="delete-auth-number"
 								inputMode="numeric"
 								maxLength={6}
 								onChange={(event) =>
-									setDeleteForm((current) => ({
-										...current,
-										authNumber: event.target.value
-											.replace(/\D/g, "")
-											.slice(0, 6),
-									}))
+									onDeleteAuthNumberChange(
+										event.target.value.replace(/\D/g, "").slice(0, 6),
+									)
 								}
-								placeholder="123456"
+								placeholder="6자리 숫자"
 								value={deleteForm.authNumber}
 							/>
-						</Field>
-						<Button
-							className="self-end"
-							disabled={sendDeleteUserEmailMutation.isPending}
-							onClick={() => void onSendDeleteEmail()}
-							type="button"
-							variant="outline"
-						>
-							{sendDeleteUserEmailMutation.isPending ? (
-								<LoaderCircle
-									className="animate-spin"
-									data-icon="inline-start"
-								/>
-							) : (
-								<KeyRound data-icon="inline-start" />
-							)}
-							인증번호 발송
-						</Button>
-					</div>
-					{sendDeleteUserEmailMutation.error ? (
-						<FieldError>
-							{getApiErrorMessage(sendDeleteUserEmailMutation.error)}
-						</FieldError>
-					) : null}
-					{sendDeleteUserEmailMutation.isSuccess ? (
-						<p className="text-sm font-medium text-emerald-700">
-							인증번호를 이메일로 보냈습니다.
-						</p>
-					) : null}
+							<Button
+								className="h-11"
+								disabled={
+									sendDeleteUserEmailMutation.isPending || isDeleteEmailVerified
+								}
+								onClick={() => void onSendDeleteEmail()}
+								type="button"
+								variant="outline"
+							>
+								{sendDeleteUserEmailMutation.isPending ? (
+									<LoaderCircle
+										className="animate-spin"
+										data-icon="inline-start"
+									/>
+								) : (
+									<MailCheck data-icon="inline-start" />
+								)}
+								번호 받기
+							</Button>
+							<Button
+								className="h-11"
+								disabled={
+									!isDeleteEmailSent ||
+									isDeleteEmailVerified ||
+									validateDeleteUserEmailMutation.isPending ||
+									isDeleteAuthNumberInvalid
+								}
+								onClick={() => void onValidateDeleteEmail()}
+								type="button"
+								variant="outline"
+							>
+								{validateDeleteUserEmailMutation.isPending ? (
+									<LoaderCircle
+										className="animate-spin"
+										data-icon="inline-start"
+									/>
+								) : isDeleteEmailVerified ? (
+									<CheckCircle2 data-icon="inline-start" />
+								) : (
+									<ShieldCheck data-icon="inline-start" />
+								)}
+								인증 확인
+							</Button>
+						</div>
+						{showDeleteAuthNumberError ? (
+							<FieldError>인증번호 6자리를 입력해 주세요.</FieldError>
+						) : sendDeleteUserEmailMutation.error ? (
+							<FieldError>
+								{getApiErrorMessage(sendDeleteUserEmailMutation.error)}
+							</FieldError>
+						) : validateDeleteUserEmailMutation.error ? (
+							<FieldError>
+								{getApiErrorMessage(validateDeleteUserEmailMutation.error)}
+							</FieldError>
+						) : isDeleteEmailVerified ? (
+							<FieldDescription>이메일 인증이 완료되었습니다.</FieldDescription>
+						) : isDeleteEmailSent ? (
+							<FieldDescription>
+								메일로 받은 6자리 숫자를 입력해 주세요.
+							</FieldDescription>
+						) : (
+							<FieldDescription>
+								번호 받기를 눌러 이메일 인증번호를 받아 주세요.
+							</FieldDescription>
+						)}
+					</Field>
 					<Field data-invalid={Boolean(deleteConfirmError)}>
 						<FieldLabel htmlFor="delete-account-confirm">확인 문구</FieldLabel>
 						<Input

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -147,6 +147,7 @@ export function ProfileView() {
 	const projectGroupError = isSignedIn ? projectGroupQuery.error : null;
 	const isProjectGroupLoading = isSignedIn && projectGroupQuery.isLoading;
 	const hasCurrentTeam = Boolean(currentProjectGroup);
+	const isMatchingAccessBlocked = hasCurrentTeam || isProjectGroupLoading;
 	const showMockTeamPreview = useMockTeamSurface && hasCurrentTeam;
 	const isProfileDirty = currentUser
 		? form.description.trim() !== (currentUser.description ?? "") ||
@@ -304,10 +305,10 @@ export function ProfileView() {
 		<AppShell
 			actions={
 				<>
-					{hasCurrentTeam ? (
+					{isMatchingAccessBlocked ? (
 						<Button disabled variant="outline">
 							<ArrowRight data-icon="inline-start" />
-							매칭 잠김
+							{isProjectGroupLoading ? "팀 확인 중" : "매칭 잠김"}
 						</Button>
 					) : (
 						<Button asChild variant="outline">

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -1,5 +1,6 @@
 import {
 	type QueryClient,
+	type QueryKey,
 	useMutation,
 	useQuery,
 	useQueryClient,
@@ -48,11 +49,20 @@ const authQueryKeys = {
 	currentUser: ["users", "me"] as const,
 };
 
+function clearQueryData(queryClient: QueryClient, queryKey: QueryKey) {
+	const filters = { queryKey };
+
+	for (const query of queryClient.getQueryCache().findAll(filters)) {
+		query.reset();
+	}
+
+	queryClient.removeQueries(filters);
+}
+
 export function clearAuthScopedQueryData(queryClient: QueryClient) {
-	queryClient.removeQueries({ queryKey: authQueryKeys.currentUser });
-	queryClient.removeQueries({ queryKey: matchQueryKeys.all });
-	queryClient.removeQueries({ queryKey: projectGroupQueryKeys.all });
-	queryClient.setQueryData(projectGroupQueryKeys.me, null);
+	clearQueryData(queryClient, authQueryKeys.currentUser);
+	clearQueryData(queryClient, matchQueryKeys.all);
+	clearQueryData(queryClient, projectGroupQueryKeys.all);
 }
 
 export function useCurrentUserQuery() {

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -1,5 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	type QueryClient,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 
+import { matchQueryKeys } from "@/features/match/hooks/use-match-queries";
+import { projectGroupQueryKeys } from "@/features/project-groups/hooks/use-project-group-queries";
 import {
 	exchangeGithubOAuthCode,
 	login,
@@ -23,7 +30,6 @@ import {
 	updateCurrentUser,
 	validateDeleteUserEmail,
 } from "@/lib/api/users";
-import { projectGroupQueryKeys } from "@/features/project-groups/hooks/use-project-group-queries";
 import type {
 	CreateUserRequest,
 	GithubOAuthTokenRequest,
@@ -42,9 +48,9 @@ const authQueryKeys = {
 	currentUser: ["users", "me"] as const,
 };
 
-function clearProjectGroupQueryData(
-	queryClient: ReturnType<typeof useQueryClient>,
-) {
+export function clearAuthScopedQueryData(queryClient: QueryClient) {
+	queryClient.removeQueries({ queryKey: authQueryKeys.currentUser });
+	queryClient.removeQueries({ queryKey: matchQueryKeys.all });
 	queryClient.removeQueries({ queryKey: projectGroupQueryKeys.all });
 	queryClient.setQueryData(projectGroupQueryKeys.me, null);
 }
@@ -64,7 +70,7 @@ export function useLoginMutation() {
 		mutationFn: (payload: LoginRequest) => login(payload),
 		onSuccess: (response) => {
 			setAuthSession(response);
-			clearProjectGroupQueryData(queryClient);
+			clearAuthScopedQueryData(queryClient);
 			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
 		},
 	});
@@ -78,7 +84,7 @@ export function useGithubOAuthTokenMutation() {
 			exchangeGithubOAuthCode(payload),
 		onSuccess: (response) => {
 			setAuthSession(response);
-			clearProjectGroupQueryData(queryClient);
+			clearAuthScopedQueryData(queryClient);
 			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
 		},
 	});
@@ -168,10 +174,7 @@ export function useEditPasswordMutation() {
 		mutationFn: (payload: EditPasswordRequest) => editPassword(payload),
 		onSuccess: () => {
 			clearAuthSession();
-			clearProjectGroupQueryData(queryClient);
-			queryClient.removeQueries({
-				queryKey: authQueryKeys.currentUser,
-			});
+			clearAuthScopedQueryData(queryClient);
 		},
 	});
 }
@@ -196,10 +199,7 @@ export function useDeleteCurrentUserMutation() {
 		mutationFn: () => deleteCurrentUser(),
 		onSuccess: () => {
 			clearAuthSession();
-			clearProjectGroupQueryData(queryClient);
-			queryClient.removeQueries({
-				queryKey: authQueryKeys.currentUser,
-			});
+			clearAuthScopedQueryData(queryClient);
 		},
 	});
 }

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -23,6 +23,7 @@ import {
 	updateCurrentUser,
 	validateDeleteUserEmail,
 } from "@/lib/api/users";
+import { projectGroupQueryKeys } from "@/features/project-groups/hooks/use-project-group-queries";
 import type {
 	CreateUserRequest,
 	GithubOAuthTokenRequest,
@@ -41,6 +42,13 @@ const authQueryKeys = {
 	currentUser: ["users", "me"] as const,
 };
 
+function clearProjectGroupQueryData(
+	queryClient: ReturnType<typeof useQueryClient>,
+) {
+	queryClient.removeQueries({ queryKey: projectGroupQueryKeys.all });
+	queryClient.setQueryData(projectGroupQueryKeys.me, null);
+}
+
 export function useCurrentUserQuery() {
 	return useQuery({
 		enabled: Boolean(getAuthSession()),
@@ -56,6 +64,7 @@ export function useLoginMutation() {
 		mutationFn: (payload: LoginRequest) => login(payload),
 		onSuccess: (response) => {
 			setAuthSession(response);
+			clearProjectGroupQueryData(queryClient);
 			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
 		},
 	});
@@ -69,6 +78,7 @@ export function useGithubOAuthTokenMutation() {
 			exchangeGithubOAuthCode(payload),
 		onSuccess: (response) => {
 			setAuthSession(response);
+			clearProjectGroupQueryData(queryClient);
 			queryClient.invalidateQueries({ queryKey: authQueryKeys.currentUser });
 		},
 	});
@@ -158,6 +168,7 @@ export function useEditPasswordMutation() {
 		mutationFn: (payload: EditPasswordRequest) => editPassword(payload),
 		onSuccess: () => {
 			clearAuthSession();
+			clearProjectGroupQueryData(queryClient);
 			queryClient.removeQueries({
 				queryKey: authQueryKeys.currentUser,
 			});
@@ -185,6 +196,7 @@ export function useDeleteCurrentUserMutation() {
 		mutationFn: () => deleteCurrentUser(),
 		onSuccess: () => {
 			clearAuthSession();
+			clearProjectGroupQueryData(queryClient);
 			queryClient.removeQueries({
 				queryKey: authQueryKeys.currentUser,
 			});

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -17,7 +17,7 @@ import {
 	XCircle,
 } from "lucide-react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import {
 	AppPanel,
@@ -46,6 +46,7 @@ import {
 	useProjectRequestStatusQuery,
 	useRejectMatchMutation,
 } from "@/features/match/hooks/use-match-queries";
+import { useMyProjectGroupQuery } from "@/features/project-groups/hooks/use-project-group-queries";
 import { demoMatchOffer } from "@/features/team/lib/demo-team-space";
 import { getAuthSession, getAuthSessionUserId } from "@/lib/api/auth-session";
 import { getApiErrorMessage } from "@/lib/api/client";
@@ -56,6 +57,7 @@ import type {
 	MatchRole,
 	MatchStatus,
 } from "@/lib/types/match";
+import type { MyProjectGroup } from "@/lib/types/project-group";
 import type { MatchDecisionStatus } from "@/lib/types/team";
 import { cn } from "@/lib/utils";
 
@@ -118,10 +120,12 @@ const roleLabels: Record<MatchRole, string> = {
 };
 
 export function MatchRequestView() {
+	const navigate = useNavigate();
+	const isSignedIn = Boolean(getAuthSession());
 	const statusQuery = useProjectRequestStatusQuery();
+	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
 	const createMutation = useCreateProjectRequestMutation();
 	const cancelMutation = useCancelProjectRequestMutation();
-	const isSignedIn = Boolean(getAuthSession());
 	const currentUserId = getAuthSessionUserId();
 	const [form, setForm] = useState({
 		projectDescription: "",
@@ -141,6 +145,8 @@ export function MatchRequestView() {
 	const matchProjectQuery = useMatchProjectQuery(activeMatchId);
 	const acceptMutation = useAcceptMatchMutation(activeMatchId);
 	const rejectMutation = useRejectMatchMutation(activeMatchId);
+	const currentProjectGroup = projectGroupQuery.data ?? undefined;
+	const hasCurrentTeam = Boolean(currentProjectGroup);
 	const currentMatchMember =
 		currentUserId && matchMembersQuery.data
 			? matchMembersQuery.data.members.find(
@@ -149,14 +155,18 @@ export function MatchRequestView() {
 			: undefined;
 	const hasAcceptedTeam = offerStatus === "accepted";
 	const canCancel =
-		!hasAcceptedTeam && (status === "WAITING" || status === "MATCHING");
+		!hasCurrentTeam &&
+		!hasAcceptedTeam &&
+		(status === "WAITING" || status === "MATCHING");
 	const canRespondToMatch = Boolean(
-		activeMatchId &&
+		!hasCurrentTeam &&
+			activeMatchId &&
 			(!currentMatchMember ||
 				(!currentMatchMember.isHost && currentMatchMember.isAccepted !== true)),
 	);
 	const isSubmitDisabled =
 		!isSignedIn ||
+		hasCurrentTeam ||
 		hasAcceptedTeam ||
 		createMutation.isPending ||
 		Boolean(status && canCancel) ||
@@ -176,6 +186,38 @@ export function MatchRequestView() {
 			role: form.role,
 		});
 		setOfferStatus(apiConfig.useMocks ? "offered" : "hidden");
+	}
+
+	async function handleAcceptMatch() {
+		if (!activeMatchId) {
+			return;
+		}
+
+		await acceptMutation.mutateAsync();
+		const [membersResult, statusResult, projectGroupResult] = await Promise.all(
+			[
+				matchMembersQuery.refetch(),
+				statusQuery.refetch(),
+				projectGroupQuery.refetch(),
+			],
+		);
+		const members = membersResult.data?.members ?? [];
+		const everyoneAccepted =
+			members.length > 0 &&
+			members.every((member) => member.isHost || member.isAccepted === true);
+		const isTeamReady =
+			statusResult.data?.status === "MATCHED" ||
+			Boolean(projectGroupResult.data) ||
+			everyoneAccepted;
+
+		if (isTeamReady) {
+			navigate("/team", { replace: true });
+		}
+	}
+
+	function handleMockOfferAccept() {
+		setOfferStatus("accepted");
+		navigate("/team", { replace: true });
 	}
 
 	return (
@@ -199,48 +241,68 @@ export function MatchRequestView() {
 			title="매칭 요청"
 		>
 			<div className="grid gap-5">
+				{currentProjectGroup ? (
+					<CurrentTeamMatchLockPanel projectGroup={currentProjectGroup} />
+				) : null}
+
 				<div className="grid gap-4 md:grid-cols-4">
 					<MetricCard
 						label="요청 상태"
 						tone={
-							hasAcceptedTeam
+							hasCurrentTeam || hasAcceptedTeam
 								? "emerald"
 								: status === "MATCHING"
 									? "primary"
 									: "amber"
 						}
 						trend={
-							hasAcceptedTeam
-								? "팀 스페이스 열림"
-								: status
-									? statusMeta[status].description
-									: undefined
+							hasCurrentTeam
+								? "팀 스페이스에서 진행"
+								: hasAcceptedTeam
+									? "팀 스페이스 열림"
+									: status
+										? statusMeta[status].description
+										: undefined
 						}
 						value={
-							hasAcceptedTeam
+							hasCurrentTeam
 								? "팀 소속"
-								: status
-									? statusMeta[status].label
-									: "없음"
+								: hasAcceptedTeam
+									? "팀 소속"
+									: status
+										? statusMeta[status].label
+										: "없음"
 						}
 					/>
 					<MetricCard label="선택 역할" value={roleLabels[form.role]} />
 					<MetricCard
 						label="제안 상태"
-						tone={offerStatus === "accepted" ? "emerald" : "primary"}
+						tone={
+							hasCurrentTeam || offerStatus === "accepted"
+								? "emerald"
+								: "primary"
+						}
 						value={
-							offerStatus === "accepted"
-								? "수락 완료"
-								: offerStatus === "hidden"
-									? "대기"
-									: "도착"
+							hasCurrentTeam
+								? "잠김"
+								: offerStatus === "accepted"
+									? "수락 완료"
+									: offerStatus === "hidden"
+										? "대기"
+										: "도착"
 						}
 					/>
 					<MetricCard
 						label="팀 생성"
-						tone={hasAcceptedTeam ? "emerald" : "primary"}
-						trend={hasAcceptedTeam ? "팀으로 이동 가능" : "수락 후 생성"}
-						value={hasAcceptedTeam ? "가능" : "대기"}
+						tone={hasCurrentTeam || hasAcceptedTeam ? "emerald" : "primary"}
+						trend={
+							hasCurrentTeam
+								? "이미 팀 스페이스 보유"
+								: hasAcceptedTeam
+									? "팀으로 이동 가능"
+									: "수락 후 생성"
+						}
+						value={hasCurrentTeam || hasAcceptedTeam ? "가능" : "대기"}
 					/>
 				</div>
 
@@ -265,240 +327,7 @@ export function MatchRequestView() {
 					</AppPanel>
 				) : null}
 
-				<div className="grid gap-5 xl:grid-cols-[0.88fr_1.12fr] xl:items-start">
-					<div className="grid gap-5">
-						<AppPanel>
-							<AppPanelHeader
-								action={
-									<Button
-										disabled={!isSignedIn || statusQuery.isFetching}
-										onClick={() => void statusQuery.refetch()}
-										type="button"
-										variant="outline"
-									>
-										<RefreshCcw data-icon="inline-start" />
-										새로고침
-									</Button>
-								}
-								description="이미 팀이 있거나 진행 중인 요청이 있으면 새 신청 대신 현재 흐름을 먼저 마무리합니다."
-								eyebrow="Queue status"
-								title="내 매칭 상태"
-							/>
-							<div className="grid gap-4 p-5">
-								{hasAcceptedTeam ? (
-									<StatusPanel
-										description="전원 수락이 완료되어 팀 스페이스가 열렸습니다."
-										icon={<CheckCircle2 />}
-										label="팀 소속"
-										tone="border-emerald-500/25 bg-emerald-50 text-emerald-700"
-									/>
-								) : statusQuery.isLoading ? (
-									<StatusPanel
-										description="내 요청이 대기 중인지 확인하고 있습니다."
-										icon={<LoaderCircle className="animate-spin" />}
-										label="조회 중"
-									/>
-								) : status ? (
-									<StatusPanel
-										description={statusMeta[status].description}
-										label={statusMeta[status].label}
-										tone={statusMeta[status].tone}
-									/>
-								) : noActiveRequest || !isSignedIn ? (
-									<StatusPanel
-										description="진행 중인 매칭 요청이 없습니다."
-										icon={<Square />}
-										label="요청 없음"
-									/>
-								) : statusQuery.isError ? (
-									<StatusPanel
-										description={getApiErrorMessage(statusQuery.error)}
-										label="조회 실패"
-										tone="border-destructive/25 bg-destructive/10 text-destructive"
-									/>
-								) : null}
-
-								<Button
-									disabled={!canCancel || cancelMutation.isPending}
-									onClick={() => {
-										setOfferStatus("hidden");
-										void cancelMutation.mutateAsync();
-									}}
-									type="button"
-									variant="outline"
-								>
-									{cancelMutation.isPending ? (
-										<LoaderCircle
-											className="animate-spin"
-											data-icon="inline-start"
-										/>
-									) : (
-										<Square data-icon="inline-start" />
-									)}
-									요청 취소
-								</Button>
-
-								{cancelMutation.error ? (
-									<FieldError>
-										{getApiErrorMessage(cancelMutation.error)}
-									</FieldError>
-								) : null}
-							</div>
-						</AppPanel>
-
-						{apiConfig.useMocks && offerStatus !== "hidden" ? (
-							<MatchOfferPanel
-								onAccept={() => setOfferStatus("accepted")}
-								onDecline={() => setOfferStatus("declined")}
-								onReset={() => setOfferStatus("offered")}
-								status={offerStatus}
-							/>
-						) : (
-							<MatchOfferPlaceholder
-								canPreview={isSignedIn && apiConfig.useMocks}
-								onPreview={() => setOfferStatus("offered")}
-								showPreviewAction={apiConfig.useMocks}
-							/>
-						)}
-					</div>
-
-					<AppPanel>
-						<AppPanelHeader
-							description="역할만 선택해도 대기열에 등록됩니다. 프로젝트를 제안하려면 제목, 설명, MVP를 모두 입력해 주세요."
-							eyebrow="Request"
-							title="매칭 요청 작성"
-						/>
-						<form
-							className="grid gap-6 p-5"
-							onSubmit={(event) => void handleSubmit(event)}
-						>
-							<FieldGroup>
-								<Field>
-									<FieldLabel>참여 역할</FieldLabel>
-									<div className="grid gap-3 lg:grid-cols-3">
-										{roleOptions.map((role) => (
-											<RoleCard
-												active={form.role === role.value}
-												key={role.value}
-												onClick={() =>
-													setForm((current) => ({
-														...current,
-														role: role.value,
-													}))
-												}
-												role={role}
-											/>
-										))}
-									</div>
-								</Field>
-
-								<Field>
-									<FieldLabel htmlFor="project-title">
-										프로젝트 제목
-										<Badge
-											aria-hidden="true"
-											className="ml-2 font-display"
-											variant="neutral"
-										>
-											선택
-										</Badge>
-									</FieldLabel>
-									<Input
-										className="h-11 bg-white"
-										id="project-title"
-										onChange={(event) =>
-											setForm((current) => ({
-												...current,
-												projectTitle: event.target.value,
-											}))
-										}
-										placeholder="예: 개발자 사이드 프로젝트 팀빌딩 서비스"
-										value={form.projectTitle}
-									/>
-								</Field>
-
-								<Field>
-									<FieldLabel htmlFor="project-description">
-										프로젝트 설명
-										<Badge
-											aria-hidden="true"
-											className="ml-2 font-display"
-											variant="neutral"
-										>
-											선택
-										</Badge>
-									</FieldLabel>
-									<textarea
-										className="min-h-28 rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-										id="project-description"
-										onChange={(event) =>
-											setForm((current) => ({
-												...current,
-												projectDescription: event.target.value,
-											}))
-										}
-										placeholder="어떤 문제를 해결하고 싶은지 간단히 적어주세요."
-										value={form.projectDescription}
-									/>
-								</Field>
-
-								<Field>
-									<FieldLabel htmlFor="project-mvp">
-										MVP 범위
-										<Badge
-											aria-hidden="true"
-											className="ml-2 font-display"
-											variant="neutral"
-										>
-											선택
-										</Badge>
-									</FieldLabel>
-									<textarea
-										className="min-h-24 rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-										id="project-mvp"
-										onChange={(event) =>
-											setForm((current) => ({
-												...current,
-												projectMvp: event.target.value,
-											}))
-										}
-										placeholder="첫 버전에서 꼭 만들고 싶은 기능을 적어주세요."
-										value={form.projectMvp}
-									/>
-									<FieldDescription>
-										프로젝트 정보는 모두 비우거나 제목, 설명, MVP를 모두 입력해
-										주세요.
-									</FieldDescription>
-									{projectInfoError ? (
-										<FieldError>{projectInfoError}</FieldError>
-									) : null}
-								</Field>
-							</FieldGroup>
-
-							{createMutation.error ? (
-								<FieldError>
-									{getApiErrorMessage(createMutation.error)}
-								</FieldError>
-							) : null}
-
-							<Button disabled={isSubmitDisabled} size="lg" type="submit">
-								{createMutation.isPending ? (
-									<LoaderCircle
-										className="animate-spin"
-										data-icon="inline-start"
-									/>
-								) : (
-									<Send data-icon="inline-start" />
-								)}
-								{hasAcceptedTeam
-									? "이미 팀에 참여 중입니다"
-									: "매칭 요청 보내기"}
-							</Button>
-						</form>
-					</AppPanel>
-				</div>
-
-				{activeMatchId ? (
+				{activeMatchId && !hasCurrentTeam ? (
 					<MatchSessionCard
 						canRespond={canRespondToMatch}
 						currentMember={currentMatchMember}
@@ -506,7 +335,7 @@ export function MatchRequestView() {
 						members={matchMembersQuery.data?.members}
 						membersError={matchMembersQuery.error}
 						membersLoading={matchMembersQuery.isLoading}
-						onAccept={() => void acceptMutation.mutateAsync()}
+						onAccept={() => void handleAcceptMatch()}
 						onReject={() => void rejectMutation.mutateAsync()}
 						project={matchProjectQuery.data}
 						projectError={matchProjectQuery.error}
@@ -517,8 +346,283 @@ export function MatchRequestView() {
 						}
 					/>
 				) : null}
+
+				{hasCurrentTeam ? null : (
+					<div className="grid gap-5 xl:grid-cols-[0.88fr_1.12fr] xl:items-start">
+						<div className="grid gap-5">
+							<AppPanel>
+								<AppPanelHeader
+									action={
+										<Button
+											disabled={!isSignedIn || statusQuery.isFetching}
+											onClick={() => void statusQuery.refetch()}
+											type="button"
+											variant="outline"
+										>
+											<RefreshCcw data-icon="inline-start" />
+											새로고침
+										</Button>
+									}
+									description="이미 팀이 있거나 진행 중인 요청이 있으면 새 신청 대신 현재 흐름을 먼저 마무리합니다."
+									eyebrow="Queue status"
+									title="내 매칭 상태"
+								/>
+								<div className="grid gap-4 p-5">
+									{hasAcceptedTeam ? (
+										<StatusPanel
+											description="전원 수락이 완료되어 팀 스페이스가 열렸습니다."
+											icon={<CheckCircle2 />}
+											label="팀 소속"
+											tone="border-emerald-500/25 bg-emerald-50 text-emerald-700"
+										/>
+									) : statusQuery.isLoading ? (
+										<StatusPanel
+											description="내 요청이 대기 중인지 확인하고 있습니다."
+											icon={<LoaderCircle className="animate-spin" />}
+											label="조회 중"
+										/>
+									) : status ? (
+										<StatusPanel
+											description={statusMeta[status].description}
+											label={statusMeta[status].label}
+											tone={statusMeta[status].tone}
+										/>
+									) : noActiveRequest || !isSignedIn ? (
+										<StatusPanel
+											description="진행 중인 매칭 요청이 없습니다."
+											icon={<Square />}
+											label="요청 없음"
+										/>
+									) : statusQuery.isError ? (
+										<StatusPanel
+											description={getApiErrorMessage(statusQuery.error)}
+											label="조회 실패"
+											tone="border-destructive/25 bg-destructive/10 text-destructive"
+										/>
+									) : null}
+
+									<Button
+										disabled={!canCancel || cancelMutation.isPending}
+										onClick={() => {
+											setOfferStatus("hidden");
+											void cancelMutation.mutateAsync();
+										}}
+										type="button"
+										variant="outline"
+									>
+										{cancelMutation.isPending ? (
+											<LoaderCircle
+												className="animate-spin"
+												data-icon="inline-start"
+											/>
+										) : (
+											<Square data-icon="inline-start" />
+										)}
+										요청 취소
+									</Button>
+
+									{cancelMutation.error ? (
+										<FieldError>
+											{getApiErrorMessage(cancelMutation.error)}
+										</FieldError>
+									) : null}
+								</div>
+							</AppPanel>
+
+							{apiConfig.useMocks && offerStatus !== "hidden" ? (
+								<MatchOfferPanel
+									onAccept={handleMockOfferAccept}
+									onDecline={() => setOfferStatus("declined")}
+									onReset={() => setOfferStatus("offered")}
+									status={offerStatus}
+								/>
+							) : (
+								<MatchOfferPlaceholder
+									canPreview={isSignedIn && apiConfig.useMocks}
+									onPreview={() => setOfferStatus("offered")}
+									showPreviewAction={apiConfig.useMocks}
+								/>
+							)}
+						</div>
+
+						<AppPanel>
+							<AppPanelHeader
+								description="역할만 선택해도 대기열에 등록됩니다. 프로젝트를 제안하려면 제목, 설명, MVP를 모두 입력해 주세요."
+								eyebrow="Request"
+								title="매칭 요청 작성"
+							/>
+							<form
+								className="grid gap-6 p-5"
+								onSubmit={(event) => void handleSubmit(event)}
+							>
+								<FieldGroup>
+									<Field>
+										<FieldLabel>참여 역할</FieldLabel>
+										<div className="grid gap-3 lg:grid-cols-3">
+											{roleOptions.map((role) => (
+												<RoleCard
+													active={form.role === role.value}
+													key={role.value}
+													onClick={() =>
+														setForm((current) => ({
+															...current,
+															role: role.value,
+														}))
+													}
+													role={role}
+												/>
+											))}
+										</div>
+									</Field>
+
+									<Field>
+										<FieldLabel htmlFor="project-title">
+											프로젝트 제목
+											<Badge
+												aria-hidden="true"
+												className="ml-2 font-display"
+												variant="neutral"
+											>
+												선택
+											</Badge>
+										</FieldLabel>
+										<Input
+											className="h-11 bg-white"
+											id="project-title"
+											onChange={(event) =>
+												setForm((current) => ({
+													...current,
+													projectTitle: event.target.value,
+												}))
+											}
+											placeholder="예: 개발자 사이드 프로젝트 팀빌딩 서비스"
+											value={form.projectTitle}
+										/>
+									</Field>
+
+									<Field>
+										<FieldLabel htmlFor="project-description">
+											프로젝트 설명
+											<Badge
+												aria-hidden="true"
+												className="ml-2 font-display"
+												variant="neutral"
+											>
+												선택
+											</Badge>
+										</FieldLabel>
+										<textarea
+											className="min-h-28 rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+											id="project-description"
+											onChange={(event) =>
+												setForm((current) => ({
+													...current,
+													projectDescription: event.target.value,
+												}))
+											}
+											placeholder="어떤 문제를 해결하고 싶은지 간단히 적어주세요."
+											value={form.projectDescription}
+										/>
+									</Field>
+
+									<Field>
+										<FieldLabel htmlFor="project-mvp">
+											MVP 범위
+											<Badge
+												aria-hidden="true"
+												className="ml-2 font-display"
+												variant="neutral"
+											>
+												선택
+											</Badge>
+										</FieldLabel>
+										<textarea
+											className="min-h-24 rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+											id="project-mvp"
+											onChange={(event) =>
+												setForm((current) => ({
+													...current,
+													projectMvp: event.target.value,
+												}))
+											}
+											placeholder="첫 버전에서 꼭 만들고 싶은 기능을 적어주세요."
+											value={form.projectMvp}
+										/>
+										<FieldDescription>
+											프로젝트 정보는 모두 비우거나 제목, 설명, MVP를 모두
+											입력해 주세요.
+										</FieldDescription>
+										{projectInfoError ? (
+											<FieldError>{projectInfoError}</FieldError>
+										) : null}
+									</Field>
+								</FieldGroup>
+
+								{createMutation.error ? (
+									<FieldError>
+										{getApiErrorMessage(createMutation.error)}
+									</FieldError>
+								) : null}
+
+								<Button disabled={isSubmitDisabled} size="lg" type="submit">
+									{createMutation.isPending ? (
+										<LoaderCircle
+											className="animate-spin"
+											data-icon="inline-start"
+										/>
+									) : (
+										<Send data-icon="inline-start" />
+									)}
+									{hasAcceptedTeam
+										? "이미 팀에 참여 중입니다"
+										: "매칭 요청 보내기"}
+								</Button>
+							</form>
+						</AppPanel>
+					</div>
+				)}
 			</div>
 		</AppShell>
+	);
+}
+
+function CurrentTeamMatchLockPanel({
+	projectGroup,
+}: {
+	projectGroup: MyProjectGroup;
+}) {
+	return (
+		<AppPanel className="border-primary/20">
+			<AppPanelHeader
+				action={
+					<Button asChild>
+						<Link to="/team">
+							<UsersRound data-icon="inline-start" />팀 스페이스 열기
+						</Link>
+					</Button>
+				}
+				description="팀 스페이스가 있는 사용자는 새 매칭을 시작하지 않습니다."
+				eyebrow="Matching locked"
+				title="이미 참여 중인 팀이 있습니다"
+			/>
+			<div className="grid gap-4 p-5 md:grid-cols-[1fr_auto] md:items-center">
+				<div>
+					<p className="text-lg font-semibold text-brand-ink">
+						{projectGroup.projectName}
+					</p>
+					<p className="mt-2 text-sm leading-6 text-muted-foreground">
+						{projectGroup.projectDescription ??
+							"팀 스페이스에서 현재 프로젝트 진행 상황을 확인하세요."}
+					</p>
+				</div>
+				<div className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-center">
+					<p className="font-mono text-3xl font-semibold text-primary">
+						{projectGroup.members.length}
+					</p>
+					<p className="mt-1 text-xs font-semibold text-primary">팀원</p>
+				</div>
+			</div>
+		</AppPanel>
 	);
 }
 

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -152,6 +152,8 @@ export function MatchRequestView() {
 		? (projectGroupQuery.data ?? undefined)
 		: undefined;
 	const hasCurrentTeam = Boolean(currentProjectGroup);
+	const isCheckingCurrentTeam = isSignedIn && projectGroupQuery.isLoading;
+	const isMatchingAccessBlocked = hasCurrentTeam || isCheckingCurrentTeam;
 	const currentMatchMember =
 		currentUserId && matchMembersQuery.data
 			? matchMembersQuery.data.members.find(
@@ -160,18 +162,18 @@ export function MatchRequestView() {
 			: undefined;
 	const hasAcceptedTeam = offerStatus === "accepted";
 	const canCancel =
-		!hasCurrentTeam &&
+		!isMatchingAccessBlocked &&
 		!hasAcceptedTeam &&
 		(status === "WAITING" || status === "MATCHING");
 	const canRespondToMatch = Boolean(
-		!hasCurrentTeam &&
+		!isMatchingAccessBlocked &&
 			activeMatchId &&
 			(!currentMatchMember ||
 				(!currentMatchMember.isHost && currentMatchMember.isAccepted !== true)),
 	);
 	const isSubmitDisabled =
 		!isSignedIn ||
-		hasCurrentTeam ||
+		isMatchingAccessBlocked ||
 		hasAcceptedTeam ||
 		createMutation.isPending ||
 		Boolean(status && canCancel) ||
@@ -249,6 +251,7 @@ export function MatchRequestView() {
 				{currentProjectGroup ? (
 					<CurrentTeamMatchLockPanel projectGroup={currentProjectGroup} />
 				) : null}
+				{isCheckingCurrentTeam ? <CurrentTeamCheckPanel /> : null}
 
 				<div className="grid gap-4 md:grid-cols-4">
 					<MetricCard
@@ -261,22 +264,26 @@ export function MatchRequestView() {
 									: "amber"
 						}
 						trend={
-							hasCurrentTeam
-								? "팀 스페이스에서 진행"
-								: hasAcceptedTeam
-									? "팀 스페이스 열림"
-									: status
-										? statusMeta[status].description
-										: undefined
+							isCheckingCurrentTeam
+								? "팀 소속 여부 확인 중"
+								: hasCurrentTeam
+									? "팀 스페이스에서 진행"
+									: hasAcceptedTeam
+										? "팀 스페이스 열림"
+										: status
+											? statusMeta[status].description
+											: undefined
 						}
 						value={
-							hasCurrentTeam
-								? "팀 소속"
-								: hasAcceptedTeam
+							isCheckingCurrentTeam
+								? "확인 중"
+								: hasCurrentTeam
 									? "팀 소속"
-									: status
-										? statusMeta[status].label
-										: "없음"
+									: hasAcceptedTeam
+										? "팀 소속"
+										: status
+											? statusMeta[status].label
+											: "없음"
 						}
 					/>
 					<MetricCard label="선택 역할" value={roleLabels[form.role]} />
@@ -332,7 +339,7 @@ export function MatchRequestView() {
 					</AppPanel>
 				) : null}
 
-				{activeMatchId && !hasCurrentTeam ? (
+				{activeMatchId && !isMatchingAccessBlocked ? (
 					<MatchSessionCard
 						canRespond={canRespondToMatch}
 						currentMember={currentMatchMember}
@@ -352,7 +359,7 @@ export function MatchRequestView() {
 					/>
 				) : null}
 
-				{hasCurrentTeam ? null : (
+				{isMatchingAccessBlocked ? null : (
 					<div className="grid gap-5 xl:grid-cols-[0.88fr_1.12fr] xl:items-start">
 						<div className="grid gap-5">
 							<AppPanel>
@@ -626,6 +633,24 @@ function CurrentTeamMatchLockPanel({
 					</p>
 					<p className="mt-1 text-xs font-semibold text-primary">팀원</p>
 				</div>
+			</div>
+		</AppPanel>
+	);
+}
+
+function CurrentTeamCheckPanel() {
+	return (
+		<AppPanel>
+			<div className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
+				<div>
+					<h2 className="text-xl font-semibold text-brand-ink">
+						팀 상태를 확인하고 있습니다
+					</h2>
+					<p className="mt-1 text-sm leading-6 text-muted-foreground">
+						이미 팀 스페이스가 있는지 확인한 뒤 매칭 요청을 열겠습니다.
+					</p>
+				</div>
+				<LoaderCircle className="size-5 animate-spin text-primary" />
 			</div>
 		</AppPanel>
 	);

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -137,15 +137,20 @@ export function MatchRequestView() {
 		"hidden" | "offered" | "accepted" | "declined"
 	>("hidden");
 	const projectInfoError = getProjectInfoError(form);
-	const noActiveRequest = statusQuery.data === null;
-	const status = statusQuery.data?.status;
+	const projectRequestStatus = isSignedIn ? statusQuery.data : null;
+	const noActiveRequest = projectRequestStatus === null;
+	const status = projectRequestStatus?.status;
 	const activeMatchId =
-		statusQuery.data?.status === "MATCHING" ? statusQuery.data.matchId : null;
+		projectRequestStatus?.status === "MATCHING"
+			? projectRequestStatus.matchId
+			: null;
 	const matchMembersQuery = useMatchMembersQuery(activeMatchId);
 	const matchProjectQuery = useMatchProjectQuery(activeMatchId);
 	const acceptMutation = useAcceptMatchMutation(activeMatchId);
 	const rejectMutation = useRejectMatchMutation(activeMatchId);
-	const currentProjectGroup = projectGroupQuery.data ?? undefined;
+	const currentProjectGroup = isSignedIn
+		? (projectGroupQuery.data ?? undefined)
+		: undefined;
 	const hasCurrentTeam = Boolean(currentProjectGroup);
 	const currentMatchMember =
 		currentUserId && matchMembersQuery.data

--- a/src/features/match/hooks/use-match-queries.ts
+++ b/src/features/match/hooks/use-match-queries.ts
@@ -19,6 +19,7 @@ import type {
 } from "@/lib/types/match";
 
 export const matchQueryKeys = {
+	all: ["match"] as const,
 	members: (matchId: number) => ["match", matchId, "members"] as const,
 	project: (matchId: number) => ["match", matchId, "project"] as const,
 	status: ["match", "status"] as const,

--- a/src/features/project-groups/hooks/use-project-group-queries.ts
+++ b/src/features/project-groups/hooks/use-project-group-queries.ts
@@ -6,17 +6,33 @@ import {
 	revokeProjectGroupAdminPermission,
 } from "@/lib/api/project-groups";
 import type { ProjectGroupAdminPermissionRequest } from "@/lib/types/project-group";
+import { isProjectGroupNotFoundError } from "@/features/project-groups/lib/errors";
 
 export const projectGroupQueryKeys = {
 	all: ["project-groups"] as const,
 	me: ["project-groups", "me"] as const,
 };
 
+const projectGroupLookupStaleTimeMs = 30_000;
+
 export function useMyProjectGroupQuery(enabled = true) {
 	return useQuery({
 		enabled,
-		queryFn: () => getMyProjectGroup(),
+		queryFn: async () => {
+			try {
+				return await getMyProjectGroup();
+			} catch (error) {
+				if (isProjectGroupNotFoundError(error)) {
+					return null;
+				}
+
+				throw error;
+			}
+		},
 		queryKey: projectGroupQueryKeys.me,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: projectGroupLookupStaleTimeMs,
 	});
 }
 

--- a/src/features/project-groups/lib/errors.ts
+++ b/src/features/project-groups/lib/errors.ts
@@ -1,0 +1,8 @@
+import { ApiError } from "@/lib/api/client";
+
+export function isProjectGroupNotFoundError(error: unknown) {
+	return (
+		error instanceof ApiError &&
+		(error.status === 404 || error.code === "PROJECT_GROUP_NOT_FOUND")
+	);
+}

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -128,7 +128,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 		useRevokeProjectGroupAdminPermissionMutation();
 	const [adminPermissionFeedback, setAdminPermissionFeedback] =
 		useState<AdminPermissionFeedback | null>(null);
-	const projectGroup = projectGroupQuery.data;
+	const projectGroup = isSignedIn ? projectGroupQuery.data : null;
 	const currentMember = useMemo(
 		() =>
 			projectGroup?.members.find(

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -39,6 +39,97 @@ let deleteEmailAuthSentUserId: number | null = null;
 let deleteEmailVerifiedUserId: number | null = null;
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
 
+function createGithubLoginUser() {
+	return createPreviewUser({
+		email: "github.dev@teampo.dev",
+		githubUsername: "github_runner",
+		isGithubLinked: true,
+		isGithubLogin: true,
+		nickname: "github_runner",
+		profileImage: "https://i.pravatar.cc/240?img=32",
+	});
+}
+
+function createGithubOnboardingUser(level: number) {
+	return createPreviewUser({
+		description: null,
+		email: "new.github.dev@teampo.dev",
+		githubUsername: "new_github_runner",
+		isGithubLinked: true,
+		isGithubLogin: true,
+		level,
+		nickname: "new_github_runner",
+		profileImage: "https://i.pravatar.cc/240?img=47",
+	});
+}
+
+function syncSessionFromRequest(request: Request) {
+	const requestUserId = getUserIdFromAuthorizationHeader(request);
+
+	if (!requestUserId || requestUserId === currentUserId) {
+		return;
+	}
+
+	if (requestUserId === 1) {
+		currentUser = createPreviewUser();
+		currentUserId = 1;
+		currentPassword = previewAuthSeed.password;
+		resetDeleteEmailState();
+		resetMatchState();
+		activeProjectGroup = createMockProjectGroup();
+		return;
+	}
+
+	if (requestUserId === 5) {
+		currentUser = createGithubLoginUser();
+		currentUserId = 5;
+		resetDeleteEmailState();
+		resetMatchState();
+		activeProjectGroup = null;
+		return;
+	}
+
+	if (requestUserId === 6) {
+		currentUser = createGithubOnboardingUser(3);
+		currentUserId = 6;
+		resetDeleteEmailState();
+		resetMatchState();
+		activeProjectGroup = null;
+	}
+}
+
+function getUserIdFromAuthorizationHeader(request: Request) {
+	const authorization = request.headers.get("Authorization");
+	const accessToken = authorization?.match(/^Bearer\s+(.+)$/i)?.[1];
+	const payload = accessToken?.split(".")[1];
+
+	if (!payload) {
+		return null;
+	}
+
+	try {
+		const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/");
+		const paddedPayload = normalizedPayload.padEnd(
+			Math.ceil(normalizedPayload.length / 4) * 4,
+			"=",
+		);
+		const parsedPayload = JSON.parse(atob(paddedPayload)) as unknown;
+
+		if (
+			typeof parsedPayload === "object" &&
+			parsedPayload !== null &&
+			"userId" in parsedPayload
+		) {
+			const userId = parsedPayload.userId;
+			return typeof userId === "number" ? userId : null;
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
+}
+
 function buildErrorResponse(
 	status: number,
 	message: string,
@@ -110,6 +201,13 @@ function resetDeleteEmailState() {
 	deleteEmailVerifiedUserId = null;
 }
 
+function resetMatchState() {
+	matchStatus = null;
+	activeMatchId = null;
+	activeMatchMembers = [];
+	activeMatchProject = null;
+}
+
 function isValidMatchRole(value: string): value is MatchRole {
 	return ["BACKEND", "FRONTEND", "DESIGN"].includes(value);
 }
@@ -133,6 +231,8 @@ function hasPartialProjectInfo(body: ProjectRequestPayload) {
 }
 
 function createMockMatchSession(body: ProjectRequestPayload) {
+	const isCurrentUserLastResponder = currentUser?.isGithubLogin === true;
+
 	activeMatchId = 42;
 	activeMatchProject = {
 		matchId: activeMatchId,
@@ -144,48 +244,91 @@ function createMockMatchSession(body: ProjectRequestPayload) {
 			"프로필 기반 매칭 요청, 팀원 응답, 팀 스페이스 생성까지 연결합니다.",
 		projectTitle: body.projectTitle ?? "Team-po 매칭 실험",
 	};
-	activeMatchMembers = [
-		{
-			isAccepted: hasCompleteProjectInfo(body) ? true : null,
-			isHost: hasCompleteProjectInfo(body),
-			level: currentUser?.level ?? 3,
-			nickname: currentUser?.nickname ?? "preview",
-			profileImageKey: currentUser?.profileImage ?? null,
-			role: body.role,
-			temperature: currentUser?.temperature ?? 50,
-			userId: currentUserId,
-		},
-		{
-			isAccepted: true,
-			isHost: !hasCompleteProjectInfo(body),
-			level: 4,
-			nickname: "api_builder",
-			profileImageKey: null,
-			role: "BACKEND",
-			temperature: 53,
-			userId: 2,
-		},
-		{
-			isAccepted: null,
-			isHost: false,
-			level: 3,
-			nickname: "pixel_runner",
-			profileImageKey: null,
-			role: "FRONTEND",
-			temperature: 49,
-			userId: 3,
-		},
-		{
-			isAccepted: null,
-			isHost: false,
-			level: 2,
-			nickname: "flow_designer",
-			profileImageKey: null,
-			role: "DESIGN",
-			temperature: 51,
-			userId: 4,
-		},
-	];
+	activeMatchMembers = isCurrentUserLastResponder
+		? [
+				{
+					isAccepted: true,
+					isHost: true,
+					level: 4,
+					nickname: "api_builder",
+					profileImageKey: null,
+					role: "BACKEND",
+					temperature: 53,
+					userId: 2,
+				},
+				{
+					isAccepted: true,
+					isHost: false,
+					level: 3,
+					nickname: "pixel_runner",
+					profileImageKey: null,
+					role: "FRONTEND",
+					temperature: 49,
+					userId: 3,
+				},
+				{
+					isAccepted: true,
+					isHost: false,
+					level: 2,
+					nickname: "flow_designer",
+					profileImageKey: null,
+					role: "DESIGN",
+					temperature: 51,
+					userId: 4,
+				},
+				{
+					isAccepted: null,
+					isHost: false,
+					level: currentUser?.level ?? 3,
+					nickname: currentUser?.nickname ?? "preview",
+					profileImageKey: currentUser?.profileImage ?? null,
+					role: body.role,
+					temperature: currentUser?.temperature ?? 50,
+					userId: currentUserId,
+				},
+			]
+		: [
+				{
+					isAccepted: hasCompleteProjectInfo(body) ? true : null,
+					isHost: hasCompleteProjectInfo(body),
+					level: currentUser?.level ?? 3,
+					nickname: currentUser?.nickname ?? "preview",
+					profileImageKey: currentUser?.profileImage ?? null,
+					role: body.role,
+					temperature: currentUser?.temperature ?? 50,
+					userId: currentUserId,
+				},
+				{
+					isAccepted: true,
+					isHost: !hasCompleteProjectInfo(body),
+					level: 4,
+					nickname: "api_builder",
+					profileImageKey: null,
+					role: "BACKEND",
+					temperature: 53,
+					userId: 2,
+				},
+				{
+					isAccepted: null,
+					isHost: false,
+					level: 3,
+					nickname: "pixel_runner",
+					profileImageKey: null,
+					role: "FRONTEND",
+					temperature: 49,
+					userId: 3,
+				},
+				{
+					isAccepted: null,
+					isHost: false,
+					level: 2,
+					nickname: "flow_designer",
+					profileImageKey: null,
+					role: "DESIGN",
+					temperature: 51,
+					userId: 4,
+				},
+			];
 }
 
 function createMockProjectGroup(): MyProjectGroup {
@@ -242,6 +385,49 @@ function createMockProjectGroup(): MyProjectGroup {
 	};
 }
 
+function createProjectGroupFromActiveMatch(): MyProjectGroup | null {
+	if (!activeMatchProject || activeMatchMembers.length === 0) {
+		return null;
+	}
+
+	const hostMember =
+		activeMatchMembers.find((member) => member.isHost) ?? activeMatchMembers[0];
+
+	return {
+		currentUserId,
+		members: activeMatchMembers.map((member) => ({
+			admin: member.isHost,
+			groupRole: member.isHost ? "HOST" : "MEMBER",
+			level: member.level,
+			memberRole: member.role,
+			nickname: member.nickname,
+			profileImage: member.profileImageKey,
+			temperature: member.temperature,
+			userId: member.userId,
+		})),
+		projectDescription: activeMatchProject.projectDescription,
+		projectGroupId: 10,
+		projectMvp: activeMatchProject.projectMvp,
+		projectName: `${hostMember.nickname} 팀`,
+		projectTitle: activeMatchProject.projectTitle,
+	};
+}
+
+function completeMatchIfEveryoneAccepted() {
+	const everyoneAccepted =
+		activeMatchMembers.length > 0 &&
+		activeMatchMembers.every(
+			(member) => member.isHost || member.isAccepted === true,
+		);
+
+	if (!everyoneAccepted) {
+		return;
+	}
+
+	matchStatus = "MATCHED";
+	activeProjectGroup = createProjectGroupFromActiveMatch();
+}
+
 export const handlers = [
 	http.post(getPath("/users/sign-in"), async ({ request }) => {
 		const body = (await request.json()) as LoginRequest;
@@ -256,19 +442,33 @@ export const handlers = [
 			);
 		}
 
-		if (!currentUser) {
-			return buildErrorResponse(
-				401,
-				"이메일 또는 비밀번호가 올바르지 않습니다.",
-				"INVALID_CREDENTIALS",
-			);
-		}
-
 		if (!isValidEmail(body.email) || body.password.length < 8) {
 			return buildErrorResponse(
 				400,
 				"입력한 정보를 다시 확인해 주세요.",
 				"INVALID_INPUT_FIELD",
+			);
+		}
+
+		if (
+			normalizeEmail(body.email) === previewAuthSeed.email &&
+			body.password === previewAuthSeed.password
+		) {
+			currentUserId = 1;
+			currentUser = createPreviewUser();
+			currentPassword = previewAuthSeed.password;
+			resetDeleteEmailState();
+			resetMatchState();
+			activeProjectGroup = createMockProjectGroup();
+
+			return HttpResponse.json(buildSession());
+		}
+
+		if (!currentUser) {
+			return buildErrorResponse(
+				401,
+				"이메일 또는 비밀번호가 올바르지 않습니다.",
+				"INVALID_CREDENTIALS",
 			);
 		}
 
@@ -300,16 +500,11 @@ export const handlers = [
 		}
 
 		if (body.code === "mock-github-login-code") {
-			currentUser = createPreviewUser({
-				email: "github.dev@teampo.dev",
-				githubUsername: "github_runner",
-				isGithubLinked: true,
-				isGithubLogin: true,
-				nickname: "github_runner",
-				profileImage: "https://i.pravatar.cc/240?img=32",
-			});
+			currentUser = createGithubLoginUser();
 			currentUserId = 5;
 			resetDeleteEmailState();
+			resetMatchState();
+			activeProjectGroup = null;
 
 			return HttpResponse.json(buildSession());
 		}
@@ -324,18 +519,11 @@ export const handlers = [
 				);
 			}
 
-			currentUser = createPreviewUser({
-				description: null,
-				email: "new.github.dev@teampo.dev",
-				githubUsername: "new_github_runner",
-				isGithubLinked: true,
-				isGithubLogin: true,
-				level: body.level,
-				nickname: "new_github_runner",
-				profileImage: "https://i.pravatar.cc/240?img=47",
-			});
+			currentUser = createGithubOnboardingUser(body.level);
 			currentUserId = 6;
 			resetDeleteEmailState();
+			resetMatchState();
+			activeProjectGroup = null;
 
 			return HttpResponse.json(buildSession());
 		}
@@ -598,12 +786,15 @@ export const handlers = [
 		});
 		currentPassword = body.password;
 		resetDeleteEmailState();
+		resetMatchState();
+		activeProjectGroup = null;
 
 		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.get(getPath("/users/me"), async () => {
+	http.get(getPath("/users/me"), async ({ request }) => {
 		await delay(250);
+		syncSessionFromRequest(request);
 
 		if (!currentUser) {
 			return buildErrorResponse(
@@ -784,8 +975,9 @@ export const handlers = [
 		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.get(getPath("/match/status"), async () => {
+	http.get(getPath("/match/status"), async ({ request }) => {
 		await delay(250);
+		syncSessionFromRequest(request);
 
 		if (!currentUser) {
 			return buildErrorResponse(
@@ -813,6 +1005,7 @@ export const handlers = [
 		const body = (await request.json()) as ProjectRequestPayload;
 
 		await delay(500);
+		syncSessionFromRequest(request);
 
 		if (!currentUser) {
 			return buildErrorResponse(
@@ -948,6 +1141,7 @@ export const handlers = [
 		}
 
 		member.isAccepted = true;
+		completeMatchIfEveryoneAccepted();
 		return new HttpResponse(null, { status: 200 });
 	}),
 
@@ -982,8 +1176,9 @@ export const handlers = [
 		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.get(getPath("/project-groups/me"), async () => {
+	http.get(getPath("/project-groups/me"), async ({ request }) => {
 		await delay(250);
+		syncSessionFromRequest(request);
 
 		if (!currentUser) {
 			return buildErrorResponse(


### PR DESCRIPTION
Summary
- Hide password changes for GitHub-login accounts and align delete-account email verification with signup.
- Make active match sessions prominent, lock matching when a team space exists, and redirect final acceptance to team space.
- Treat missing team space 404 responses as a normal no-team state without repeated lookup noise.

Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build
- Browser verification at 1440px wide viewport

Closes #57