### PR TITLE
Improve UI interaction emphasis

### DIFF
--- a/src/features/landing/components/hero-section.tsx
+++ b/src/features/landing/components/hero-section.tsx
@@ -8,6 +8,24 @@ import { Container } from "@/components/ui/container";
 import { Surface } from "@/components/ui/surface";
 import { heroStats } from "@/features/landing/constants";
 
+const heroFlowSteps = [
+	{
+		label: "01",
+		title: "역할 선택",
+		description: "내가 맡을 파트를 고릅니다.",
+	},
+	{
+		label: "02",
+		title: "제안 확인",
+		description: "팀 후보와 프로젝트를 봅니다.",
+	},
+	{
+		label: "03",
+		title: "팀 스페이스",
+		description: "수락 후 바로 협업을 시작합니다.",
+	},
+] as const;
+
 function renderHeroStatValue(value: string) {
 	const parts = value.match(/[0-9A-Za-z%]+|[^0-9A-Za-z%]+/g) ?? [value];
 	let currentOffset = 0;
@@ -79,6 +97,25 @@ export function HeroSection() {
 							<Link to="/team">팀 스페이스 보기</Link>
 						</Button>
 					</div>
+
+					<div className="grid max-w-xl gap-2 rounded-lg border border-primary/15 bg-white/80 p-2.5 shadow-crisp sm:grid-cols-3">
+						{heroFlowSteps.map((step) => (
+							<div
+								className="rounded-md px-3 py-2 transition-colors hover:bg-primary/5"
+								key={step.label}
+							>
+								<p className="font-mono text-xs font-semibold text-primary">
+									{step.label}
+								</p>
+								<p className="mt-1 text-sm font-semibold text-brand-ink">
+									{step.title}
+								</p>
+								<p className="mt-1 text-xs leading-5 text-muted-foreground">
+									{step.description}
+								</p>
+							</div>
+						))}
+					</div>
 				</div>
 
 				<div className="relative animate-rise-in [animation-delay:140ms]">
@@ -91,9 +128,14 @@ export function HeroSection() {
 							<p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary/80">
 								Queue Snapshot
 							</p>
-							<p className="font-display text-2xl leading-tight">
-								내 역할을 입력하면 팀 후보를 찾기 시작합니다
-							</p>
+							<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+								<p className="font-display text-2xl leading-tight">
+									내 역할을 입력하면 팀 후보를 찾기 시작합니다
+								</p>
+								<Badge variant="warm" className="w-fit">
+									응답까지 한 흐름
+								</Badge>
+							</div>
 						</div>
 
 						<div className="space-y-3 rounded-xl border border-border/70 bg-white/80 p-4">

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -171,6 +171,7 @@ export function MatchRequestView() {
 			(!currentMatchMember ||
 				(!currentMatchMember.isHost && currentMatchMember.isAccepted !== true)),
 	);
+	const hasLiveMatch = Boolean(activeMatchId && !isMatchingAccessBlocked);
 	const isSubmitDisabled =
 		!isSignedIn ||
 		isMatchingAccessBlocked ||
@@ -292,31 +293,59 @@ export function MatchRequestView() {
 						tone={
 							hasCurrentTeam || offerStatus === "accepted"
 								? "emerald"
-								: "primary"
+								: hasLiveMatch || offerStatus === "offered"
+									? "amber"
+									: "primary"
 						}
 						value={
 							hasCurrentTeam
 								? "잠김"
-								: offerStatus === "accepted"
-									? "수락 완료"
-									: offerStatus === "hidden"
-										? "대기"
-										: "도착"
+								: hasLiveMatch
+									? "응답 필요"
+									: offerStatus === "accepted"
+										? "수락 완료"
+										: offerStatus === "hidden"
+											? "대기"
+											: "도착"
 						}
 					/>
 					<MetricCard
 						label="팀 생성"
-						tone={hasCurrentTeam || hasAcceptedTeam ? "emerald" : "primary"}
+						tone={
+							hasCurrentTeam || hasAcceptedTeam
+								? "emerald"
+								: hasLiveMatch
+									? "amber"
+									: "primary"
+						}
 						trend={
 							hasCurrentTeam
 								? "이미 팀 스페이스 보유"
 								: hasAcceptedTeam
 									? "팀으로 이동 가능"
-									: "수락 후 생성"
+									: hasLiveMatch
+										? "내 응답 후 생성"
+										: "수락 후 생성"
 						}
-						value={hasCurrentTeam || hasAcceptedTeam ? "가능" : "대기"}
+						value={
+							hasCurrentTeam || hasAcceptedTeam
+								? "가능"
+								: hasLiveMatch
+									? "수락 대기"
+									: "대기"
+						}
 					/>
 				</div>
+
+				{isMatchingAccessBlocked ? null : (
+					<MatchProgressPanel
+						hasAcceptedTeam={hasAcceptedTeam}
+						hasCurrentTeam={hasCurrentTeam}
+						hasLiveMatch={hasLiveMatch}
+						isSignedIn={isSignedIn}
+						status={status}
+					/>
+				)}
 
 				{!isSignedIn ? (
 					<AppPanel>
@@ -340,23 +369,25 @@ export function MatchRequestView() {
 				) : null}
 
 				{activeMatchId && !isMatchingAccessBlocked ? (
-					<MatchSessionCard
-						canRespond={canRespondToMatch}
-						currentMember={currentMatchMember}
-						matchId={activeMatchId}
-						members={matchMembersQuery.data?.members}
-						membersError={matchMembersQuery.error}
-						membersLoading={matchMembersQuery.isLoading}
-						onAccept={() => void handleAcceptMatch()}
-						onReject={() => void rejectMutation.mutateAsync()}
-						project={matchProjectQuery.data}
-						projectError={matchProjectQuery.error}
-						projectLoading={matchProjectQuery.isLoading}
-						responseError={acceptMutation.error ?? rejectMutation.error}
-						responsePending={
-							acceptMutation.isPending || rejectMutation.isPending
-						}
-					/>
+					<div id="match-session">
+						<MatchSessionCard
+							canRespond={canRespondToMatch}
+							currentMember={currentMatchMember}
+							matchId={activeMatchId}
+							members={matchMembersQuery.data?.members}
+							membersError={matchMembersQuery.error}
+							membersLoading={matchMembersQuery.isLoading}
+							onAccept={() => void handleAcceptMatch()}
+							onReject={() => void rejectMutation.mutateAsync()}
+							project={matchProjectQuery.data}
+							projectError={matchProjectQuery.error}
+							projectLoading={matchProjectQuery.isLoading}
+							responseError={acceptMutation.error ?? rejectMutation.error}
+							responsePending={
+								acceptMutation.isPending || rejectMutation.isPending
+							}
+						/>
+					</div>
 				) : null}
 
 				{isMatchingAccessBlocked ? null : (
@@ -441,7 +472,9 @@ export function MatchRequestView() {
 								</div>
 							</AppPanel>
 
-							{apiConfig.useMocks && offerStatus !== "hidden" ? (
+							{hasLiveMatch ? (
+								<MatchLiveHintPanel canRespond={canRespondToMatch} />
+							) : apiConfig.useMocks && offerStatus !== "hidden" ? (
 								<MatchOfferPanel
 									onAccept={handleMockOfferAccept}
 									onDecline={() => setOfferStatus("declined")}
@@ -459,6 +492,11 @@ export function MatchRequestView() {
 
 						<AppPanel>
 							<AppPanelHeader
+								action={
+									status && canCancel ? (
+										<Badge variant="neutral">현재 요청 진행 중</Badge>
+									) : null
+								}
 								description="역할만 선택해도 대기열에 등록됩니다. 프로젝트를 제안하려면 제목, 설명, MVP를 모두 입력해 주세요."
 								eyebrow="Request"
 								title="매칭 요청 작성"
@@ -595,6 +633,147 @@ export function MatchRequestView() {
 				)}
 			</div>
 		</AppShell>
+	);
+}
+
+interface MatchProgressPanelProps {
+	hasAcceptedTeam: boolean;
+	hasCurrentTeam: boolean;
+	hasLiveMatch: boolean;
+	isSignedIn: boolean;
+	status?: MatchStatus;
+}
+
+function MatchProgressPanel({
+	hasAcceptedTeam,
+	hasCurrentTeam,
+	hasLiveMatch,
+	isSignedIn,
+	status,
+}: MatchProgressPanelProps) {
+	const isTeamReady = hasAcceptedTeam || hasCurrentTeam || status === "MATCHED";
+	const currentStep = isTeamReady ? 2 : hasLiveMatch ? 1 : 0;
+	const steps = [
+		{
+			description: isSignedIn
+				? "역할과 프로젝트 힌트를 보내 대기열에 들어갑니다."
+				: "로그인 후 매칭 요청을 보낼 수 있습니다.",
+			label: "요청 작성",
+		},
+		{
+			description: hasLiveMatch
+				? "팀 후보가 도착했습니다. 세션에서 응답을 마무리하세요."
+				: "조건이 맞는 팀 후보가 생기면 이 단계로 넘어갑니다.",
+			label: "팀 후보 확인",
+		},
+		{
+			description: isTeamReady
+				? "팀 스페이스가 열렸습니다."
+				: "전원이 수락하면 협업 공간이 생성됩니다.",
+			label: "팀 생성",
+		},
+	] as const;
+
+	return (
+		<AppPanel className="border-primary/20">
+			<div className="grid gap-4 p-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+				<div className="min-w-0">
+					<div className="flex flex-wrap items-center gap-2">
+						<Badge variant={hasLiveMatch ? "warm" : "brand"}>
+							{hasLiveMatch ? "응답 필요" : "매칭 흐름"}
+						</Badge>
+						{status ? (
+							<Badge variant="neutral">{statusMeta[status].label}</Badge>
+						) : null}
+					</div>
+					<h2 className="mt-3 text-xl font-semibold text-brand-ink">
+						{hasLiveMatch
+							? "도착한 매칭 세션을 확인하고 팀 생성을 결정하세요"
+							: "요청 작성부터 팀 생성까지 한 흐름으로 진행됩니다"}
+					</h2>
+					<p className="mt-1 text-sm leading-6 text-muted-foreground">
+						{hasLiveMatch
+							? "아래 매칭 세션에서 현재 제안의 프로젝트와 팀원 정보를 확인하고 바로 응답합니다."
+							: "역할 선택, 제안 확인, 팀 스페이스 진입이 끊기지 않도록 현재 위치를 표시합니다."}
+					</p>
+				</div>
+
+				<div className="grid min-w-0 gap-2 sm:grid-cols-3 lg:w-[31rem]">
+					{steps.map((step, index) => {
+						const isComplete = index < currentStep;
+						const isActive = index === currentStep;
+
+						return (
+							<div
+								className={cn(
+									"rounded-lg border p-3 transition-colors",
+									isActive
+										? "border-primary/25 bg-primary/5"
+										: isComplete
+											? "border-emerald-500/25 bg-emerald-50"
+											: "border-border/70 bg-white",
+								)}
+								key={step.label}
+							>
+								<div className="flex items-center gap-2">
+									<span
+										className={cn(
+											"flex size-6 shrink-0 items-center justify-center rounded-md border font-mono text-[11px] font-semibold",
+											isActive
+												? "border-primary bg-primary text-primary-foreground"
+												: isComplete
+													? "border-emerald-500 bg-emerald-500 text-white"
+													: "border-border bg-secondary text-muted-foreground",
+										)}
+									>
+										{index + 1}
+									</span>
+									<p className="text-sm font-semibold text-brand-ink">
+										{step.label}
+									</p>
+								</div>
+								<p className="mt-2 text-xs leading-5 text-muted-foreground">
+									{step.description}
+								</p>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</AppPanel>
+	);
+}
+
+function MatchLiveHintPanel({ canRespond }: { canRespond: boolean }) {
+	return (
+		<AppPanel className="border-amber-500/25 bg-amber-50/70">
+			<AppPanelHeader
+				action={
+					<Badge variant={canRespond ? "warm" : "neutral"}>
+						{canRespond ? "내 응답 대기" : "응답 확인됨"}
+					</Badge>
+				}
+				description="현재 도착한 제안은 위 매칭 세션 카드에서만 응답합니다."
+				eyebrow="Next action"
+				title={
+					canRespond
+						? "매칭 세션에서 결정하세요"
+						: "팀원의 응답을 기다리는 중입니다"
+				}
+			/>
+			<div className="grid gap-3 p-5">
+				<p className="rounded-lg border border-amber-500/20 bg-white p-4 text-sm leading-6 text-amber-800">
+					프로젝트와 팀원 구성을 다시 확인한 뒤 한 번의 응답으로 다음 단계로
+					넘어갑니다.
+				</p>
+				<Button asChild variant="outline">
+					<a href="#match-session">
+						<ArrowRight data-icon="inline-start" />
+						매칭 세션 보기
+					</a>
+				</Button>
+			</div>
+		</AppPanel>
 	);
 }
 
@@ -936,8 +1115,15 @@ function MatchSessionCard({
 	return (
 		<AppPanel className="border-primary/20">
 			<AppPanelHeader
-				action={<Badge variant="brand">#{matchId}</Badge>}
-				description="팀원과 프로젝트 정보를 확인한 뒤 수락 또는 거절할 수 있습니다."
+				action={
+					<div className="flex flex-wrap justify-end gap-2">
+						<Badge variant={canRespond ? "warm" : "brand"}>
+							{canRespond ? "응답 필요" : "응답 완료"}
+						</Badge>
+						<Badge variant="brand">#{matchId}</Badge>
+					</div>
+				}
+				description="팀원과 프로젝트 정보를 확인한 뒤 이 카드에서 바로 수락 또는 거절할 수 있습니다."
 				eyebrow="Live session"
 				title="매칭 세션"
 			/>
@@ -995,6 +1181,18 @@ function MatchSessionCard({
 					) : null}
 
 					<div className="flex flex-col gap-3 border-border/60 border-t pt-4">
+						<div
+							className={cn(
+								"rounded-lg border p-3 text-sm leading-6",
+								canRespond
+									? "border-amber-500/25 bg-amber-50 text-amber-800"
+									: "border-emerald-500/25 bg-emerald-50 text-emerald-700",
+							)}
+						>
+							{canRespond
+								? "지금 할 일은 이 매칭을 수락하거나 거절하는 것입니다. 수락하면 팀 스페이스로 이동합니다."
+								: "내 응답은 완료되었습니다. 남은 팀원의 응답이 끝나면 팀 스페이스가 열립니다."}
+						</div>
 						{currentMember?.isHost ? (
 							<FieldDescription>
 								프로젝트 제안자는 자동으로 수락 처리됩니다.

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -293,7 +293,7 @@ export function MatchRequestView() {
 						tone={
 							hasCurrentTeam || offerStatus === "accepted"
 								? "emerald"
-								: hasLiveMatch || offerStatus === "offered"
+								: canRespondToMatch || offerStatus === "offered"
 									? "amber"
 									: "primary"
 						}
@@ -301,7 +301,9 @@ export function MatchRequestView() {
 							hasCurrentTeam
 								? "잠김"
 								: hasLiveMatch
-									? "응답 필요"
+									? canRespondToMatch
+										? "응답 필요"
+										: "응답 완료"
 									: offerStatus === "accepted"
 										? "수락 완료"
 										: offerStatus === "hidden"
@@ -314,7 +316,7 @@ export function MatchRequestView() {
 						tone={
 							hasCurrentTeam || hasAcceptedTeam
 								? "emerald"
-								: hasLiveMatch
+								: canRespondToMatch
 									? "amber"
 									: "primary"
 						}
@@ -324,14 +326,18 @@ export function MatchRequestView() {
 								: hasAcceptedTeam
 									? "팀으로 이동 가능"
 									: hasLiveMatch
-										? "내 응답 후 생성"
+										? canRespondToMatch
+											? "내 응답 후 생성"
+											: "팀원 응답 대기"
 										: "수락 후 생성"
 						}
 						value={
 							hasCurrentTeam || hasAcceptedTeam
 								? "가능"
 								: hasLiveMatch
-									? "수락 대기"
+									? canRespondToMatch
+										? "수락 대기"
+										: "대기 중"
 									: "대기"
 						}
 					/>
@@ -343,6 +349,7 @@ export function MatchRequestView() {
 						hasCurrentTeam={hasCurrentTeam}
 						hasLiveMatch={hasLiveMatch}
 						isSignedIn={isSignedIn}
+						needsResponse={canRespondToMatch}
 						status={status}
 					/>
 				)}
@@ -641,6 +648,7 @@ interface MatchProgressPanelProps {
 	hasCurrentTeam: boolean;
 	hasLiveMatch: boolean;
 	isSignedIn: boolean;
+	needsResponse: boolean;
 	status?: MatchStatus;
 }
 
@@ -649,6 +657,7 @@ function MatchProgressPanel({
 	hasCurrentTeam,
 	hasLiveMatch,
 	isSignedIn,
+	needsResponse,
 	status,
 }: MatchProgressPanelProps) {
 	const isTeamReady = hasAcceptedTeam || hasCurrentTeam || status === "MATCHED";
@@ -662,7 +671,9 @@ function MatchProgressPanel({
 		},
 		{
 			description: hasLiveMatch
-				? "팀 후보가 도착했습니다. 세션에서 응답을 마무리하세요."
+				? needsResponse
+					? "팀 후보가 도착했습니다. 세션에서 응답을 마무리하세요."
+					: "내 응답은 완료됐고 남은 팀원의 응답을 기다립니다."
 				: "조건이 맞는 팀 후보가 생기면 이 단계로 넘어갑니다.",
 			label: "팀 후보 확인",
 		},
@@ -679,8 +690,12 @@ function MatchProgressPanel({
 			<div className="grid gap-4 p-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
 				<div className="min-w-0">
 					<div className="flex flex-wrap items-center gap-2">
-						<Badge variant={hasLiveMatch ? "warm" : "brand"}>
-							{hasLiveMatch ? "응답 필요" : "매칭 흐름"}
+						<Badge variant={needsResponse ? "warm" : "brand"}>
+							{needsResponse
+								? "응답 필요"
+								: hasLiveMatch
+									? "응답 완료"
+									: "매칭 흐름"}
 						</Badge>
 						{status ? (
 							<Badge variant="neutral">{statusMeta[status].label}</Badge>
@@ -688,12 +703,16 @@ function MatchProgressPanel({
 					</div>
 					<h2 className="mt-3 text-xl font-semibold text-brand-ink">
 						{hasLiveMatch
-							? "도착한 매칭 세션을 확인하고 팀 생성을 결정하세요"
+							? needsResponse
+								? "도착한 매칭 세션을 확인하고 팀 생성을 결정하세요"
+								: "내 응답은 완료됐고 팀원의 응답을 기다립니다"
 							: "요청 작성부터 팀 생성까지 한 흐름으로 진행됩니다"}
 					</h2>
 					<p className="mt-1 text-sm leading-6 text-muted-foreground">
 						{hasLiveMatch
-							? "아래 매칭 세션에서 현재 제안의 프로젝트와 팀원 정보를 확인하고 바로 응답합니다."
+							? needsResponse
+								? "아래 매칭 세션에서 현재 제안의 프로젝트와 팀원 정보를 확인하고 바로 응답합니다."
+								: "매칭 세션에서 현재 제안과 팀원 응답 상태를 확인할 수 있습니다."
 							: "역할 선택, 제안 확인, 팀 스페이스 진입이 끊기지 않도록 현재 위치를 표시합니다."}
 					</p>
 				</div>

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -631,16 +631,24 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 					</div>
 				) : null}
 
+				<TeamFocusPanel
+					checklist={checklist}
+					lifecycleStatus={lifecycleStatus}
+					onSelectTab={setSelectedTab}
+				/>
+
 				<AppPanel>
 					<div className="flex gap-2 overflow-x-auto p-2">
 						{tabs.map((tab) => {
 							const Icon = tab.icon;
+							const badge = getTeamTabBadge(tab.id, checklist, messages);
+							const isSelected = selectedTab === tab.id;
 
 							return (
 								<button
 									className={cn(
 										"flex h-10 shrink-0 items-center gap-2 rounded-lg px-3 text-sm font-semibold transition-colors",
-										selectedTab === tab.id
+										isSelected
 											? "bg-primary text-primary-foreground shadow-soft"
 											: "text-muted-foreground hover:bg-secondary hover:text-foreground",
 									)}
@@ -650,6 +658,18 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 								>
 									<Icon className="size-4" />
 									{tab.label}
+									{badge ? (
+										<span
+											className={cn(
+												"rounded-md px-1.5 py-0.5 font-mono text-[10px] leading-none",
+												isSelected
+													? "bg-white/20 text-primary-foreground"
+													: "bg-secondary text-muted-foreground",
+											)}
+										>
+											{badge}
+										</span>
+									) : null}
 								</button>
 							);
 						})}
@@ -682,6 +702,129 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 				</section>
 			</div>
 		</AppShell>
+	);
+}
+
+function TeamFocusPanel({
+	checklist,
+	lifecycleStatus,
+	onSelectTab,
+}: {
+	checklist: TeamChecklistItem[];
+	lifecycleStatus: ProjectLifecycleStatus;
+	onSelectTab: (tab: TeamTab) => void;
+}) {
+	const openTasks = checklist.filter((item) => item.status !== "done");
+	const doneTasks = checklist.length - openTasks.length;
+	const primaryTask =
+		checklist.find((item) => item.status === "doing") ??
+		checklist.find((item) => item.status === "todo") ??
+		checklist[0];
+
+	return (
+		<AppPanel className="border-primary/20">
+			<div className="grid gap-5 p-5 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center">
+				<div className="min-w-0">
+					<div className="flex flex-wrap items-center gap-2">
+						<Badge variant="brand">오늘의 핵심</Badge>
+						<Badge variant="neutral">
+							{getLifecycleLabel(lifecycleStatus)}
+						</Badge>
+					</div>
+					<h2 className="mt-3 text-xl font-semibold text-brand-ink">
+						{primaryTask
+							? primaryTask.title
+							: "새 작업을 추가해 다음 액션을 정하세요"}
+					</h2>
+					<p className="mt-1 text-sm leading-6 text-muted-foreground">
+						{primaryTask
+							? `${primaryTask.assignee} 담당 · ${primaryTask.dueLabel} · ${checklistLabels[primaryTask.status]}`
+							: "체크리스트에서 첫 작업을 만들면 팀 홈 상단에 바로 강조됩니다."}
+					</p>
+				</div>
+
+				<div className="grid gap-3 sm:grid-cols-3 xl:w-[33rem]">
+					<div className="rounded-lg border border-border/70 bg-white p-3">
+						<p className="text-xs font-semibold text-muted-foreground">
+							남은 작업
+						</p>
+						<p className="mt-1 font-mono text-2xl font-semibold text-brand-ink">
+							{openTasks.length}
+						</p>
+					</div>
+					<div className="rounded-lg border border-border/70 bg-white p-3">
+						<p className="text-xs font-semibold text-muted-foreground">
+							완료 작업
+						</p>
+						<p className="mt-1 font-mono text-2xl font-semibold text-emerald-700">
+							{doneTasks}
+						</p>
+					</div>
+					<div className="rounded-lg border border-border/70 bg-white p-3">
+						<p className="text-xs font-semibold text-muted-foreground">
+							다음 회의
+						</p>
+						<p className="mt-1 text-sm font-semibold leading-6 text-brand-ink">
+							{demoTeamSpace.nextMeetingLabel}
+						</p>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-2 sm:flex-row xl:col-span-2">
+					<Button onClick={() => onSelectTab("checklist")} type="button">
+						<CheckCircle2 data-icon="inline-start" />
+						체크리스트 열기
+					</Button>
+					<Button
+						onClick={() => onSelectTab("github")}
+						type="button"
+						variant="outline"
+					>
+						<GitPullRequest data-icon="inline-start" />
+						GitHub 연동
+					</Button>
+					<Button
+						onClick={() => onSelectTab("chat")}
+						type="button"
+						variant="outline"
+					>
+						<MessageSquareText data-icon="inline-start" />
+						채팅 열기
+						<ArrowRight data-icon="inline-end" />
+					</Button>
+				</div>
+			</div>
+		</AppPanel>
+	);
+}
+
+function getTeamTabBadge(
+	tabId: TeamTab,
+	checklist: TeamChecklistItem[],
+	messages: TeamMessage[],
+) {
+	if (tabId === "checklist") {
+		const openTaskCount = checklist.filter(
+			(item) => item.status !== "done",
+		).length;
+		return openTaskCount > 0 ? String(openTaskCount) : "완료";
+	}
+
+	if (tabId === "github") {
+		return demoTeamSpace.githubSummary.projectGroupGithubLinked ? null : "설정";
+	}
+
+	if (tabId === "chat") {
+		return String(messages.length);
+	}
+
+	return null;
+}
+
+function getLifecycleLabel(status: ProjectLifecycleStatus) {
+	return (
+		lifecycleOptions.find((option) => option.status === status)?.label ??
+		"상태 미정"
 	);
 }
 

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -548,6 +548,9 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 	);
 	const [checklist, setChecklist] = useState(demoTeamSpace.checklist);
 	const [messages, setMessages] = useState(demoTeamSpace.messages);
+	const [isGithubLinked, setIsGithubLinked] = useState(
+		demoTeamSpace.githubSummary.projectGroupGithubLinked,
+	);
 	const activeStepIndex = useMemo(
 		() => lifecycleSteps.findIndex((step) => step.status === lifecycleStatus),
 		[lifecycleStatus],
@@ -641,7 +644,12 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 					<div className="flex gap-2 overflow-x-auto p-2">
 						{tabs.map((tab) => {
 							const Icon = tab.icon;
-							const badge = getTeamTabBadge(tab.id, checklist, messages);
+							const badge = getTeamTabBadge(
+								tab.id,
+								checklist,
+								messages,
+								isGithubLinked,
+							);
 							const isSelected = selectedTab === tab.id;
 
 							return (
@@ -695,7 +703,12 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 							onStatusChange={handleChecklistStatusChange}
 						/>
 					) : null}
-					{selectedTab === "github" ? <GithubPanel /> : null}
+					{selectedTab === "github" ? (
+						<GithubPanel
+							isProjectGroupGithubLinked={isGithubLinked}
+							onProjectGroupGithubLinkedChange={setIsGithubLinked}
+						/>
+					) : null}
 					{selectedTab === "chat" ? (
 						<ChatPanel messages={messages} onSend={handleSendMessage} />
 					) : null}
@@ -802,6 +815,7 @@ function getTeamTabBadge(
 	tabId: TeamTab,
 	checklist: TeamChecklistItem[],
 	messages: TeamMessage[],
+	isGithubLinked: boolean,
 ) {
 	if (tabId === "checklist") {
 		const openTaskCount = checklist.filter(
@@ -811,7 +825,7 @@ function getTeamTabBadge(
 	}
 
 	if (tabId === "github") {
-		return demoTeamSpace.githubSummary.projectGroupGithubLinked ? null : "설정";
+		return isGithubLinked ? null : "설정";
 	}
 
 	if (tabId === "chat") {
@@ -1356,7 +1370,13 @@ function ChecklistPanel({
 	);
 }
 
-function GithubPanel() {
+function GithubPanel({
+	isProjectGroupGithubLinked,
+	onProjectGroupGithubLinkedChange,
+}: {
+	isProjectGroupGithubLinked: boolean;
+	onProjectGroupGithubLinkedChange: (isLinked: boolean) => void;
+}) {
 	const initialSelectedRepoIds =
 		demoTeamSpace.githubSummary.connectedRepos.length > 0
 			? demoTeamSpace.githubSummary.connectedRepos.map((repo) => repo.id)
@@ -1366,9 +1386,6 @@ function GithubPanel() {
 	);
 	const [installationStatus, setInstallationStatus] = useState(
 		demoTeamSpace.githubSummary.appInstallation.status,
-	);
-	const [projectGroupGithubLinked, setProjectGroupGithubLinked] = useState(
-		demoTeamSpace.githubSummary.projectGroupGithubLinked,
 	);
 	const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>(
 		initialSelectedRepoIds,
@@ -1410,10 +1427,10 @@ function GithubPanel() {
 			ready: connectedRepos.length > 0,
 		},
 		{
-			description: projectGroupGithubLinked ? "기여도 집계 가능" : "연동 전",
+			description: isProjectGroupGithubLinked ? "기여도 집계 가능" : "연동 전",
 			icon: ShieldCheck,
 			label: "TeamSpace",
-			ready: projectGroupGithubLinked,
+			ready: isProjectGroupGithubLinked,
 		},
 	];
 
@@ -1425,7 +1442,7 @@ function GithubPanel() {
 		});
 		setInstallationStatus("installed");
 		setConnectedRepos([]);
-		setProjectGroupGithubLinked(false);
+		onProjectGroupGithubLinkedChange(false);
 		setSelectedRepoIds((current) =>
 			current.length > 0
 				? current
@@ -1449,7 +1466,7 @@ function GithubPanel() {
 		}
 
 		setConnectedRepos(selectedRepositories);
-		setProjectGroupGithubLinked(true);
+		onProjectGroupGithubLinkedChange(true);
 	}
 
 	return (
@@ -1654,8 +1671,8 @@ function GithubPanel() {
 									확인합니다.
 								</p>
 							</div>
-							<Badge variant={projectGroupGithubLinked ? "brand" : "neutral"}>
-								{projectGroupGithubLinked ? "linked" : "not linked"}
+							<Badge variant={isProjectGroupGithubLinked ? "brand" : "neutral"}>
+								{isProjectGroupGithubLinked ? "linked" : "not linked"}
 							</Badge>
 						</div>
 						{connectedRepos.length > 0 ? (
@@ -1703,9 +1720,9 @@ function GithubPanel() {
 									기여량이 많을수록 색과 밀도가 진해집니다.
 								</p>
 							</div>
-							<Badge variant={projectGroupGithubLinked ? "brand" : "neutral"}>
+							<Badge variant={isProjectGroupGithubLinked ? "brand" : "neutral"}>
 								open PR{" "}
-								{projectGroupGithubLinked
+								{isProjectGroupGithubLinked
 									? demoTeamSpace.githubSummary.openPrs
 									: "-"}
 							</Badge>
@@ -1715,19 +1732,19 @@ function GithubPanel() {
 								<div
 									className={cn(
 										"aspect-square rounded-sm transition-transform hover:scale-110",
-										projectGroupGithubLinked
+										isProjectGroupGithubLinked
 											? contributionLevelClass[day.level]
 											: "bg-secondary/60",
 									)}
 									key={day.id}
 									title={`${day.label}: level ${
-										projectGroupGithubLinked ? day.level : 0
+										isProjectGroupGithubLinked ? day.level : 0
 									}`}
 								/>
 							))}
 						</div>
 						<p className="mt-4 text-sm leading-6 text-muted-foreground">
-							{projectGroupGithubLinked
+							{isProjectGroupGithubLinked
 								? demoTeamSpace.githubSummary.weeklySummary
 								: "저장소를 연결하면 커밋, PR, 리뷰, 이슈 기준으로 팀원별 기여 흐름을 집계합니다."}
 						</p>
@@ -1757,14 +1774,14 @@ function GithubPanel() {
 												<span
 													className={cn(
 														"size-4 rounded-sm",
-														projectGroupGithubLinked
+														isProjectGroupGithubLinked
 															? contributionLevelClass[contribution.level]
 															: "bg-secondary",
 													)}
 												/>
 											</div>
 											<p className="mt-2 text-xs leading-5 text-muted-foreground">
-												{projectGroupGithubLinked
+												{isProjectGroupGithubLinked
 													? `커밋 ${contribution.commits} · PR ${contribution.prs} · 리뷰 ${contribution.reviews} · 이슈 ${contribution.issues}`
 													: "저장소 연결 후 기여 수치가 표시됩니다."}
 											</p>
@@ -1777,7 +1794,7 @@ function GithubPanel() {
 				</div>
 				<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
 					<p className="text-sm font-semibold text-brand-ink">최근 활동</p>
-					{projectGroupGithubLinked ? (
+					{isProjectGroupGithubLinked ? (
 						<div className="mt-4 grid gap-3 md:grid-cols-3">
 							{demoTeamSpace.githubSummary.recentActivities.map((activity) => (
 								<div

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -703,12 +703,12 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 							onStatusChange={handleChecklistStatusChange}
 						/>
 					) : null}
-					{selectedTab === "github" ? (
+					<div hidden={selectedTab !== "github"}>
 						<GithubPanel
 							isProjectGroupGithubLinked={isGithubLinked}
 							onProjectGroupGithubLinkedChange={setIsGithubLinked}
 						/>
-					) : null}
+					</div>
 					{selectedTab === "chat" ? (
 						<ChatPanel messages={messages} onSend={handleSendMessage} />
 					) : null}


### PR DESCRIPTION
Summary
- Clarify the landing hero with a role-to-team-space flow
- Emphasize live matching sessions and remove duplicate mock offer actions
- Add a team workspace focus panel with tab badges and direct next-action controls

Validation
- pnpm typecheck: pass
- pnpm biome lint .: pass
- pnpm build: pass (bundle size warning only)

Closes #59