### PR TITLE
feat(team): sync Client with Server checklist and team-space APIs

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -11,6 +11,8 @@ tags:
   - name: Users
   - name: Match
   - name: ProjectGroups
+  - name: ProjectChecklists
+  - name: TeamSpace
 paths:
   /signup/email:
     post:
@@ -500,6 +502,195 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /project-groups/{projectGroupId}/checklists:
+    get:
+      tags: [ProjectChecklists]
+      security:
+        - bearerAuth: []
+      summary: Get project group checklists
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: Project checklist list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectChecklist'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [ProjectChecklists]
+      security:
+        - bearerAuth: []
+      summary: Create a project group checklist
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateProjectChecklistRequest'
+      responses:
+        '201':
+          description: Project checklist created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectChecklist'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /project-groups/{projectGroupId}/checklists/{checklistId}:
+    patch:
+      tags: [ProjectChecklists]
+      security:
+        - bearerAuth: []
+      summary: Update a project group checklist
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/ChecklistId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProjectChecklistRequest'
+      responses:
+        '200':
+          description: Project checklist updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectChecklist'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [ProjectChecklists]
+      security:
+        - bearerAuth: []
+      summary: Delete a project group checklist
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/ChecklistId'
+      responses:
+        '204':
+          description: Project checklist deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /project-groups/{projectGroupId}/checklists/{checklistId}/advice:
+    post:
+      tags: [ProjectChecklists]
+      security:
+        - bearerAuth: []
+      summary: Generate AI advice for a project group checklist
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/ChecklistId'
+      responses:
+        '200':
+          description: Checklist advice generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateChecklistAdviceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /team-space/{projectGroupId}/github/status:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get GitHub App installation status for a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: GitHub installation status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GithubInstallationStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /team-space/{projectGroupId}/github/install-url:
+    post:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Create a GitHub App installation URL
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: GitHub App installation URL issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GithubAppInstallationUrl'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /team-space/{projectGroupId}/github/installations/complete:
+    post:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Complete a GitHub App installation callback
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompleteGithubAppInstallationRequest'
+      responses:
+        '200':
+          description: GitHub App installation completed
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '502':
+          $ref: '#/components/responses/BadGateway'
 components:
   securitySchemes:
     bearerAuth:
@@ -524,6 +715,13 @@ components:
     TargetUserId:
       in: path
       name: targetUserId
+      required: true
+      schema:
+        type: integer
+        format: int64
+    ChecklistId:
+      in: path
+      name: checklistId
       required: true
       schema:
         type: integer
@@ -903,6 +1101,183 @@ components:
           enum: [HOST, MEMBER]
         admin:
           type: boolean
+    ProjectChecklistStatus:
+      type: string
+      enum: [TODO, DONE]
+    ChecklistAiAdvice:
+      type: object
+      additionalProperties: false
+      required: [summary, recommendedFlow, considerations, improvementPoints]
+      properties:
+        summary:
+          type: string
+        recommendedFlow:
+          type: array
+          minItems: 3
+          maxItems: 5
+          items:
+            type: string
+        considerations:
+          type: array
+          minItems: 2
+          maxItems: 4
+          items:
+            type: string
+        improvementPoints:
+          type: array
+          minItems: 1
+          maxItems: 3
+          items:
+            type: string
+    ProjectChecklist:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - description
+        - status
+        - dueDate
+        - createdAt
+        - createdByUserId
+        - createdByNickname
+        - assigneeUserId
+        - assigneeNickname
+        - aiAdvice
+      properties:
+        id:
+          type: integer
+          format: int64
+        title:
+          type: string
+        description:
+          type:
+            - string
+            - 'null'
+        status:
+          $ref: '#/components/schemas/ProjectChecklistStatus'
+        dueDate:
+          type:
+            - string
+            - 'null'
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        createdByUserId:
+          type: integer
+          format: int64
+        createdByNickname:
+          type: string
+        assigneeUserId:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        assigneeNickname:
+          type:
+            - string
+            - 'null'
+        aiAdvice:
+          anyOf:
+            - $ref: '#/components/schemas/ChecklistAiAdvice'
+            - type: 'null'
+    CreateProjectChecklistRequest:
+      type: object
+      additionalProperties: false
+      required: [title]
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type:
+            - string
+            - 'null'
+          maxLength: 3000
+        dueDate:
+          type:
+            - string
+            - 'null'
+          format: date
+        assigneeUserId:
+          type:
+            - integer
+            - 'null'
+          format: int64
+    UpdateProjectChecklistRequest:
+      type: object
+      additionalProperties: false
+      required: [title, status]
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type:
+            - string
+            - 'null'
+          maxLength: 3000
+        status:
+          $ref: '#/components/schemas/ProjectChecklistStatus'
+        dueDate:
+          type:
+            - string
+            - 'null'
+          format: date
+        assigneeUserId:
+          type:
+            - integer
+            - 'null'
+          format: int64
+    GenerateChecklistAdviceResponse:
+      type: object
+      additionalProperties: false
+      required: [checklistId, aiAdvice]
+      properties:
+        checklistId:
+          type: integer
+          format: int64
+        aiAdvice:
+          $ref: '#/components/schemas/ChecklistAiAdvice'
+    GithubInstallationStatus:
+      type: object
+      additionalProperties: false
+      required: [connected, organizationLogin, repositoryCount]
+      properties:
+        connected:
+          type: boolean
+        organizationLogin:
+          type:
+            - string
+            - 'null'
+        repositoryCount:
+          type: integer
+          format: int64
+    GithubAppInstallationUrl:
+      type: object
+      additionalProperties: false
+      required: [installUrl]
+      properties:
+        installUrl:
+          type: string
+          format: uri
+    CompleteGithubAppInstallationRequest:
+      type: object
+      additionalProperties: false
+      required: [installationId, setupAction, state]
+      properties:
+        installationId:
+          type: integer
+          format: int64
+        setupAction:
+          type: string
+          minLength: 1
+        state:
+          type: string
+          minLength: 1
   responses:
     BadRequest:
       description: Validation failed or business rule rejected the request

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -28,7 +28,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 import {
 	AppPanel,
@@ -43,11 +43,30 @@ import {
 	useMyProjectGroupQuery,
 	useRevokeProjectGroupAdminPermissionMutation,
 } from "@/features/project-groups/hooks/use-project-group-queries";
+import {
+	useCreateProjectChecklistMutation,
+	useDeleteProjectChecklistMutation,
+	useGenerateChecklistAdviceMutation,
+	useProjectChecklistsQuery,
+	useUpdateProjectChecklistMutation,
+} from "@/features/team/hooks/use-project-checklist-queries";
+import {
+	useCompleteGithubAppInstallationMutation,
+	useCreateGithubAppInstallationUrlMutation,
+	useGithubInstallationStatusQuery,
+} from "@/features/team/hooks/use-team-space-queries";
 import { demoTeamSpace } from "@/features/team/lib/demo-team-space";
 import { getAuthSession } from "@/lib/api/auth-session";
 import { getApiErrorMessage } from "@/lib/api/client";
 import { apiConfig } from "@/lib/api/config";
-import type { ProjectGroupMember } from "@/lib/types/project-group";
+import type {
+	ProjectChecklist,
+	ProjectChecklistStatus,
+} from "@/lib/types/project-checklist";
+import type {
+	MyProjectGroup,
+	ProjectGroupMember,
+} from "@/lib/types/project-group";
 import type {
 	GithubRepositorySummary,
 	ProjectLifecycleStatus,
@@ -57,10 +76,11 @@ import type {
 import { cn } from "@/lib/utils";
 
 type TeamTab = "overview" | "guide" | "rules" | "checklist" | "github" | "chat";
-type AdminPermissionFeedback = {
+type ActionFeedback = {
 	message: string;
 	tone: "error" | "success";
 };
+type AdminPermissionFeedback = ActionFeedback;
 
 const lifecycleSteps: Array<{
 	label: string;
@@ -102,6 +122,16 @@ const checklistLabels: Record<TeamChecklistItem["status"], string> = {
 	todo: "할 일",
 };
 
+const projectChecklistStatusLabels: Record<ProjectChecklistStatus, string> = {
+	DONE: "완료",
+	TODO: "할 일",
+};
+
+const projectChecklistStatusTone: Record<ProjectChecklistStatus, string> = {
+	DONE: "border-emerald-500/25 bg-emerald-50 text-emerald-700",
+	TODO: "border-border bg-secondary/45 text-muted-foreground",
+};
+
 const contributionLevelClass = [
 	"bg-secondary",
 	"bg-emerald-100",
@@ -121,13 +151,21 @@ export function TeamSpaceView() {
 }
 
 function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
+	const [searchParams, setSearchParams] = useSearchParams();
 	const projectGroupQuery = useMyProjectGroupQuery(isSignedIn);
 	const grantAdminPermissionMutation =
 		useGrantProjectGroupAdminPermissionMutation();
 	const revokeAdminPermissionMutation =
 		useRevokeProjectGroupAdminPermissionMutation();
+	const {
+		isPending: isCompletingGithubInstallation,
+		mutate: completeGithubAppInstallation,
+	} = useCompleteGithubAppInstallationMutation();
 	const [adminPermissionFeedback, setAdminPermissionFeedback] =
 		useState<AdminPermissionFeedback | null>(null);
+	const [githubCompletionFeedback, setGithubCompletionFeedback] =
+		useState<ActionFeedback | null>(null);
+	const completedGithubInstallationKeyRef = useRef<string | null>(null);
 	const projectGroup = isSignedIn ? projectGroupQuery.data : null;
 	const currentMember = useMemo(
 		() =>
@@ -145,6 +183,68 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 		: revokeAdminPermissionMutation.isPending
 			? revokeAdminPermissionMutation.variables.targetUserId
 			: null;
+
+	useEffect(() => {
+		const installationIdParam = searchParams.get("installation_id");
+		const setupAction = searchParams.get("setup_action");
+		const state = searchParams.get("state");
+
+		if (!projectGroup || !installationIdParam || !setupAction || !state) {
+			return;
+		}
+
+		const completionKey = `${projectGroup.projectGroupId}:${installationIdParam}:${setupAction}:${state}`;
+
+		if (completedGithubInstallationKeyRef.current === completionKey) {
+			return;
+		}
+
+		const installationId = Number(installationIdParam);
+		completedGithubInstallationKeyRef.current = completionKey;
+
+		if (!Number.isFinite(installationId)) {
+			setGithubCompletionFeedback({
+				message: "GitHub App 설치 정보를 확인할 수 없습니다.",
+				tone: "error",
+			});
+			return;
+		}
+
+		setGithubCompletionFeedback(null);
+		completeGithubAppInstallation(
+			{
+				installationId,
+				projectGroupId: projectGroup.projectGroupId,
+				setupAction,
+				state,
+			},
+			{
+				onError: (error: unknown) => {
+					completedGithubInstallationKeyRef.current = null;
+					setGithubCompletionFeedback({
+						message: getApiErrorMessage(error),
+						tone: "error",
+					});
+				},
+				onSuccess: () => {
+					const nextSearchParams = new URLSearchParams(searchParams);
+					nextSearchParams.delete("installation_id");
+					nextSearchParams.delete("setup_action");
+					nextSearchParams.delete("state");
+					setSearchParams(nextSearchParams, { replace: true });
+					setGithubCompletionFeedback({
+						message: "GitHub App 설치를 팀 스페이스에 연결했습니다.",
+						tone: "success",
+					});
+				},
+			},
+		);
+	}, [
+		projectGroup,
+		searchParams,
+		setSearchParams,
+		completeGithubAppInstallation,
+	]);
 
 	function handleAdminPermissionChange(member: ProjectGroupMember) {
 		if (!projectGroup) {
@@ -314,6 +414,14 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 								}
 							/>
 						</div>
+
+						<RealProjectChecklistsPanel projectGroup={projectGroup} />
+						<RealGithubInstallationPanel
+							canManageGithubInstallation={canManageAdminPermissions}
+							completionFeedback={githubCompletionFeedback}
+							isCompletingInstallation={isCompletingGithubInstallation}
+							projectGroup={projectGroup}
+						/>
 					</>
 				) : null}
 
@@ -516,6 +624,607 @@ function RealProjectGroupMemberCard({
 					</span>
 				) : null}
 			</div>
+		</div>
+	);
+}
+
+function RealProjectChecklistsPanel({
+	projectGroup,
+}: {
+	projectGroup: MyProjectGroup;
+}) {
+	const checklistQuery = useProjectChecklistsQuery(projectGroup.projectGroupId);
+	const createChecklistMutation = useCreateProjectChecklistMutation();
+	const updateChecklistMutation = useUpdateProjectChecklistMutation();
+	const deleteChecklistMutation = useDeleteProjectChecklistMutation();
+	const generateAdviceMutation = useGenerateChecklistAdviceMutation();
+	const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+	const [draft, setDraft] = useState({
+		assigneeUserId: "",
+		description: "",
+		dueDate: "",
+		title: "",
+	});
+	const checklists = checklistQuery.data ?? [];
+	const pendingChecklistId = updateChecklistMutation.isPending
+		? (updateChecklistMutation.variables?.checklistId ?? null)
+		: deleteChecklistMutation.isPending
+			? (deleteChecklistMutation.variables?.checklistId ?? null)
+			: generateAdviceMutation.isPending
+				? (generateAdviceMutation.variables?.checklistId ?? null)
+				: null;
+
+	function handleCreateChecklist(event: FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+
+		const title = draft.title.trim();
+
+		if (!title) {
+			setFeedback({
+				message: "체크리스트 제목을 입력해 주세요.",
+				tone: "error",
+			});
+			return;
+		}
+
+		setFeedback(null);
+		createChecklistMutation.mutate(
+			{
+				assigneeUserId: draft.assigneeUserId
+					? Number(draft.assigneeUserId)
+					: null,
+				description: draft.description.trim() || null,
+				dueDate: draft.dueDate || null,
+				projectGroupId: projectGroup.projectGroupId,
+				title,
+			},
+			{
+				onError: (error: unknown) => {
+					setFeedback({
+						message: getApiErrorMessage(error),
+						tone: "error",
+					});
+				},
+				onSuccess: () => {
+					setDraft({
+						assigneeUserId: "",
+						description: "",
+						dueDate: "",
+						title: "",
+					});
+					setFeedback({
+						message: "체크리스트를 추가했습니다.",
+						tone: "success",
+					});
+				},
+			},
+		);
+	}
+
+	function handleStatusChange(
+		checklist: ProjectChecklist,
+		status: ProjectChecklistStatus,
+	) {
+		setFeedback(null);
+		updateChecklistMutation.mutate(
+			{
+				assigneeUserId: checklist.assigneeUserId,
+				checklistId: checklist.id,
+				description: checklist.description,
+				dueDate: checklist.dueDate,
+				projectGroupId: projectGroup.projectGroupId,
+				status,
+				title: checklist.title,
+			},
+			{
+				onError: (error: unknown) => {
+					setFeedback({
+						message: getApiErrorMessage(error),
+						tone: "error",
+					});
+				},
+			},
+		);
+	}
+
+	function handleDeleteChecklist(checklist: ProjectChecklist) {
+		setFeedback(null);
+		deleteChecklistMutation.mutate(
+			{
+				checklistId: checklist.id,
+				projectGroupId: projectGroup.projectGroupId,
+			},
+			{
+				onError: (error: unknown) => {
+					setFeedback({
+						message: getApiErrorMessage(error),
+						tone: "error",
+					});
+				},
+				onSuccess: () => {
+					setFeedback({
+						message: "체크리스트를 삭제했습니다.",
+						tone: "success",
+					});
+				},
+			},
+		);
+	}
+
+	function handleGenerateAdvice(checklist: ProjectChecklist) {
+		setFeedback(null);
+		generateAdviceMutation.mutate(
+			{
+				checklistId: checklist.id,
+				projectGroupId: projectGroup.projectGroupId,
+			},
+			{
+				onError: (error: unknown) => {
+					setFeedback({
+						message: getApiErrorMessage(error),
+						tone: "error",
+					});
+				},
+				onSuccess: () => {
+					setFeedback({
+						message: "AI 조언을 생성했습니다.",
+						tone: "success",
+					});
+				},
+			},
+		);
+	}
+
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				action={<Badge variant="neutral">{checklists.length} tasks</Badge>}
+				description="팀 작업을 등록하고 담당자, 마감일, AI 조언을 관리합니다."
+				eyebrow="Checklist"
+				title="프로젝트 체크리스트"
+			/>
+			<div className="grid gap-5 p-5">
+				<form
+					className="grid gap-3 rounded-lg border border-border/70 bg-white p-4 shadow-crisp lg:grid-cols-[1fr_1.2fr_10rem_12rem_auto]"
+					onSubmit={handleCreateChecklist}
+				>
+					<label
+						className="grid gap-2 text-sm font-semibold text-brand-ink"
+						htmlFor="real-checklist-title"
+					>
+						제목
+						<input
+							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+							id="real-checklist-title"
+							maxLength={255}
+							onChange={(event) =>
+								setDraft((current) => ({
+									...current,
+									title: event.target.value,
+								}))
+							}
+							placeholder="작업 제목"
+							value={draft.title}
+						/>
+					</label>
+					<label
+						className="grid gap-2 text-sm font-semibold text-brand-ink"
+						htmlFor="real-checklist-description"
+					>
+						설명
+						<input
+							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+							id="real-checklist-description"
+							maxLength={3000}
+							onChange={(event) =>
+								setDraft((current) => ({
+									...current,
+									description: event.target.value,
+								}))
+							}
+							placeholder="작업 설명"
+							value={draft.description}
+						/>
+					</label>
+					<label
+						className="grid gap-2 text-sm font-semibold text-brand-ink"
+						htmlFor="real-checklist-due-date"
+					>
+						마감일
+						<input
+							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+							id="real-checklist-due-date"
+							onChange={(event) =>
+								setDraft((current) => ({
+									...current,
+									dueDate: event.target.value,
+								}))
+							}
+							type="date"
+							value={draft.dueDate}
+						/>
+					</label>
+					<label
+						className="grid gap-2 text-sm font-semibold text-brand-ink"
+						htmlFor="real-checklist-assignee"
+					>
+						담당자
+						<select
+							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+							id="real-checklist-assignee"
+							onChange={(event) =>
+								setDraft((current) => ({
+									...current,
+									assigneeUserId: event.target.value,
+								}))
+							}
+							value={draft.assigneeUserId}
+						>
+							<option value="">미지정</option>
+							{projectGroup.members.map((member) => (
+								<option key={member.userId} value={member.userId}>
+									{member.nickname}
+								</option>
+							))}
+						</select>
+					</label>
+					<div className="flex items-end">
+						<Button
+							className="w-full lg:w-auto"
+							disabled={createChecklistMutation.isPending}
+							type="submit"
+						>
+							{createChecklistMutation.isPending ? (
+								<LoaderCircle
+									className="animate-spin"
+									data-icon="inline-start"
+								/>
+							) : (
+								<Plus data-icon="inline-start" />
+							)}
+							추가
+						</Button>
+					</div>
+				</form>
+
+				<RealActionFeedback feedback={feedback} />
+
+				{checklistQuery.isLoading ? (
+					<RealInlineStatus
+						icon={<LoaderCircle className="size-4 animate-spin" />}
+						message="체크리스트를 불러오고 있습니다."
+					/>
+				) : null}
+
+				{checklistQuery.error ? (
+					<RealInlineStatus
+						message={getApiErrorMessage(checklistQuery.error)}
+					/>
+				) : null}
+
+				<div className="grid gap-3">
+					{checklists.map((checklist) => {
+						const isPending = pendingChecklistId === checklist.id;
+
+						return (
+							<div
+								className="grid gap-4 rounded-lg border border-border/70 bg-white p-4 shadow-crisp xl:grid-cols-[1fr_auto]"
+								key={checklist.id}
+							>
+								<div className="min-w-0">
+									<div className="flex flex-wrap items-center gap-2">
+										<Badge
+											className={projectChecklistStatusTone[checklist.status]}
+											variant="neutral"
+										>
+											{projectChecklistStatusLabels[checklist.status]}
+										</Badge>
+										<p className="text-sm font-semibold text-brand-ink">
+											{checklist.title}
+										</p>
+									</div>
+									<p className="mt-2 text-sm leading-6 text-muted-foreground">
+										{checklist.description ?? "설명이 없습니다."}
+									</p>
+									<div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+										<span>담당 {checklist.assigneeNickname ?? "미지정"}</span>
+										<span>마감 {checklist.dueDate ?? "미정"}</span>
+										<span>생성 {checklist.createdByNickname}</span>
+									</div>
+									{checklist.aiAdvice ? (
+										<RealChecklistAdvice checklist={checklist} />
+									) : null}
+								</div>
+								<div className="flex flex-wrap items-start gap-2 xl:justify-end">
+									<Button
+										disabled={isPending}
+										onClick={() =>
+											handleStatusChange(
+												checklist,
+												checklist.status === "DONE" ? "TODO" : "DONE",
+											)
+										}
+										size="sm"
+										type="button"
+										variant="outline"
+									>
+										{isPending &&
+										updateChecklistMutation.variables?.checklistId ===
+											checklist.id ? (
+											<LoaderCircle
+												className="animate-spin"
+												data-icon="inline-start"
+											/>
+										) : (
+											<CheckCircle2 data-icon="inline-start" />
+										)}
+										{checklist.status === "DONE" ? "다시 열기" : "완료"}
+									</Button>
+									<Button
+										disabled={isPending}
+										onClick={() => handleGenerateAdvice(checklist)}
+										size="sm"
+										type="button"
+										variant="outline"
+									>
+										{isPending &&
+										generateAdviceMutation.variables?.checklistId ===
+											checklist.id ? (
+											<LoaderCircle
+												className="animate-spin"
+												data-icon="inline-start"
+											/>
+										) : (
+											<Sparkles data-icon="inline-start" />
+										)}
+										AI 조언
+									</Button>
+									<Button
+										disabled={isPending}
+										onClick={() => handleDeleteChecklist(checklist)}
+										size="icon"
+										type="button"
+										variant="ghost"
+									>
+										{isPending &&
+										deleteChecklistMutation.variables?.checklistId ===
+											checklist.id ? (
+											<LoaderCircle className="size-4 animate-spin" />
+										) : (
+											<Trash2 />
+										)}
+									</Button>
+								</div>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</AppPanel>
+	);
+}
+
+function RealChecklistAdvice({ checklist }: { checklist: ProjectChecklist }) {
+	if (!checklist.aiAdvice) {
+		return null;
+	}
+
+	return (
+		<div className="mt-4 rounded-lg border border-primary/15 bg-primary/5 p-4">
+			<p className="text-sm font-semibold text-primary">
+				{checklist.aiAdvice.summary}
+			</p>
+			<div className="mt-3 grid gap-3 md:grid-cols-3">
+				<RealAdviceList
+					items={checklist.aiAdvice.recommendedFlow}
+					title="추천 흐름"
+				/>
+				<RealAdviceList
+					items={checklist.aiAdvice.considerations}
+					title="고려 사항"
+				/>
+				<RealAdviceList
+					items={checklist.aiAdvice.improvementPoints}
+					title="개선 포인트"
+				/>
+			</div>
+		</div>
+	);
+}
+
+function RealAdviceList({ items, title }: { items: string[]; title: string }) {
+	return (
+		<div>
+			<p className="text-xs font-semibold uppercase tracking-[0.12em] text-primary">
+				{title}
+			</p>
+			<ul className="mt-2 grid gap-2 text-xs leading-5 text-muted-foreground">
+				{items.map((item) => (
+					<li key={item}>{item}</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+function RealGithubInstallationPanel({
+	canManageGithubInstallation,
+	completionFeedback,
+	isCompletingInstallation,
+	projectGroup,
+}: {
+	canManageGithubInstallation: boolean;
+	completionFeedback: ActionFeedback | null;
+	isCompletingInstallation: boolean;
+	projectGroup: MyProjectGroup;
+}) {
+	const githubStatusQuery = useGithubInstallationStatusQuery(
+		projectGroup.projectGroupId,
+	);
+	const createInstallUrlMutation = useCreateGithubAppInstallationUrlMutation();
+	const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+	const githubStatus = githubStatusQuery.data;
+	const canCreateInstallUrl =
+		githubStatusQuery.isSuccess &&
+		canManageGithubInstallation &&
+		!githubStatus?.connected &&
+		!createInstallUrlMutation.isPending;
+
+	function handleCreateInstallUrl() {
+		setFeedback(null);
+		createInstallUrlMutation.mutate(projectGroup.projectGroupId, {
+			onError: (error: unknown) => {
+				setFeedback({
+					message: getApiErrorMessage(error),
+					tone: "error",
+				});
+			},
+			onSuccess: ({ installUrl }) => {
+				window.location.assign(installUrl);
+			},
+		});
+	}
+
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				action={
+					<Badge variant={githubStatus?.connected ? "brand" : "neutral"}>
+						{githubStatus?.connected ? "connected" : "not connected"}
+					</Badge>
+				}
+				description="Organization 연결 상태와 저장소 집계 준비 상태를 확인합니다."
+				eyebrow="GitHub App"
+				title="Organization 연동"
+			/>
+			<div className="grid gap-5 p-5">
+				<RealActionFeedback feedback={completionFeedback ?? feedback} />
+
+				{githubStatusQuery.isLoading || isCompletingInstallation ? (
+					<RealInlineStatus
+						icon={<LoaderCircle className="size-4 animate-spin" />}
+						message={
+							isCompletingInstallation
+								? "GitHub App 설치를 완료하고 있습니다."
+								: "GitHub 연동 상태를 불러오고 있습니다."
+						}
+					/>
+				) : null}
+
+				{githubStatusQuery.error ? (
+					<RealInlineStatus
+						message={getApiErrorMessage(githubStatusQuery.error)}
+					/>
+				) : null}
+
+				<div className="grid gap-3 md:grid-cols-3">
+					<RealGithubStatusCard
+						label="Organization"
+						ready={githubStatus?.connected === true}
+						value={githubStatus?.organizationLogin ?? "연결 전"}
+					/>
+					<RealGithubStatusCard
+						label="Repositories"
+						ready={(githubStatus?.repositoryCount ?? 0) > 0}
+						value={`${githubStatus?.repositoryCount ?? 0}개`}
+					/>
+					<RealGithubStatusCard
+						label="Permission"
+						ready={canManageGithubInstallation}
+						value={canManageGithubInstallation ? "HOST" : "READ ONLY"}
+					/>
+				</div>
+
+				<div className="flex flex-col gap-3 rounded-lg border border-border/70 bg-white p-4 shadow-crisp sm:flex-row sm:items-center sm:justify-between">
+					<div className="min-w-0">
+						<p className="text-sm font-semibold text-brand-ink">
+							TeamPo GitHub App
+						</p>
+						<p className="mt-1 text-sm leading-6 text-muted-foreground">
+							{githubStatus?.connected
+								? "Organization이 팀 스페이스에 연결되어 있습니다."
+								: "호스트가 GitHub 설치 흐름을 시작할 수 있습니다."}
+						</p>
+					</div>
+					<Button
+						disabled={!canCreateInstallUrl}
+						onClick={handleCreateInstallUrl}
+						type="button"
+					>
+						{createInstallUrlMutation.isPending ? (
+							<LoaderCircle className="animate-spin" data-icon="inline-start" />
+						) : (
+							<Github data-icon="inline-start" />
+						)}
+						설치 URL 발급
+					</Button>
+				</div>
+			</div>
+		</AppPanel>
+	);
+}
+
+function RealGithubStatusCard({
+	label,
+	ready,
+	value,
+}: {
+	label: string;
+	ready: boolean;
+	value: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"rounded-lg border p-4 shadow-crisp",
+				ready ? "border-primary/20 bg-primary/5" : "border-border/70 bg-white",
+			)}
+		>
+			<div className="flex items-center justify-between gap-3">
+				<p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+					{label}
+				</p>
+				<Badge variant={ready ? "brand" : "neutral"}>
+					{ready ? "ready" : "pending"}
+				</Badge>
+			</div>
+			<p className="mt-3 truncate text-sm font-semibold text-brand-ink">
+				{value}
+			</p>
+		</div>
+	);
+}
+
+function RealActionFeedback({ feedback }: { feedback: ActionFeedback | null }) {
+	if (!feedback) {
+		return null;
+	}
+
+	return (
+		<output
+			className={cn(
+				"rounded-lg border px-4 py-3 text-sm font-medium",
+				feedback.tone === "success"
+					? "border-emerald-500/20 bg-emerald-50 text-emerald-700"
+					: "border-red-500/20 bg-red-50 text-red-700",
+			)}
+		>
+			{feedback.message}
+		</output>
+	);
+}
+
+function RealInlineStatus({
+	icon,
+	message,
+}: {
+	icon?: ReactNode;
+	message: string;
+}) {
+	return (
+		<div className="flex items-center gap-2 rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
+			{icon}
+			<span>{message}</span>
 		</div>
 	);
 }

--- a/src/features/team/hooks/use-project-checklist-queries.ts
+++ b/src/features/team/hooks/use-project-checklist-queries.ts
@@ -1,0 +1,112 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+	createProjectChecklist,
+	deleteProjectChecklist,
+	generateChecklistAdvice,
+	getProjectChecklists,
+	updateProjectChecklist,
+} from "@/lib/api/project-checklists";
+import type {
+	CreateProjectChecklistRequest,
+	DeleteProjectChecklistRequest,
+	GenerateChecklistAdviceRequest,
+	UpdateProjectChecklistRequest,
+} from "@/lib/types/project-checklist";
+
+export const projectChecklistQueryKeys = {
+	all: ["project-checklists"] as const,
+	byProjectGroup: (projectGroupId: number) =>
+		["project-checklists", projectGroupId] as const,
+};
+
+const checklistStaleTimeMs = 15_000;
+
+function requireProjectGroupId(projectGroupId: number | undefined) {
+	if (typeof projectGroupId !== "number") {
+		throw new Error("Project group id is required.");
+	}
+
+	return projectGroupId;
+}
+
+export function useProjectChecklistsQuery(
+	projectGroupId: number | undefined,
+	enabled = true,
+) {
+	return useQuery({
+		enabled: enabled && typeof projectGroupId === "number",
+		queryFn: () => getProjectChecklists(requireProjectGroupId(projectGroupId)),
+		queryKey:
+			typeof projectGroupId === "number"
+				? projectChecklistQueryKeys.byProjectGroup(projectGroupId)
+				: projectChecklistQueryKeys.all,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: checklistStaleTimeMs,
+	});
+}
+
+export function useCreateProjectChecklistMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: CreateProjectChecklistRequest) =>
+			createProjectChecklist(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: projectChecklistQueryKeys.byProjectGroup(
+					variables.projectGroupId,
+				),
+			});
+		},
+	});
+}
+
+export function useUpdateProjectChecklistMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: UpdateProjectChecklistRequest) =>
+			updateProjectChecklist(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: projectChecklistQueryKeys.byProjectGroup(
+					variables.projectGroupId,
+				),
+			});
+		},
+	});
+}
+
+export function useDeleteProjectChecklistMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: DeleteProjectChecklistRequest) =>
+			deleteProjectChecklist(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: projectChecklistQueryKeys.byProjectGroup(
+					variables.projectGroupId,
+				),
+			});
+		},
+	});
+}
+
+export function useGenerateChecklistAdviceMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: GenerateChecklistAdviceRequest) =>
+			generateChecklistAdvice(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: projectChecklistQueryKeys.byProjectGroup(
+					variables.projectGroupId,
+				),
+			});
+		},
+	});
+}

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -1,0 +1,63 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+	completeGithubAppInstallation,
+	createGithubAppInstallationUrl,
+	getGithubInstallationStatus,
+} from "@/lib/api/team-space";
+import type { GithubAppInstallationCompleteRequest } from "@/lib/types/team-space";
+
+export const teamSpaceQueryKeys = {
+	all: ["team-space"] as const,
+	githubStatus: (projectGroupId: number) =>
+		["team-space", projectGroupId, "github", "status"] as const,
+};
+
+const githubStatusStaleTimeMs = 15_000;
+
+function requireProjectGroupId(projectGroupId: number | undefined) {
+	if (typeof projectGroupId !== "number") {
+		throw new Error("Project group id is required.");
+	}
+
+	return projectGroupId;
+}
+
+export function useGithubInstallationStatusQuery(
+	projectGroupId: number | undefined,
+	enabled = true,
+) {
+	return useQuery({
+		enabled: enabled && typeof projectGroupId === "number",
+		queryFn: () =>
+			getGithubInstallationStatus(requireProjectGroupId(projectGroupId)),
+		queryKey:
+			typeof projectGroupId === "number"
+				? teamSpaceQueryKeys.githubStatus(projectGroupId)
+				: teamSpaceQueryKeys.all,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: githubStatusStaleTimeMs,
+	});
+}
+
+export function useCreateGithubAppInstallationUrlMutation() {
+	return useMutation({
+		mutationFn: (projectGroupId: number) =>
+			createGithubAppInstallationUrl(projectGroupId),
+	});
+}
+
+export function useCompleteGithubAppInstallationMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: GithubAppInstallationCompleteRequest) =>
+			completeGithubAppInstallation(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.githubStatus(variables.projectGroupId),
+			});
+		},
+	});
+}

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -20,7 +20,17 @@ import type {
 	MatchStatus,
 	ProjectRequestPayload,
 } from "@/lib/types/match";
+import type {
+	CreateProjectChecklistRequest,
+	ProjectChecklist,
+	ProjectChecklistStatus,
+	UpdateProjectChecklistRequest,
+} from "@/lib/types/project-checklist";
 import type { MyProjectGroup } from "@/lib/types/project-group";
+import type {
+	GithubAppInstallationCompleteRequest,
+	GithubInstallationStatus,
+} from "@/lib/types/team-space";
 import type {
 	EditPasswordRequest,
 	UpdateCurrentUserRequest,
@@ -35,6 +45,11 @@ let activeMatchId: number | null = null;
 let activeMatchMembers: MatchMemberResponse["members"] = [];
 let activeMatchProject: MatchProjectResponse | null = null;
 let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
+let activeProjectChecklists: ProjectChecklist[] = createMockProjectChecklists();
+let nextProjectChecklistId = 103;
+let githubInstallationStatus: GithubInstallationStatus =
+	createDisconnectedGithubStatus();
+let pendingGithubInstallationState: string | null = null;
 let deleteEmailAuthSentUserId: number | null = null;
 let deleteEmailVerifiedUserId: number | null = null;
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
@@ -77,6 +92,7 @@ function syncSessionFromRequest(request: Request) {
 		resetDeleteEmailState();
 		resetMatchState();
 		activeProjectGroup = createMockProjectGroup();
+		resetTeamSpaceApiState();
 		return;
 	}
 
@@ -86,6 +102,7 @@ function syncSessionFromRequest(request: Request) {
 		resetDeleteEmailState();
 		resetMatchState();
 		activeProjectGroup = null;
+		resetTeamSpaceApiState();
 		return;
 	}
 
@@ -95,6 +112,7 @@ function syncSessionFromRequest(request: Request) {
 		resetDeleteEmailState();
 		resetMatchState();
 		activeProjectGroup = null;
+		resetTeamSpaceApiState();
 	}
 }
 
@@ -208,6 +226,23 @@ function resetMatchState() {
 	activeMatchProject = null;
 }
 
+function resetTeamSpaceApiState() {
+	activeProjectChecklists = activeProjectGroup
+		? createMockProjectChecklists()
+		: [];
+	nextProjectChecklistId = 103;
+	githubInstallationStatus = createDisconnectedGithubStatus();
+	pendingGithubInstallationState = null;
+}
+
+function createDisconnectedGithubStatus(): GithubInstallationStatus {
+	return {
+		connected: false,
+		organizationLogin: null,
+		repositoryCount: 0,
+	};
+}
+
 function isValidMatchRole(value: string): value is MatchRole {
 	return ["BACKEND", "FRONTEND", "DESIGN"].includes(value);
 }
@@ -228,6 +263,83 @@ function hasPartialProjectInfo(body: ProjectRequestPayload) {
 	];
 
 	return fields.some(Boolean) && !fields.every(Boolean);
+}
+
+function isValidProjectChecklistStatus(
+	value: string,
+): value is ProjectChecklistStatus {
+	return ["TODO", "DONE"].includes(value);
+}
+
+function normalizeOptionalText(value: string | null | undefined) {
+	const trimmedValue = value?.trim();
+	return trimmedValue ? trimmedValue : null;
+}
+
+function findProjectGroupMember(userId: number | null | undefined) {
+	if (typeof userId !== "number") {
+		return null;
+	}
+
+	return (
+		activeProjectGroup?.members.find((member) => member.userId === userId) ??
+		null
+	);
+}
+
+function assertSignedIn() {
+	if (!currentUser) {
+		return buildErrorResponse(
+			401,
+			"로그인이 필요합니다.",
+			"NO_AUTHENTICATED_USER",
+		);
+	}
+
+	return null;
+}
+
+function assertProjectGroupAccess(projectGroupId: number) {
+	const authError = assertSignedIn();
+
+	if (authError) {
+		return authError;
+	}
+
+	if (
+		!activeProjectGroup ||
+		activeProjectGroup.projectGroupId !== projectGroupId
+	) {
+		return buildErrorResponse(
+			403,
+			"팀 스페이스 접근 권한이 없습니다.",
+			"PROJECT_GROUP_ACCESS_DENIED",
+		);
+	}
+
+	return null;
+}
+
+function assertProjectGroupHost(projectGroupId: number) {
+	const accessError = assertProjectGroupAccess(projectGroupId);
+
+	if (accessError) {
+		return accessError;
+	}
+
+	const currentMember = activeProjectGroup?.members.find(
+		(member) => member.userId === currentUserId,
+	);
+
+	if (currentMember?.groupRole !== "HOST") {
+		return buildErrorResponse(
+			403,
+			"팀 스페이스 호스트만 Github Organization 연결을 진행할 수 있습니다.",
+			"PROJECT_GROUP_PERMISSION_DENIED",
+		);
+	}
+
+	return null;
 }
 
 function createMockMatchSession(body: ProjectRequestPayload) {
@@ -385,6 +497,69 @@ function createMockProjectGroup(): MyProjectGroup {
 	};
 }
 
+function createMockProjectChecklists(): ProjectChecklist[] {
+	const currentMember = activeProjectGroup?.members.find(
+		(member) => member.userId === currentUserId,
+	);
+	const backendMember = activeProjectGroup?.members.find(
+		(member) => member.memberRole === "BACKEND",
+	);
+
+	return [
+		{
+			aiAdvice: {
+				considerations: [
+					"응답 코드와 에러 코드는 API 문서에 같이 남깁니다.",
+					"실패 케이스는 MSW에서 먼저 재현할 수 있게 둡니다.",
+				],
+				improvementPoints: ["공통 에러 메시지 매핑을 재사용합니다."],
+				recommendedFlow: [
+					"서버 컨트롤러와 DTO를 먼저 확인합니다.",
+					"Client 타입과 request 함수를 맞춥니다.",
+					"실패 응답을 화면에서 확인합니다.",
+				],
+				summary: "API 계약을 기준으로 체크리스트를 정리하세요.",
+			},
+			assigneeNickname: backendMember?.nickname ?? "api_builder",
+			assigneeUserId: backendMember?.userId ?? 2,
+			createdAt: "2026-05-17T10:00:00Z",
+			createdByNickname: currentMember?.nickname ?? "preview",
+			createdByUserId: currentUserId,
+			description: "서버 응답과 Client 처리 흐름을 함께 검증합니다.",
+			dueDate: "2026-05-28",
+			id: 100,
+			status: "TODO",
+			title: "API 계약 동기화",
+		},
+		{
+			aiAdvice: null,
+			assigneeNickname: currentMember?.nickname ?? "preview",
+			assigneeUserId: currentUserId,
+			createdAt: "2026-05-18T09:30:00Z",
+			createdByNickname: currentMember?.nickname ?? "preview",
+			createdByUserId: currentUserId,
+			description: "팀 스페이스 홈에서 가장 먼저 볼 작업을 정합니다.",
+			dueDate: "2026-05-30",
+			id: 101,
+			status: "DONE",
+			title: "첫 스프린트 작업 정리",
+		},
+		{
+			aiAdvice: null,
+			assigneeNickname: null,
+			assigneeUserId: null,
+			createdAt: "2026-05-19T08:10:00Z",
+			createdByNickname: currentMember?.nickname ?? "preview",
+			createdByUserId: currentUserId,
+			description: null,
+			dueDate: null,
+			id: 102,
+			status: "TODO",
+			title: "GitHub Organization 연결 확인",
+		},
+	];
+}
+
 function createProjectGroupFromActiveMatch(): MyProjectGroup | null {
 	if (!activeMatchProject || activeMatchMembers.length === 0) {
 		return null;
@@ -426,6 +601,7 @@ function completeMatchIfEveryoneAccepted() {
 
 	matchStatus = "MATCHED";
 	activeProjectGroup = createProjectGroupFromActiveMatch();
+	resetTeamSpaceApiState();
 }
 
 export const handlers = [
@@ -460,6 +636,7 @@ export const handlers = [
 			resetDeleteEmailState();
 			resetMatchState();
 			activeProjectGroup = createMockProjectGroup();
+			resetTeamSpaceApiState();
 
 			return HttpResponse.json(buildSession());
 		}
@@ -505,6 +682,7 @@ export const handlers = [
 			resetDeleteEmailState();
 			resetMatchState();
 			activeProjectGroup = null;
+			resetTeamSpaceApiState();
 
 			return HttpResponse.json(buildSession());
 		}
@@ -524,6 +702,7 @@ export const handlers = [
 			resetDeleteEmailState();
 			resetMatchState();
 			activeProjectGroup = null;
+			resetTeamSpaceApiState();
 
 			return HttpResponse.json(buildSession());
 		}
@@ -788,6 +967,7 @@ export const handlers = [
 		resetDeleteEmailState();
 		resetMatchState();
 		activeProjectGroup = null;
+		resetTeamSpaceApiState();
 
 		return new HttpResponse(null, { status: 200 });
 	}),
@@ -971,6 +1151,7 @@ export const handlers = [
 		activeMatchMembers = [];
 		activeMatchProject = null;
 		activeProjectGroup = null;
+		resetTeamSpaceApiState();
 
 		return new HttpResponse(null, { status: 200 });
 	}),
@@ -1275,6 +1456,353 @@ export const handlers = [
 			}
 
 			targetMember.admin = false;
+			return new HttpResponse(null, { status: 200 });
+		},
+	),
+
+	http.get(
+		getPath("/project-groups/:projectGroupId/checklists"),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			return HttpResponse.json(activeProjectChecklists);
+		},
+	),
+
+	http.post(
+		getPath("/project-groups/:projectGroupId/checklists"),
+		async ({ params, request }) => {
+			const body = (await request.json()) as CreateProjectChecklistRequest;
+
+			await delay(350);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			if (!body.title?.trim() || body.title.length > 255) {
+				return buildErrorResponse(
+					400,
+					"체크리스트 제목은 필수입니다.",
+					"INVALID_INPUT_FIELD",
+					{ title: "체크리스트 제목은 255자 이하로 입력해 주세요." },
+				);
+			}
+
+			const assignee = findProjectGroupMember(body.assigneeUserId);
+
+			if (typeof body.assigneeUserId === "number" && !assignee) {
+				return buildErrorResponse(
+					400,
+					"담당자는 현재 팀 멤버여야 합니다.",
+					"PROJECT_CHECKLIST_ASSIGNEE_NOT_MEMBER",
+				);
+			}
+
+			const currentMember = findProjectGroupMember(currentUserId);
+			const checklist: ProjectChecklist = {
+				aiAdvice: null,
+				assigneeNickname: assignee?.nickname ?? null,
+				assigneeUserId: assignee?.userId ?? null,
+				createdAt: new Date().toISOString(),
+				createdByNickname: currentMember?.nickname ?? "preview",
+				createdByUserId: currentUserId,
+				description: normalizeOptionalText(body.description),
+				dueDate: body.dueDate ?? null,
+				id: nextProjectChecklistId,
+				status: "TODO",
+				title: body.title.trim(),
+			};
+
+			nextProjectChecklistId += 1;
+			activeProjectChecklists = [...activeProjectChecklists, checklist];
+
+			return HttpResponse.json(checklist, { status: 201 });
+		},
+	),
+
+	http.patch(
+		getPath("/project-groups/:projectGroupId/checklists/:checklistId"),
+		async ({ params, request }) => {
+			const body = (await request.json()) as UpdateProjectChecklistRequest;
+
+			await delay(350);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const checklistId = Number(params.checklistId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			const checklist = activeProjectChecklists.find(
+				(candidate) => candidate.id === checklistId,
+			);
+
+			if (!checklist) {
+				return buildErrorResponse(
+					404,
+					"체크리스트를 찾을 수 없습니다.",
+					"PROJECT_CHECKLIST_NOT_FOUND",
+				);
+			}
+
+			if (
+				!body.title?.trim() ||
+				body.title.length > 255 ||
+				!isValidProjectChecklistStatus(body.status)
+			) {
+				return buildErrorResponse(
+					400,
+					"입력한 정보를 다시 확인해 주세요.",
+					"INVALID_INPUT_FIELD",
+				);
+			}
+
+			const assignee = findProjectGroupMember(body.assigneeUserId);
+
+			if (typeof body.assigneeUserId === "number" && !assignee) {
+				return buildErrorResponse(
+					400,
+					"담당자는 현재 팀 멤버여야 합니다.",
+					"PROJECT_CHECKLIST_ASSIGNEE_NOT_MEMBER",
+				);
+			}
+
+			const updatedChecklist: ProjectChecklist = {
+				...checklist,
+				assigneeNickname: assignee?.nickname ?? null,
+				assigneeUserId: assignee?.userId ?? null,
+				description: normalizeOptionalText(body.description),
+				dueDate: body.dueDate ?? null,
+				status: body.status,
+				title: body.title.trim(),
+			};
+
+			activeProjectChecklists = activeProjectChecklists.map((candidate) =>
+				candidate.id === checklistId ? updatedChecklist : candidate,
+			);
+
+			return HttpResponse.json(updatedChecklist);
+		},
+	),
+
+	http.delete(
+		getPath("/project-groups/:projectGroupId/checklists/:checklistId"),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const checklistId = Number(params.checklistId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			const checklistExists = activeProjectChecklists.some(
+				(candidate) => candidate.id === checklistId,
+			);
+
+			if (!checklistExists) {
+				return buildErrorResponse(
+					404,
+					"체크리스트를 찾을 수 없습니다.",
+					"PROJECT_CHECKLIST_NOT_FOUND",
+				);
+			}
+
+			activeProjectChecklists = activeProjectChecklists.filter(
+				(candidate) => candidate.id !== checklistId,
+			);
+
+			return new HttpResponse(null, { status: 204 });
+		},
+	),
+
+	http.post(
+		getPath("/project-groups/:projectGroupId/checklists/:checklistId/advice"),
+		async ({ params, request }) => {
+			await delay(600);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const checklistId = Number(params.checklistId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			const checklist = activeProjectChecklists.find(
+				(candidate) => candidate.id === checklistId,
+			);
+
+			if (!checklist) {
+				return buildErrorResponse(
+					404,
+					"체크리스트를 찾을 수 없습니다.",
+					"PROJECT_CHECKLIST_NOT_FOUND",
+				);
+			}
+
+			if (!checklist.description) {
+				return buildErrorResponse(
+					400,
+					"체크리스트 설명이 있어야 AI 조언을 생성할 수 있습니다.",
+					"PROJECT_CHECKLIST_DESCRIPTION_REQUIRED_FOR_AI",
+				);
+			}
+
+			if (checklist.title.includes("서버 오류")) {
+				return buildErrorResponse(
+					500,
+					"Gemini API 응답 형식이 올바르지 않습니다.",
+					"GEMINI_INVALID_RESPONSE",
+				);
+			}
+
+			const aiAdvice = {
+				considerations: [
+					"완료 기준을 한 문장으로 먼저 정리하세요.",
+					"담당자와 마감일을 실제 일정에 맞춰 조정하세요.",
+				],
+				improvementPoints: ["체크리스트 설명에 검증 방법을 추가하세요."],
+				recommendedFlow: [
+					"작업 범위를 작게 나눕니다.",
+					"서버 응답과 화면 상태를 함께 확인합니다.",
+					"완료 후 팀 스페이스에서 결과를 공유합니다.",
+				],
+				summary: `${checklist.title} 작업은 검증 기준부터 고정하는 편이 좋습니다.`,
+			};
+			const updatedChecklist: ProjectChecklist = {
+				...checklist,
+				aiAdvice,
+			};
+
+			activeProjectChecklists = activeProjectChecklists.map((candidate) =>
+				candidate.id === checklistId ? updatedChecklist : candidate,
+			);
+
+			return HttpResponse.json({
+				aiAdvice,
+				checklistId,
+			});
+		},
+	),
+
+	http.get(
+		getPath("/team-space/:projectGroupId/github/status"),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			return HttpResponse.json(githubInstallationStatus);
+		},
+	),
+
+	http.post(
+		getPath("/team-space/:projectGroupId/github/install-url"),
+		async ({ params, request }) => {
+			await delay(350);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const hostError = assertProjectGroupHost(projectGroupId);
+
+			if (hostError) {
+				return hostError;
+			}
+
+			if (githubInstallationStatus.connected) {
+				return buildErrorResponse(
+					409,
+					"이미 Github Organization이 연결된 팀 스페이스입니다.",
+					"GITHUB_APP_INSTALLATION_ALREADY_EXISTS",
+				);
+			}
+
+			pendingGithubInstallationState = crypto.randomUUID();
+
+			return HttpResponse.json({
+				installUrl: `https://github.com/apps/team-po/installations/new?state=${pendingGithubInstallationState}`,
+			});
+		},
+	),
+
+	http.post(
+		getPath("/team-space/:projectGroupId/github/installations/complete"),
+		async ({ params, request }) => {
+			const body =
+				(await request.json()) as GithubAppInstallationCompleteRequest;
+
+			await delay(400);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const hostError = assertProjectGroupHost(projectGroupId);
+
+			if (hostError) {
+				return hostError;
+			}
+
+			if (
+				body.setupAction !== "install" ||
+				!pendingGithubInstallationState ||
+				body.state !== pendingGithubInstallationState
+			) {
+				return buildErrorResponse(
+					400,
+					"GitHub App 설치 요청 상태가 만료되었거나 올바르지 않습니다.",
+					"INVALID_GITHUB_APP_INSTALLATION_STATE",
+				);
+			}
+
+			if (body.installationId === 500) {
+				return buildErrorResponse(
+					502,
+					"GitHub API 요청에 실패했습니다.",
+					"GITHUB_API_REQUEST_FAILED",
+				);
+			}
+
+			if (githubInstallationStatus.connected) {
+				return buildErrorResponse(
+					409,
+					"이미 Github Organization이 연결된 팀 스페이스입니다.",
+					"GITHUB_APP_INSTALLATION_ALREADY_EXISTS",
+				);
+			}
+
+			pendingGithubInstallationState = null;
+			githubInstallationStatus = {
+				connected: true,
+				organizationLogin: "team-po-labs",
+				repositoryCount: 2,
+			};
+
 			return new HttpResponse(null, { status: 200 });
 		},
 	),

--- a/src/lib/api/project-checklists.ts
+++ b/src/lib/api/project-checklists.ts
@@ -1,0 +1,66 @@
+import { apiRequest } from "@/lib/api/client";
+import type {
+	CreateProjectChecklistRequest,
+	DeleteProjectChecklistRequest,
+	GenerateChecklistAdviceRequest,
+	GenerateChecklistAdviceResponse,
+	ProjectChecklist,
+	UpdateProjectChecklistRequest,
+} from "@/lib/types/project-checklist";
+
+export function getProjectChecklists(projectGroupId: number) {
+	return apiRequest<ProjectChecklist[]>(
+		`/project-groups/${projectGroupId}/checklists`,
+	);
+}
+
+export function createProjectChecklist({
+	projectGroupId,
+	...payload
+}: CreateProjectChecklistRequest) {
+	return apiRequest<ProjectChecklist>(
+		`/project-groups/${projectGroupId}/checklists`,
+		{
+			json: payload,
+			method: "POST",
+		},
+	);
+}
+
+export function updateProjectChecklist({
+	checklistId,
+	projectGroupId,
+	...payload
+}: UpdateProjectChecklistRequest) {
+	return apiRequest<ProjectChecklist>(
+		`/project-groups/${projectGroupId}/checklists/${checklistId}`,
+		{
+			json: payload,
+			method: "PATCH",
+		},
+	);
+}
+
+export function deleteProjectChecklist({
+	checklistId,
+	projectGroupId,
+}: DeleteProjectChecklistRequest) {
+	return apiRequest<void>(
+		`/project-groups/${projectGroupId}/checklists/${checklistId}`,
+		{
+			method: "DELETE",
+		},
+	);
+}
+
+export function generateChecklistAdvice({
+	checklistId,
+	projectGroupId,
+}: GenerateChecklistAdviceRequest) {
+	return apiRequest<GenerateChecklistAdviceResponse>(
+		`/project-groups/${projectGroupId}/checklists/${checklistId}/advice`,
+		{
+			method: "POST",
+		},
+	);
+}

--- a/src/lib/api/team-space.ts
+++ b/src/lib/api/team-space.ts
@@ -1,0 +1,40 @@
+import { apiRequest } from "@/lib/api/client";
+import type {
+	GithubAppInstallationCompleteRequest,
+	GithubAppInstallationUrl,
+	GithubInstallationStatus,
+} from "@/lib/types/team-space";
+
+export function getGithubInstallationStatus(projectGroupId: number) {
+	return apiRequest<GithubInstallationStatus>(
+		`/team-space/${projectGroupId}/github/status`,
+	);
+}
+
+export function createGithubAppInstallationUrl(projectGroupId: number) {
+	return apiRequest<GithubAppInstallationUrl>(
+		`/team-space/${projectGroupId}/github/install-url`,
+		{
+			method: "POST",
+		},
+	);
+}
+
+export function completeGithubAppInstallation({
+	installationId,
+	projectGroupId,
+	setupAction,
+	state,
+}: GithubAppInstallationCompleteRequest) {
+	return apiRequest<void>(
+		`/team-space/${projectGroupId}/github/installations/complete`,
+		{
+			json: {
+				installationId,
+				setupAction,
+				state,
+			},
+			method: "POST",
+		},
+	);
+}

--- a/src/lib/types/project-checklist.ts
+++ b/src/lib/types/project-checklist.ts
@@ -1,0 +1,53 @@
+export type ProjectChecklistStatus = "TODO" | "DONE";
+
+export interface ChecklistAiAdvice {
+	summary: string;
+	recommendedFlow: string[];
+	considerations: string[];
+	improvementPoints: string[];
+}
+
+export interface ProjectChecklist {
+	aiAdvice: ChecklistAiAdvice | null;
+	assigneeNickname: string | null;
+	assigneeUserId: number | null;
+	createdAt: string;
+	createdByNickname: string;
+	createdByUserId: number;
+	description: string | null;
+	dueDate: string | null;
+	id: number;
+	status: ProjectChecklistStatus;
+	title: string;
+}
+
+export interface ProjectChecklistPathParams {
+	checklistId: number;
+	projectGroupId: number;
+}
+
+export interface CreateProjectChecklistRequest {
+	assigneeUserId?: number | null;
+	description?: string | null;
+	dueDate?: string | null;
+	projectGroupId: number;
+	title: string;
+}
+
+export interface UpdateProjectChecklistRequest
+	extends ProjectChecklistPathParams {
+	assigneeUserId?: number | null;
+	description?: string | null;
+	dueDate?: string | null;
+	status: ProjectChecklistStatus;
+	title: string;
+}
+
+export type DeleteProjectChecklistRequest = ProjectChecklistPathParams;
+
+export type GenerateChecklistAdviceRequest = ProjectChecklistPathParams;
+
+export interface GenerateChecklistAdviceResponse {
+	aiAdvice: ChecklistAiAdvice;
+	checklistId: number;
+}

--- a/src/lib/types/team-space.ts
+++ b/src/lib/types/team-space.ts
@@ -1,0 +1,16 @@
+export interface GithubInstallationStatus {
+	connected: boolean;
+	organizationLogin: string | null;
+	repositoryCount: number;
+}
+
+export interface GithubAppInstallationUrl {
+	installUrl: string;
+}
+
+export interface GithubAppInstallationCompleteRequest {
+	installationId: number;
+	projectGroupId: number;
+	setupAction: string;
+	state: string;
+}


### PR DESCRIPTION
<!-- codex-server-api-sync-to-client -->

## Summary
- Mirror Server mainline project checklist CRUD and AI advice endpoints in Client OpenAPI, shared types, request functions, query hooks, and MSW handlers.
- Mirror Server team-space GitHub App installation status, install URL, and completion endpoints.
- Connect the real Team Space view to server-backed checklist and GitHub installation flows while keeping the mock preview path intact.

## Validation
- [x] pnpm typecheck
- [x] pnpm biome lint .
- [x] pnpm build

Closes #63