### PR TITLE
feat(team): complete checklist edit API UI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,9 @@
 - Matching UI lives in `src/features/match/*`.
 - Team workspace UI lives in `src/features/team/*`.
 - Shared domain types live in `src/lib/types/*`.
-- API request functions stay in `src/lib/api/*`; the current team-space preview uses local demo data only because backend endpoints are not ready yet.
+- API request functions stay in `src/lib/api/*`.
+- `/team` uses project group, checklist, admin permission, and GitHub App installation request functions when a user is signed in.
+- In mock API mode, signed-in `/team` calls the same request functions through MSW; signed-out `/team` keeps the richer local demo workspace as a preview.
 
 ## Current User Flow
 
@@ -16,8 +18,8 @@
 
 ## Temporary UI State
 
-- Team workspace editing is currently local-only React state.
-- Editable surfaces include team name, lifecycle status, rules Markdown, checklist items, GitHub connection preview, random reviewer, and team messages.
-- Replace these local state handlers with `src/lib/api/*` request functions when backend endpoints are available.
+- Real API mode and signed-in mock mode use `src/lib/api/*` request functions for implemented team-space server capabilities.
+- Signed-out mock mode still keeps team name, lifecycle status, rules Markdown, GitHub repository preview, random reviewer, and team messages in local React state.
+- Move remaining mock-only team surfaces to `src/lib/api/*` when matching backend endpoints are introduced.
 
 Presentation routes under `/deck/team-po*` are intentionally unchanged.

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -18,6 +18,7 @@ import {
 	ShieldCheck,
 	Sparkles,
 	Trash2,
+	X,
 } from "lucide-react";
 import {
 	type ComponentType,
@@ -143,7 +144,7 @@ const contributionLevelClass = [
 export function TeamSpaceView() {
 	const [isSignedIn] = useState(() => Boolean(getAuthSession()));
 
-	if (!apiConfig.useMocks) {
+	if (!apiConfig.useMocks || isSignedIn) {
 		return <RealTeamSpaceView isSignedIn={isSignedIn} />;
 	}
 
@@ -645,6 +646,9 @@ function RealProjectChecklistsPanel({
 		dueDate: "",
 		title: "",
 	});
+	const [editingChecklistId, setEditingChecklistId] = useState<number | null>(
+		null,
+	);
 	const checklists = checklistQuery.data ?? [];
 	const pendingChecklistId = updateChecklistMutation.isPending
 		? (updateChecklistMutation.variables?.checklistId ?? null)
@@ -701,6 +705,73 @@ function RealProjectChecklistsPanel({
 		);
 	}
 
+	function handleStartEdit(checklist: ProjectChecklist) {
+		setFeedback(null);
+		setEditingChecklistId(checklist.id);
+	}
+
+	function handleCancelEdit() {
+		setEditingChecklistId(null);
+	}
+
+	function handleUpdateChecklist(
+		event: FormEvent<HTMLFormElement>,
+		checklist: ProjectChecklist,
+	) {
+		event.preventDefault();
+
+		const formData = new FormData(event.currentTarget);
+		const title = getChecklistFormValue(formData, "title").trim();
+		const description = getChecklistFormValue(formData, "description").trim();
+		const dueDate = getChecklistFormValue(formData, "dueDate");
+		const assigneeUserId = getChecklistFormValue(formData, "assigneeUserId");
+		const status = getChecklistFormValue(formData, "status");
+
+		if (!title) {
+			setFeedback({
+				message: "체크리스트 제목을 입력해 주세요.",
+				tone: "error",
+			});
+			return;
+		}
+
+		if (!isProjectChecklistStatus(status)) {
+			setFeedback({
+				message: "체크리스트 상태를 다시 선택해 주세요.",
+				tone: "error",
+			});
+			return;
+		}
+
+		setFeedback(null);
+		updateChecklistMutation.mutate(
+			{
+				assigneeUserId: assigneeUserId ? Number(assigneeUserId) : null,
+				checklistId: checklist.id,
+				description: description || null,
+				dueDate: dueDate || null,
+				projectGroupId: projectGroup.projectGroupId,
+				status,
+				title,
+			},
+			{
+				onError: (error: unknown) => {
+					setFeedback({
+						message: getApiErrorMessage(error),
+						tone: "error",
+					});
+				},
+				onSuccess: () => {
+					handleCancelEdit();
+					setFeedback({
+						message: "체크리스트를 수정했습니다.",
+						tone: "success",
+					});
+				},
+			},
+		);
+	}
+
 	function handleStatusChange(
 		checklist: ProjectChecklist,
 		status: ProjectChecklistStatus,
@@ -721,6 +792,12 @@ function RealProjectChecklistsPanel({
 					setFeedback({
 						message: getApiErrorMessage(error),
 						tone: "error",
+					});
+				},
+				onSuccess: () => {
+					setFeedback({
+						message: "체크리스트 상태를 변경했습니다.",
+						tone: "success",
 					});
 				},
 			},
@@ -905,96 +982,224 @@ function RealProjectChecklistsPanel({
 				<div className="grid gap-3">
 					{checklists.map((checklist) => {
 						const isPending = pendingChecklistId === checklist.id;
+						const isEditing = editingChecklistId === checklist.id;
 
 						return (
 							<div
 								className="grid gap-4 rounded-lg border border-border/70 bg-white p-4 shadow-crisp xl:grid-cols-[1fr_auto]"
 								key={checklist.id}
 							>
-								<div className="min-w-0">
-									<div className="flex flex-wrap items-center gap-2">
-										<Badge
-											className={projectChecklistStatusTone[checklist.status]}
-											variant="neutral"
-										>
-											{projectChecklistStatusLabels[checklist.status]}
-										</Badge>
-										<p className="text-sm font-semibold text-brand-ink">
-											{checklist.title}
-										</p>
-									</div>
-									<p className="mt-2 text-sm leading-6 text-muted-foreground">
-										{checklist.description ?? "설명이 없습니다."}
-									</p>
-									<div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
-										<span>담당 {checklist.assigneeNickname ?? "미지정"}</span>
-										<span>마감 {checklist.dueDate ?? "미정"}</span>
-										<span>생성 {checklist.createdByNickname}</span>
-									</div>
-									{checklist.aiAdvice ? (
-										<RealChecklistAdvice checklist={checklist} />
-									) : null}
-								</div>
-								<div className="flex flex-wrap items-start gap-2 xl:justify-end">
-									<Button
-										disabled={isPending}
-										onClick={() =>
-											handleStatusChange(
-												checklist,
-												checklist.status === "DONE" ? "TODO" : "DONE",
-											)
+								{isEditing ? (
+									<form
+										className="grid gap-3 xl:col-span-2"
+										onSubmit={(event) =>
+											handleUpdateChecklist(event, checklist)
 										}
-										size="sm"
-										type="button"
-										variant="outline"
 									>
-										{isPending &&
-										updateChecklistMutation.variables?.checklistId ===
-											checklist.id ? (
-											<LoaderCircle
-												className="animate-spin"
-												data-icon="inline-start"
-											/>
-										) : (
-											<CheckCircle2 data-icon="inline-start" />
-										)}
-										{checklist.status === "DONE" ? "다시 열기" : "완료"}
-									</Button>
-									<Button
-										disabled={isPending}
-										onClick={() => handleGenerateAdvice(checklist)}
-										size="sm"
-										type="button"
-										variant="outline"
-									>
-										{isPending &&
-										generateAdviceMutation.variables?.checklistId ===
-											checklist.id ? (
-											<LoaderCircle
-												className="animate-spin"
-												data-icon="inline-start"
-											/>
-										) : (
-											<Sparkles data-icon="inline-start" />
-										)}
-										AI 조언
-									</Button>
-									<Button
-										disabled={isPending}
-										onClick={() => handleDeleteChecklist(checklist)}
-										size="icon"
-										type="button"
-										variant="ghost"
-									>
-										{isPending &&
-										deleteChecklistMutation.variables?.checklistId ===
-											checklist.id ? (
-											<LoaderCircle className="size-4 animate-spin" />
-										) : (
-											<Trash2 />
-										)}
-									</Button>
-								</div>
+										<div className="grid gap-3 lg:grid-cols-[1fr_1.2fr_9rem_10rem_12rem]">
+											<label
+												className="grid gap-2 text-sm font-semibold text-brand-ink"
+												htmlFor={`real-checklist-edit-title-${checklist.id}`}
+											>
+												제목
+												<input
+													className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+													defaultValue={checklist.title}
+													id={`real-checklist-edit-title-${checklist.id}`}
+													maxLength={255}
+													name="title"
+												/>
+											</label>
+											<label
+												className="grid gap-2 text-sm font-semibold text-brand-ink"
+												htmlFor={`real-checklist-edit-description-${checklist.id}`}
+											>
+												설명
+												<input
+													className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+													defaultValue={checklist.description ?? ""}
+													id={`real-checklist-edit-description-${checklist.id}`}
+													maxLength={3000}
+													name="description"
+												/>
+											</label>
+											<label
+												className="grid gap-2 text-sm font-semibold text-brand-ink"
+												htmlFor={`real-checklist-edit-status-${checklist.id}`}
+											>
+												상태
+												<select
+													className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+													defaultValue={checklist.status}
+													id={`real-checklist-edit-status-${checklist.id}`}
+													name="status"
+												>
+													<option value="TODO">할 일</option>
+													<option value="DONE">완료</option>
+												</select>
+											</label>
+											<label
+												className="grid gap-2 text-sm font-semibold text-brand-ink"
+												htmlFor={`real-checklist-edit-due-date-${checklist.id}`}
+											>
+												마감일
+												<input
+													className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+													defaultValue={checklist.dueDate ?? ""}
+													id={`real-checklist-edit-due-date-${checklist.id}`}
+													name="dueDate"
+													type="date"
+												/>
+											</label>
+											<label
+												className="grid gap-2 text-sm font-semibold text-brand-ink"
+												htmlFor={`real-checklist-edit-assignee-${checklist.id}`}
+											>
+												담당자
+												<select
+													className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+													defaultValue={checklist.assigneeUserId ?? ""}
+													id={`real-checklist-edit-assignee-${checklist.id}`}
+													name="assigneeUserId"
+												>
+													<option value="">미지정</option>
+													{projectGroup.members.map((member) => (
+														<option key={member.userId} value={member.userId}>
+															{member.nickname}
+														</option>
+													))}
+												</select>
+											</label>
+										</div>
+										<div className="flex flex-wrap justify-end gap-2">
+											<Button
+												disabled={isPending}
+												onClick={handleCancelEdit}
+												type="button"
+												variant="outline"
+											>
+												<X data-icon="inline-start" />
+												취소
+											</Button>
+											<Button disabled={isPending} type="submit">
+												{isPending &&
+												updateChecklistMutation.variables?.checklistId ===
+													checklist.id ? (
+													<LoaderCircle
+														className="animate-spin"
+														data-icon="inline-start"
+													/>
+												) : (
+													<Save data-icon="inline-start" />
+												)}
+												저장
+											</Button>
+										</div>
+									</form>
+								) : (
+									<>
+										<div className="min-w-0">
+											<div className="flex flex-wrap items-center gap-2">
+												<Badge
+													className={
+														projectChecklistStatusTone[checklist.status]
+													}
+													variant="neutral"
+												>
+													{projectChecklistStatusLabels[checklist.status]}
+												</Badge>
+												<p className="text-sm font-semibold text-brand-ink">
+													{checklist.title}
+												</p>
+											</div>
+											<p className="mt-2 text-sm leading-6 text-muted-foreground">
+												{checklist.description ?? "설명이 없습니다."}
+											</p>
+											<div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+												<span>
+													담당 {checklist.assigneeNickname ?? "미지정"}
+												</span>
+												<span>마감 {checklist.dueDate ?? "미정"}</span>
+												<span>생성 {checklist.createdByNickname}</span>
+											</div>
+											{checklist.aiAdvice ? (
+												<RealChecklistAdvice checklist={checklist} />
+											) : null}
+										</div>
+										<div className="flex flex-wrap items-start gap-2 xl:justify-end">
+											<Button
+												disabled={isPending}
+												onClick={() => handleStartEdit(checklist)}
+												size="sm"
+												type="button"
+												variant="outline"
+											>
+												<PencilLine data-icon="inline-start" />
+												수정
+											</Button>
+											<Button
+												disabled={isPending}
+												onClick={() =>
+													handleStatusChange(
+														checklist,
+														checklist.status === "DONE" ? "TODO" : "DONE",
+													)
+												}
+												size="sm"
+												type="button"
+												variant="outline"
+											>
+												{isPending &&
+												updateChecklistMutation.variables?.checklistId ===
+													checklist.id ? (
+													<LoaderCircle
+														className="animate-spin"
+														data-icon="inline-start"
+													/>
+												) : (
+													<CheckCircle2 data-icon="inline-start" />
+												)}
+												{checklist.status === "DONE" ? "다시 열기" : "완료"}
+											</Button>
+											<Button
+												disabled={isPending}
+												onClick={() => handleGenerateAdvice(checklist)}
+												size="sm"
+												type="button"
+												variant="outline"
+											>
+												{isPending &&
+												generateAdviceMutation.variables?.checklistId ===
+													checklist.id ? (
+													<LoaderCircle
+														className="animate-spin"
+														data-icon="inline-start"
+													/>
+												) : (
+													<Sparkles data-icon="inline-start" />
+												)}
+												AI 조언
+											</Button>
+											<Button
+												aria-label="체크리스트 삭제"
+												disabled={isPending}
+												onClick={() => handleDeleteChecklist(checklist)}
+												size="icon"
+												title="체크리스트 삭제"
+												type="button"
+												variant="ghost"
+											>
+												{isPending &&
+												deleteChecklistMutation.variables?.checklistId ===
+													checklist.id ? (
+													<LoaderCircle className="size-4 animate-spin" />
+												) : (
+													<Trash2 />
+												)}
+											</Button>
+										</div>
+									</>
+								)}
 							</div>
 						);
 					})}
@@ -1045,6 +1250,17 @@ function RealAdviceList({ items, title }: { items: string[]; title: string }) {
 			</ul>
 		</div>
 	);
+}
+
+function getChecklistFormValue(formData: FormData, key: string) {
+	const value = formData.get(key);
+	return typeof value === "string" ? value : "";
+}
+
+function isProjectChecklistStatus(
+	value: string,
+): value is ProjectChecklistStatus {
+	return value === "TODO" || value === "DONE";
 }
 
 function RealGithubInstallationPanel({

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -710,8 +710,14 @@ function RealProjectChecklistsPanel({
 		setEditingChecklistId(checklist.id);
 	}
 
-	function handleCancelEdit() {
-		setEditingChecklistId(null);
+	function handleCancelEdit(checklistId?: number) {
+		setEditingChecklistId((currentChecklistId) => {
+			if (checklistId === undefined || currentChecklistId === checklistId) {
+				return null;
+			}
+
+			return currentChecklistId;
+		});
 	}
 
 	function handleUpdateChecklist(
@@ -762,7 +768,7 @@ function RealProjectChecklistsPanel({
 					});
 				},
 				onSuccess: () => {
-					handleCancelEdit();
+					handleCancelEdit(checklist.id);
 					setFeedback({
 						message: "체크리스트를 수정했습니다.",
 						tone: "success",
@@ -1074,7 +1080,7 @@ function RealProjectChecklistsPanel({
 										<div className="flex flex-wrap justify-end gap-2">
 											<Button
 												disabled={isPending}
-												onClick={handleCancelEdit}
+												onClick={() => handleCancelEdit()}
 												type="button"
 												variant="outline"
 											>

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -657,8 +657,12 @@ function RealProjectChecklistsPanel({
 			: generateAdviceMutation.isPending
 				? (generateAdviceMutation.variables?.checklistId ?? null)
 				: null;
+	const isChecklistActionPending =
+		updateChecklistMutation.isPending ||
+		deleteChecklistMutation.isPending ||
+		generateAdviceMutation.isPending;
 
-	function handleCreateChecklist(event: FormEvent<HTMLFormElement>) {
+	async function handleCreateChecklist(event: FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 
 		const title = draft.title.trim();
@@ -672,8 +676,8 @@ function RealProjectChecklistsPanel({
 		}
 
 		setFeedback(null);
-		createChecklistMutation.mutate(
-			{
+		try {
+			await createChecklistMutation.mutateAsync({
 				assigneeUserId: draft.assigneeUserId
 					? Number(draft.assigneeUserId)
 					: null,
@@ -681,28 +685,23 @@ function RealProjectChecklistsPanel({
 				dueDate: draft.dueDate || null,
 				projectGroupId: projectGroup.projectGroupId,
 				title,
-			},
-			{
-				onError: (error: unknown) => {
-					setFeedback({
-						message: getApiErrorMessage(error),
-						tone: "error",
-					});
-				},
-				onSuccess: () => {
-					setDraft({
-						assigneeUserId: "",
-						description: "",
-						dueDate: "",
-						title: "",
-					});
-					setFeedback({
-						message: "체크리스트를 추가했습니다.",
-						tone: "success",
-					});
-				},
-			},
-		);
+			});
+			setDraft({
+				assigneeUserId: "",
+				description: "",
+				dueDate: "",
+				title: "",
+			});
+			setFeedback({
+				message: "체크리스트를 추가했습니다.",
+				tone: "success",
+			});
+		} catch (error: unknown) {
+			setFeedback({
+				message: getApiErrorMessage(error),
+				tone: "error",
+			});
+		}
 	}
 
 	function handleStartEdit(checklist: ProjectChecklist) {
@@ -720,7 +719,7 @@ function RealProjectChecklistsPanel({
 		});
 	}
 
-	function handleUpdateChecklist(
+	async function handleUpdateChecklist(
 		event: FormEvent<HTMLFormElement>,
 		checklist: ProjectChecklist,
 	) {
@@ -750,8 +749,8 @@ function RealProjectChecklistsPanel({
 		}
 
 		setFeedback(null);
-		updateChecklistMutation.mutate(
-			{
+		try {
+			await updateChecklistMutation.mutateAsync({
 				assigneeUserId: assigneeUserId ? Number(assigneeUserId) : null,
 				checklistId: checklist.id,
 				description: description || null,
@@ -759,32 +758,27 @@ function RealProjectChecklistsPanel({
 				projectGroupId: projectGroup.projectGroupId,
 				status,
 				title,
-			},
-			{
-				onError: (error: unknown) => {
-					setFeedback({
-						message: getApiErrorMessage(error),
-						tone: "error",
-					});
-				},
-				onSuccess: () => {
-					handleCancelEdit(checklist.id);
-					setFeedback({
-						message: "체크리스트를 수정했습니다.",
-						tone: "success",
-					});
-				},
-			},
-		);
+			});
+			handleCancelEdit(checklist.id);
+			setFeedback({
+				message: "체크리스트를 수정했습니다.",
+				tone: "success",
+			});
+		} catch (error: unknown) {
+			setFeedback({
+				message: getApiErrorMessage(error),
+				tone: "error",
+			});
+		}
 	}
 
-	function handleStatusChange(
+	async function handleStatusChange(
 		checklist: ProjectChecklist,
 		status: ProjectChecklistStatus,
 	) {
 		setFeedback(null);
-		updateChecklistMutation.mutate(
-			{
+		try {
+			await updateChecklistMutation.mutateAsync({
 				assigneeUserId: checklist.assigneeUserId,
 				checklistId: checklist.id,
 				description: checklist.description,
@@ -792,70 +786,55 @@ function RealProjectChecklistsPanel({
 				projectGroupId: projectGroup.projectGroupId,
 				status,
 				title: checklist.title,
-			},
-			{
-				onError: (error: unknown) => {
-					setFeedback({
-						message: getApiErrorMessage(error),
-						tone: "error",
-					});
-				},
-				onSuccess: () => {
-					setFeedback({
-						message: "체크리스트 상태를 변경했습니다.",
-						tone: "success",
-					});
-				},
-			},
-		);
+			});
+			setFeedback({
+				message: "체크리스트 상태를 변경했습니다.",
+				tone: "success",
+			});
+		} catch (error: unknown) {
+			setFeedback({
+				message: getApiErrorMessage(error),
+				tone: "error",
+			});
+		}
 	}
 
-	function handleDeleteChecklist(checklist: ProjectChecklist) {
+	async function handleDeleteChecklist(checklist: ProjectChecklist) {
 		setFeedback(null);
-		deleteChecklistMutation.mutate(
-			{
+		try {
+			await deleteChecklistMutation.mutateAsync({
 				checklistId: checklist.id,
 				projectGroupId: projectGroup.projectGroupId,
-			},
-			{
-				onError: (error: unknown) => {
-					setFeedback({
-						message: getApiErrorMessage(error),
-						tone: "error",
-					});
-				},
-				onSuccess: () => {
-					setFeedback({
-						message: "체크리스트를 삭제했습니다.",
-						tone: "success",
-					});
-				},
-			},
-		);
+			});
+			setFeedback({
+				message: "체크리스트를 삭제했습니다.",
+				tone: "success",
+			});
+		} catch (error: unknown) {
+			setFeedback({
+				message: getApiErrorMessage(error),
+				tone: "error",
+			});
+		}
 	}
 
-	function handleGenerateAdvice(checklist: ProjectChecklist) {
+	async function handleGenerateAdvice(checklist: ProjectChecklist) {
 		setFeedback(null);
-		generateAdviceMutation.mutate(
-			{
+		try {
+			await generateAdviceMutation.mutateAsync({
 				checklistId: checklist.id,
 				projectGroupId: projectGroup.projectGroupId,
-			},
-			{
-				onError: (error: unknown) => {
-					setFeedback({
-						message: getApiErrorMessage(error),
-						tone: "error",
-					});
-				},
-				onSuccess: () => {
-					setFeedback({
-						message: "AI 조언을 생성했습니다.",
-						tone: "success",
-					});
-				},
-			},
-		);
+			});
+			setFeedback({
+				message: "AI 조언을 생성했습니다.",
+				tone: "success",
+			});
+		} catch (error: unknown) {
+			setFeedback({
+				message: getApiErrorMessage(error),
+				tone: "error",
+			});
+		}
 	}
 
 	return (
@@ -1079,7 +1058,7 @@ function RealProjectChecklistsPanel({
 										</div>
 										<div className="flex flex-wrap justify-end gap-2">
 											<Button
-												disabled={isPending}
+												disabled={isChecklistActionPending}
 												onClick={() => handleCancelEdit()}
 												type="button"
 												variant="outline"
@@ -1087,7 +1066,7 @@ function RealProjectChecklistsPanel({
 												<X data-icon="inline-start" />
 												취소
 											</Button>
-											<Button disabled={isPending} type="submit">
+											<Button disabled={isChecklistActionPending} type="submit">
 												{isPending &&
 												updateChecklistMutation.variables?.checklistId ===
 													checklist.id ? (
@@ -1134,7 +1113,7 @@ function RealProjectChecklistsPanel({
 										</div>
 										<div className="flex flex-wrap items-start gap-2 xl:justify-end">
 											<Button
-												disabled={isPending}
+												disabled={isChecklistActionPending}
 												onClick={() => handleStartEdit(checklist)}
 												size="sm"
 												type="button"
@@ -1144,7 +1123,7 @@ function RealProjectChecklistsPanel({
 												수정
 											</Button>
 											<Button
-												disabled={isPending}
+												disabled={isChecklistActionPending}
 												onClick={() =>
 													handleStatusChange(
 														checklist,
@@ -1168,7 +1147,7 @@ function RealProjectChecklistsPanel({
 												{checklist.status === "DONE" ? "다시 열기" : "완료"}
 											</Button>
 											<Button
-												disabled={isPending}
+												disabled={isChecklistActionPending}
 												onClick={() => handleGenerateAdvice(checklist)}
 												size="sm"
 												type="button"
@@ -1188,7 +1167,7 @@ function RealProjectChecklistsPanel({
 											</Button>
 											<Button
 												aria-label="체크리스트 삭제"
-												disabled={isPending}
+												disabled={isChecklistActionPending}
 												onClick={() => handleDeleteChecklist(checklist)}
 												size="icon"
 												title="체크리스트 삭제"


### PR DESCRIPTION
Summary
- Add full checklist edit controls for title, description, status, due date, and assignee
- Route signed-in mock team workspace through MSW-backed API request functions for QA parity
- Update architecture notes for real/mock team workspace data flow

Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build
- Browser QA: mock login, checklist edit/save all fields, status toggle, desktop/mobile viewport checks

Closes #65