### PR TITLE
feat(landing): 랜딩 스크롤 리빌 애니메이션 추가

### DIFF
--- a/src/features/landing/components/landing-page-view.tsx
+++ b/src/features/landing/components/landing-page-view.tsx
@@ -4,6 +4,7 @@ import { CtaSection } from "@/features/landing/components/cta-section";
 import { HeroSection } from "@/features/landing/components/hero-section";
 import { HowItWorksSection } from "@/features/landing/components/how-it-works-section";
 import { LifecycleSection } from "@/features/landing/components/lifecycle-section";
+import { ScrollReveal } from "@/features/landing/components/scroll-reveal";
 import { SystemSection } from "@/features/landing/components/system-section";
 import { ValueSection } from "@/features/landing/components/value-section";
 
@@ -13,11 +14,21 @@ export function LandingPageView() {
 			<SiteHeader />
 			<main className="flex-1">
 				<HeroSection />
-				<HowItWorksSection />
-				<LifecycleSection />
-				<ValueSection />
-				<SystemSection />
-				<CtaSection />
+				<ScrollReveal className="[transition-delay:40ms]">
+					<HowItWorksSection />
+				</ScrollReveal>
+				<ScrollReveal className="[transition-delay:90ms]">
+					<LifecycleSection />
+				</ScrollReveal>
+				<ScrollReveal className="[transition-delay:140ms]">
+					<ValueSection />
+				</ScrollReveal>
+				<ScrollReveal className="[transition-delay:190ms]">
+					<SystemSection />
+				</ScrollReveal>
+				<ScrollReveal className="[transition-delay:240ms]">
+					<CtaSection />
+				</ScrollReveal>
 			</main>
 			<SiteFooter />
 		</div>

--- a/src/features/landing/components/scroll-reveal.tsx
+++ b/src/features/landing/components/scroll-reveal.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ScrollRevealProps {
+	children: ReactNode;
+	className?: string;
+}
+
+export function ScrollReveal({ children, className }: ScrollRevealProps) {
+	const [isVisible, setIsVisible] = useState(false);
+	const containerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const target = containerRef.current;
+
+		if (!target) {
+			return;
+		}
+
+		if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+			setIsVisible(true);
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (!entry.isIntersecting) {
+						continue;
+					}
+
+					setIsVisible(true);
+					observer.unobserve(entry.target);
+				}
+			},
+			{
+				threshold: 0.16,
+				rootMargin: "0px 0px -8% 0px",
+			},
+		);
+
+		observer.observe(target);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, []);
+
+	return (
+		<div
+			className={cn(
+				"transition-all duration-700 ease-out",
+				isVisible
+					? "translate-y-0 opacity-100 blur-0"
+					: "translate-y-6 opacity-0 blur-[2px]",
+				className,
+			)}
+			ref={containerRef}
+		>
+			{children}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- 랜딩 페이지 섹션이 뷰포트에 들어올 때 순차적으로 나타나는 스크롤 리빌 컴포넌트를 추가했습니다.
- `landing-page-view`에 리빌 래퍼를 적용해 각 섹션이 아래로 스크롤될 때 자연스럽게 등장하도록 구성했습니다.

## Validation
- [x] pnpm tsc --noEmit
- [x] pnpm biome lint .
- [x] pnpm build

Closes #69