### PR TITLE
feat(team-space): sync Server GitHub repository APIs

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Team-po Server API
-  version: 0.3.0
+  version: 0.4.0
   summary: Client-facing contract mirrored from the current Spring controllers.
 servers:
   - url: /api
@@ -691,6 +691,74 @@ paths:
           $ref: '#/components/responses/Conflict'
         '502':
           $ref: '#/components/responses/BadGateway'
+  /team-space/{projectGroupId}/github/available-repositories:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get repositories accessible to the installed GitHub App
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: Accessible GitHub repositories
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GithubRepositoryListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+  /team-space/{projectGroupId}/github/repositories:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get repositories registered to a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: Registered GitHub repositories
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GithubRepositoryListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    put:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Replace repositories registered to a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetGithubRepositoryListRequest'
+      responses:
+        '200':
+          description: GitHub repositories updated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '502':
+          $ref: '#/components/responses/BadGateway'
 components:
   securitySchemes:
     bearerAuth:
@@ -1278,6 +1346,37 @@ components:
         state:
           type: string
           minLength: 1
+    GithubRepository:
+      type: object
+      additionalProperties: false
+      required: [githubRepositoryId, repoName, fullName]
+      properties:
+        githubRepositoryId:
+          type: integer
+          format: int64
+        repoName:
+          type: string
+        fullName:
+          type: string
+    GithubRepositoryListResponse:
+      type: object
+      additionalProperties: false
+      required: [repositories]
+      properties:
+        repositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/GithubRepository'
+    SetGithubRepositoryListRequest:
+      type: object
+      additionalProperties: false
+      required: [githubRepositoryIds]
+      properties:
+        githubRepositoryIds:
+          type: array
+          items:
+            type: integer
+            format: int64
   responses:
     BadRequest:
       description: Validation failed or business rule rejected the request

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -52,9 +52,12 @@ import {
 	useUpdateProjectChecklistMutation,
 } from "@/features/team/hooks/use-project-checklist-queries";
 import {
+	useAvailableGithubRepositoriesQuery,
 	useCompleteGithubAppInstallationMutation,
 	useCreateGithubAppInstallationUrlMutation,
 	useGithubInstallationStatusQuery,
+	useGithubRepositoriesQuery,
+	useSetGithubRepositoriesMutation,
 } from "@/features/team/hooks/use-team-space-queries";
 import { demoTeamSpace } from "@/features/team/lib/demo-team-space";
 import { getAuthSession } from "@/lib/api/auth-session";
@@ -68,6 +71,7 @@ import type {
 	MyProjectGroup,
 	ProjectGroupMember,
 } from "@/lib/types/project-group";
+import type { GithubRepository } from "@/lib/types/team-space";
 import type {
 	GithubRepositorySummary,
 	ProjectLifecycleStatus,
@@ -132,6 +136,23 @@ const projectChecklistStatusTone: Record<ProjectChecklistStatus, string> = {
 	DONE: "border-emerald-500/25 bg-emerald-50 text-emerald-700",
 	TODO: "border-border bg-secondary/45 text-muted-foreground",
 };
+
+function areNumberSelectionsEqual(left: number[], right: number[]) {
+	if (left.length !== right.length) {
+		return false;
+	}
+
+	const normalizedLeft = [...left].sort(
+		(leftValue, rightValue) => leftValue - rightValue,
+	);
+	const normalizedRight = [...right].sort(
+		(leftValue, rightValue) => leftValue - rightValue,
+	);
+
+	return normalizedLeft.every(
+		(value, index) => value === normalizedRight[index],
+	);
+}
 
 const contributionLevelClass = [
 	"bg-secondary",
@@ -1263,13 +1284,59 @@ function RealGithubInstallationPanel({
 		projectGroup.projectGroupId,
 	);
 	const createInstallUrlMutation = useCreateGithubAppInstallationUrlMutation();
+	const setGithubRepositoriesMutation = useSetGithubRepositoriesMutation();
 	const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
 	const githubStatus = githubStatusQuery.data;
+	const isGithubConnected = githubStatus?.connected === true;
+	const githubRepositoriesQuery = useGithubRepositoriesQuery(
+		projectGroup.projectGroupId,
+		isGithubConnected,
+	);
+	const availableGithubRepositoriesQuery = useAvailableGithubRepositoriesQuery(
+		projectGroup.projectGroupId,
+		isGithubConnected && canManageGithubInstallation,
+	);
+	const connectedRepositories =
+		githubRepositoriesQuery.data?.repositories ?? [];
+	const availableRepositories =
+		availableGithubRepositoriesQuery.data?.repositories ?? [];
+	const connectedRepositoryIds = useMemo(
+		() =>
+			connectedRepositories.map((repository) => repository.githubRepositoryId),
+		[connectedRepositories],
+	);
+	const [selectedGithubRepositoryIds, setSelectedGithubRepositoryIds] =
+		useState<number[]>([]);
+	const selectedGithubRepositoryIdSet = useMemo(
+		() => new Set(selectedGithubRepositoryIds),
+		[selectedGithubRepositoryIds],
+	);
+	const hasRepositorySelectionChanged = !areNumberSelectionsEqual(
+		selectedGithubRepositoryIds,
+		connectedRepositoryIds,
+	);
 	const canCreateInstallUrl =
 		githubStatusQuery.isSuccess &&
 		canManageGithubInstallation &&
 		!githubStatus?.connected &&
 		!createInstallUrlMutation.isPending;
+	const canChangeGithubRepositories =
+		canManageGithubInstallation &&
+		githubRepositoriesQuery.isSuccess &&
+		availableGithubRepositoriesQuery.isSuccess &&
+		!setGithubRepositoriesMutation.isPending;
+	const canSaveGithubRepositories =
+		isGithubConnected &&
+		canChangeGithubRepositories &&
+		hasRepositorySelectionChanged;
+
+	useEffect(() => {
+		if (!githubRepositoriesQuery.data) {
+			return;
+		}
+
+		setSelectedGithubRepositoryIds(connectedRepositoryIds);
+	}, [connectedRepositoryIds, githubRepositoriesQuery.data]);
 
 	function handleCreateInstallUrl() {
 		setFeedback(null);
@@ -1284,6 +1351,39 @@ function RealGithubInstallationPanel({
 				window.location.assign(installUrl);
 			},
 		});
+	}
+
+	function handleGithubRepositoryToggle(githubRepositoryId: number) {
+		setFeedback(null);
+		setSelectedGithubRepositoryIds((current) =>
+			current.includes(githubRepositoryId)
+				? current.filter((repositoryId) => repositoryId !== githubRepositoryId)
+				: [...current, githubRepositoryId],
+		);
+	}
+
+	function handleSaveGithubRepositories() {
+		setFeedback(null);
+		setGithubRepositoriesMutation.mutate(
+			{
+				githubRepositoryIds: selectedGithubRepositoryIds,
+				projectGroupId: projectGroup.projectGroupId,
+			},
+			{
+				onError: (error: unknown) => {
+					setFeedback({
+						message: getApiErrorMessage(error),
+						tone: "error",
+					});
+				},
+				onSuccess: () => {
+					setFeedback({
+						message: "GitHub 저장소 연결을 저장했습니다.",
+						tone: "success",
+					});
+				},
+			},
+		);
 	}
 
 	return (
@@ -1360,6 +1460,146 @@ function RealGithubInstallationPanel({
 						설치 URL 발급
 					</Button>
 				</div>
+
+				{isGithubConnected ? (
+					<div className="grid gap-4 2xl:grid-cols-[0.95fr_1.05fr]">
+						<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
+							<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+								<div>
+									<p className="text-sm font-semibold text-brand-ink">
+										연결된 저장소
+									</p>
+									<p className="mt-1 text-sm leading-6 text-muted-foreground">
+										팀 스페이스에 등록된 GitHub 저장소입니다.
+									</p>
+								</div>
+								<Badge
+									variant={
+										connectedRepositories.length > 0 ? "brand" : "neutral"
+									}
+								>
+									{connectedRepositories.length}개
+								</Badge>
+							</div>
+
+							<div className="mt-4 grid gap-3">
+								{githubRepositoriesQuery.isLoading ? (
+									<RealInlineStatus
+										icon={<LoaderCircle className="size-4 animate-spin" />}
+										message="등록된 저장소를 불러오고 있습니다."
+									/>
+								) : null}
+
+								{githubRepositoriesQuery.error ? (
+									<RealInlineStatus
+										message={getApiErrorMessage(githubRepositoriesQuery.error)}
+									/>
+								) : null}
+
+								{githubRepositoriesQuery.isSuccess &&
+								connectedRepositories.length === 0 ? (
+									<div className="rounded-lg border border-dashed border-border bg-white/65 p-4">
+										<p className="text-sm leading-6 text-muted-foreground">
+											아직 팀 스페이스에 등록된 GitHub 저장소가 없습니다.
+										</p>
+									</div>
+								) : null}
+
+								{connectedRepositories.map((repository) => (
+									<RealGithubRepositoryItem
+										key={repository.githubRepositoryId}
+										repository={repository}
+									/>
+								))}
+							</div>
+						</div>
+
+						<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+							<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+								<div>
+									<p className="text-sm font-semibold text-brand-ink">
+										저장소 설정
+									</p>
+									<p className="mt-1 text-sm leading-6 text-muted-foreground">
+										GitHub App이 접근 가능한 저장소 중 집계할 대상을 선택합니다.
+									</p>
+								</div>
+								<Badge
+									variant={canManageGithubInstallation ? "brand" : "neutral"}
+								>
+									{canManageGithubInstallation ? "editable" : "read only"}
+								</Badge>
+							</div>
+
+							{canManageGithubInstallation ? (
+								<div className="mt-4 grid gap-3">
+									{availableGithubRepositoriesQuery.isLoading ? (
+										<RealInlineStatus
+											icon={<LoaderCircle className="size-4 animate-spin" />}
+											message="선택 가능한 저장소를 불러오고 있습니다."
+										/>
+									) : null}
+
+									{availableGithubRepositoriesQuery.error ? (
+										<RealInlineStatus
+											message={getApiErrorMessage(
+												availableGithubRepositoriesQuery.error,
+											)}
+										/>
+									) : null}
+
+									{availableGithubRepositoriesQuery.isSuccess &&
+									availableRepositories.length === 0 ? (
+										<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4">
+											<p className="text-sm leading-6 text-muted-foreground">
+												GitHub App이 접근 가능한 저장소가 없습니다.
+											</p>
+										</div>
+									) : null}
+
+									{availableRepositories.map((repository) => (
+										<RealGithubRepositoryOption
+											disabled={!canChangeGithubRepositories}
+											key={repository.githubRepositoryId}
+											onToggle={handleGithubRepositoryToggle}
+											repository={repository}
+											selected={selectedGithubRepositoryIdSet.has(
+												repository.githubRepositoryId,
+											)}
+										/>
+									))}
+
+									<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+										<p className="text-xs leading-5 text-muted-foreground">
+											{selectedGithubRepositoryIds.length}개 저장소 선택됨
+										</p>
+										<Button
+											disabled={!canSaveGithubRepositories}
+											onClick={handleSaveGithubRepositories}
+											type="button"
+										>
+											{setGithubRepositoriesMutation.isPending ? (
+												<LoaderCircle
+													className="animate-spin"
+													data-icon="inline-start"
+												/>
+											) : (
+												<Save data-icon="inline-start" />
+											)}
+											저장소 설정 저장
+										</Button>
+									</div>
+								</div>
+							) : (
+								<div className="mt-4 rounded-lg border border-dashed border-border bg-secondary/30 p-4">
+									<p className="text-sm leading-6 text-muted-foreground">
+										호스트만 GitHub 저장소 설정을 변경할 수 있습니다.
+									</p>
+								</div>
+							)}
+						</div>
+					</div>
+				) : null}
 			</div>
 		</AppPanel>
 	);
@@ -1393,6 +1633,71 @@ function RealGithubStatusCard({
 				{value}
 			</p>
 		</div>
+	);
+}
+
+function RealGithubRepositoryItem({
+	repository,
+}: {
+	repository: GithubRepository;
+}) {
+	return (
+		<a
+			className="flex flex-col gap-2 rounded-lg border border-primary/15 bg-white p-4 transition-colors hover:border-primary/30 sm:flex-row sm:items-center sm:justify-between"
+			href={`https://github.com/${repository.fullName}`}
+			rel="noreferrer"
+			target="_blank"
+		>
+			<div className="min-w-0">
+				<p className="truncate font-mono text-sm font-semibold text-primary">
+					{repository.fullName}
+				</p>
+				<p className="mt-1 text-xs text-muted-foreground">
+					{repository.repoName}
+				</p>
+			</div>
+			<ExternalLink className="size-4 shrink-0 text-primary" />
+		</a>
+	);
+}
+
+function RealGithubRepositoryOption({
+	disabled,
+	onToggle,
+	repository,
+	selected,
+}: {
+	disabled: boolean;
+	onToggle: (githubRepositoryId: number) => void;
+	repository: GithubRepository;
+	selected: boolean;
+}) {
+	return (
+		<label
+			className={cn(
+				"flex cursor-pointer items-start gap-3 rounded-lg border p-4 shadow-crisp transition-colors",
+				selected
+					? "border-primary/30 bg-primary/5"
+					: "border-border/70 bg-white",
+				disabled ? "cursor-not-allowed opacity-70" : "hover:border-primary/30",
+			)}
+		>
+			<input
+				checked={selected}
+				className="mt-1 size-4 rounded border-border text-primary"
+				disabled={disabled}
+				onChange={() => onToggle(repository.githubRepositoryId)}
+				type="checkbox"
+			/>
+			<span className="min-w-0">
+				<span className="block truncate font-mono text-sm font-semibold text-brand-ink">
+					{repository.fullName}
+				</span>
+				<span className="mt-1 block text-xs text-muted-foreground">
+					{repository.repoName}
+				</span>
+			</span>
+		</label>
 	);
 }
 

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -1305,6 +1305,30 @@ function RealGithubInstallationPanel({
 			connectedRepositories.map((repository) => repository.githubRepositoryId),
 		[connectedRepositories],
 	);
+	const availableGithubRepositoryIdSet = useMemo(
+		() =>
+			new Set(
+				availableRepositories.map(
+					(repository) => repository.githubRepositoryId,
+				),
+			),
+		[availableRepositories],
+	);
+	const configurableRepositories = useMemo(() => {
+		const repositoriesById = new Map<number, GithubRepository>();
+
+		for (const repository of availableRepositories) {
+			repositoriesById.set(repository.githubRepositoryId, repository);
+		}
+
+		for (const repository of connectedRepositories) {
+			if (!repositoriesById.has(repository.githubRepositoryId)) {
+				repositoriesById.set(repository.githubRepositoryId, repository);
+			}
+		}
+
+		return [...repositoriesById.values()];
+	}, [availableRepositories, connectedRepositories]);
 	const [selectedGithubRepositoryIds, setSelectedGithubRepositoryIds] =
 		useState<number[]>([]);
 	const selectedGithubRepositoryIdSet = useMemo(
@@ -1557,17 +1581,28 @@ function RealGithubInstallationPanel({
 										</div>
 									) : null}
 
-									{availableRepositories.map((repository) => (
-										<RealGithubRepositoryOption
-											disabled={!canChangeGithubRepositories}
-											key={repository.githubRepositoryId}
-											onToggle={handleGithubRepositoryToggle}
-											repository={repository}
-											selected={selectedGithubRepositoryIdSet.has(
-												repository.githubRepositoryId,
-											)}
-										/>
-									))}
+									{configurableRepositories.map((repository) => {
+										const selected = selectedGithubRepositoryIdSet.has(
+											repository.githubRepositoryId,
+										);
+										const available = availableGithubRepositoryIdSet.has(
+											repository.githubRepositoryId,
+										);
+
+										return (
+											<RealGithubRepositoryOption
+												disabled={
+													!canChangeGithubRepositories ||
+													(!available && !selected)
+												}
+												key={repository.githubRepositoryId}
+												onToggle={handleGithubRepositoryToggle}
+												repository={repository}
+												selected={selected}
+												unavailable={!available}
+											/>
+										);
+									})}
 
 									<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 										<p className="text-xs leading-5 text-muted-foreground">
@@ -1666,11 +1701,13 @@ function RealGithubRepositoryOption({
 	onToggle,
 	repository,
 	selected,
+	unavailable,
 }: {
 	disabled: boolean;
 	onToggle: (githubRepositoryId: number) => void;
 	repository: GithubRepository;
 	selected: boolean;
+	unavailable: boolean;
 }) {
 	return (
 		<label
@@ -1694,7 +1731,7 @@ function RealGithubRepositoryOption({
 					{repository.fullName}
 				</span>
 				<span className="mt-1 block text-xs text-muted-foreground">
-					{repository.repoName}
+					{unavailable ? "GitHub App 접근 권한 없음" : repository.repoName}
 				</span>
 			</span>
 		</label>

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -3,17 +3,28 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	completeGithubAppInstallation,
 	createGithubAppInstallationUrl,
+	getAvailableGithubRepositories,
 	getGithubInstallationStatus,
+	getGithubRepositories,
+	setGithubRepositories,
 } from "@/lib/api/team-space";
-import type { GithubAppInstallationCompleteRequest } from "@/lib/types/team-space";
+import type {
+	GithubAppInstallationCompleteRequest,
+	SetGithubRepositoriesRequest,
+} from "@/lib/types/team-space";
 
 export const teamSpaceQueryKeys = {
 	all: ["team-space"] as const,
+	githubAvailableRepositories: (projectGroupId: number) =>
+		["team-space", projectGroupId, "github", "available-repositories"] as const,
+	githubRepositories: (projectGroupId: number) =>
+		["team-space", projectGroupId, "github", "repositories"] as const,
 	githubStatus: (projectGroupId: number) =>
 		["team-space", projectGroupId, "github", "status"] as const,
 };
 
 const githubStatusStaleTimeMs = 15_000;
+const githubRepositoryStaleTimeMs = 15_000;
 
 function requireProjectGroupId(projectGroupId: number | undefined) {
 	if (typeof projectGroupId !== "number") {
@@ -48,6 +59,41 @@ export function useCreateGithubAppInstallationUrlMutation() {
 	});
 }
 
+export function useAvailableGithubRepositoriesQuery(
+	projectGroupId: number | undefined,
+	enabled = true,
+) {
+	return useQuery({
+		enabled: enabled && typeof projectGroupId === "number",
+		queryFn: () =>
+			getAvailableGithubRepositories(requireProjectGroupId(projectGroupId)),
+		queryKey:
+			typeof projectGroupId === "number"
+				? teamSpaceQueryKeys.githubAvailableRepositories(projectGroupId)
+				: teamSpaceQueryKeys.all,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: githubRepositoryStaleTimeMs,
+	});
+}
+
+export function useGithubRepositoriesQuery(
+	projectGroupId: number | undefined,
+	enabled = true,
+) {
+	return useQuery({
+		enabled: enabled && typeof projectGroupId === "number",
+		queryFn: () => getGithubRepositories(requireProjectGroupId(projectGroupId)),
+		queryKey:
+			typeof projectGroupId === "number"
+				? teamSpaceQueryKeys.githubRepositories(projectGroupId)
+				: teamSpaceQueryKeys.all,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: githubRepositoryStaleTimeMs,
+	});
+}
+
 export function useCompleteGithubAppInstallationMutation() {
 	const queryClient = useQueryClient();
 
@@ -57,6 +103,40 @@ export function useCompleteGithubAppInstallationMutation() {
 		onSuccess: (_, variables) => {
 			queryClient.invalidateQueries({
 				queryKey: teamSpaceQueryKeys.githubStatus(variables.projectGroupId),
+			});
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.githubAvailableRepositories(
+					variables.projectGroupId,
+				),
+			});
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.githubRepositories(
+					variables.projectGroupId,
+				),
+			});
+		},
+	});
+}
+
+export function useSetGithubRepositoriesMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: SetGithubRepositoriesRequest) =>
+			setGithubRepositories(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.githubStatus(variables.projectGroupId),
+			});
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.githubRepositories(
+					variables.projectGroupId,
+				),
+			});
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.githubAvailableRepositories(
+					variables.projectGroupId,
+				),
 			});
 		},
 	});

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -30,6 +30,7 @@ import type { MyProjectGroup } from "@/lib/types/project-group";
 import type {
 	GithubAppInstallationCompleteRequest,
 	GithubInstallationStatus,
+	GithubRepository,
 } from "@/lib/types/team-space";
 import type {
 	EditPasswordRequest,
@@ -50,6 +51,7 @@ let nextProjectChecklistId = 103;
 let githubInstallationStatus: GithubInstallationStatus =
 	createDisconnectedGithubStatus();
 let pendingGithubInstallationState: string | null = null;
+let selectedGithubRepositories: GithubRepository[] = [];
 let deleteEmailAuthSentUserId: number | null = null;
 let deleteEmailVerifiedUserId: number | null = null;
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
@@ -233,6 +235,7 @@ function resetTeamSpaceApiState() {
 	nextProjectChecklistId = 103;
 	githubInstallationStatus = createDisconnectedGithubStatus();
 	pendingGithubInstallationState = null;
+	selectedGithubRepositories = [];
 }
 
 function createDisconnectedGithubStatus(): GithubInstallationStatus {
@@ -240,6 +243,62 @@ function createDisconnectedGithubStatus(): GithubInstallationStatus {
 		connected: false,
 		organizationLogin: null,
 		repositoryCount: 0,
+	};
+}
+
+function createMockAvailableGithubRepositories(): GithubRepository[] {
+	return [
+		{
+			fullName: "team-po-labs/client",
+			githubRepositoryId: 100,
+			repoName: "client",
+		},
+		{
+			fullName: "team-po-labs/server",
+			githubRepositoryId: 200,
+			repoName: "server",
+		},
+		{
+			fullName: "team-po-labs/product-notes",
+			githubRepositoryId: 300,
+			repoName: "product-notes",
+		},
+	];
+}
+
+const availableGithubRepositories = createMockAvailableGithubRepositories();
+
+function parseGithubRepositoryIds(value: unknown): number[] | null {
+	if (!value || typeof value !== "object") {
+		return null;
+	}
+
+	const { githubRepositoryIds } = value as {
+		githubRepositoryIds?: unknown;
+	};
+
+	if (!Array.isArray(githubRepositoryIds)) {
+		return null;
+	}
+
+	if (
+		!githubRepositoryIds.every(
+			(repositoryId): repositoryId is number =>
+				typeof repositoryId === "number" &&
+				Number.isFinite(repositoryId) &&
+				Number.isInteger(repositoryId),
+		)
+	) {
+		return null;
+	}
+
+	return githubRepositoryIds;
+}
+
+function syncGithubRepositoryCount() {
+	githubInstallationStatus = {
+		...githubInstallationStatus,
+		repositoryCount: selectedGithubRepositories.length,
 	};
 }
 
@@ -1797,11 +1856,125 @@ export const handlers = [
 			}
 
 			pendingGithubInstallationState = null;
+			selectedGithubRepositories = [];
 			githubInstallationStatus = {
 				connected: true,
 				organizationLogin: "team-po-labs",
-				repositoryCount: 2,
+				repositoryCount: 0,
 			};
+
+			return new HttpResponse(null, { status: 200 });
+		},
+	),
+
+	http.get(
+		getPath("/team-space/:projectGroupId/github/available-repositories"),
+		async ({ params, request }) => {
+			await delay(300);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const hostError = assertProjectGroupHost(projectGroupId);
+
+			if (hostError) {
+				return hostError;
+			}
+
+			if (!githubInstallationStatus.connected) {
+				return buildErrorResponse(
+					404,
+					"Github Organization이 연결되지 않은 팀 스페이스입니다.",
+					"GITHUB_APP_INSTALLATION_NOT_CONNECTED",
+				);
+			}
+
+			return HttpResponse.json({
+				repositories: availableGithubRepositories,
+			});
+		},
+	),
+
+	http.get(
+		getPath("/team-space/:projectGroupId/github/repositories"),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			return HttpResponse.json({
+				repositories: selectedGithubRepositories,
+			});
+		},
+	),
+
+	http.put(
+		getPath("/team-space/:projectGroupId/github/repositories"),
+		async ({ params, request }) => {
+			const body = await request.json();
+
+			await delay(400);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const hostError = assertProjectGroupHost(projectGroupId);
+
+			if (hostError) {
+				return hostError;
+			}
+
+			if (!githubInstallationStatus.connected) {
+				return buildErrorResponse(
+					404,
+					"Github Organization이 연결되지 않은 팀 스페이스입니다.",
+					"GITHUB_APP_INSTALLATION_NOT_CONNECTED",
+				);
+			}
+
+			const githubRepositoryIds = parseGithubRepositoryIds(body);
+
+			if (!githubRepositoryIds) {
+				return buildErrorResponse(
+					400,
+					"Github Repository 목록은 필수입니다.",
+					"INVALID_INPUT_FIELD",
+				);
+			}
+
+			const accessibleRepositoryIds = new Set(
+				availableGithubRepositories.map(
+					(repository) => repository.githubRepositoryId,
+				),
+			);
+			const selectedRepositoryIds = Array.from(new Set(githubRepositoryIds));
+
+			if (
+				selectedRepositoryIds.some(
+					(repositoryId) => !accessibleRepositoryIds.has(repositoryId),
+				)
+			) {
+				return buildErrorResponse(
+					400,
+					"선택한 Github Repository에 접근할 수 없습니다.",
+					"GITHUB_REPOSITORY_NOT_ACCESSIBLE",
+				);
+			}
+
+			selectedGithubRepositories = selectedRepositoryIds
+				.map((repositoryId) =>
+					availableGithubRepositories.find(
+						(repository) => repository.githubRepositoryId === repositoryId,
+					),
+				)
+				.filter((repository): repository is GithubRepository =>
+					Boolean(repository),
+				);
+			syncGithubRepositoryCount();
 
 			return new HttpResponse(null, { status: 200 });
 		},

--- a/src/lib/api/team-space.ts
+++ b/src/lib/api/team-space.ts
@@ -3,6 +3,8 @@ import type {
 	GithubAppInstallationCompleteRequest,
 	GithubAppInstallationUrl,
 	GithubInstallationStatus,
+	GithubRepositoryListResponse,
+	SetGithubRepositoriesRequest,
 } from "@/lib/types/team-space";
 
 export function getGithubInstallationStatus(projectGroupId: number) {
@@ -37,4 +39,28 @@ export function completeGithubAppInstallation({
 			method: "POST",
 		},
 	);
+}
+
+export function getAvailableGithubRepositories(projectGroupId: number) {
+	return apiRequest<GithubRepositoryListResponse>(
+		`/team-space/${projectGroupId}/github/available-repositories`,
+	);
+}
+
+export function getGithubRepositories(projectGroupId: number) {
+	return apiRequest<GithubRepositoryListResponse>(
+		`/team-space/${projectGroupId}/github/repositories`,
+	);
+}
+
+export function setGithubRepositories({
+	githubRepositoryIds,
+	projectGroupId,
+}: SetGithubRepositoriesRequest) {
+	return apiRequest<void>(`/team-space/${projectGroupId}/github/repositories`, {
+		json: {
+			githubRepositoryIds,
+		},
+		method: "PUT",
+	});
 }

--- a/src/lib/types/team-space.ts
+++ b/src/lib/types/team-space.ts
@@ -14,3 +14,18 @@ export interface GithubAppInstallationCompleteRequest {
 	setupAction: string;
 	state: string;
 }
+
+export interface GithubRepository {
+	fullName: string;
+	githubRepositoryId: number;
+	repoName: string;
+}
+
+export interface GithubRepositoryListResponse {
+	repositories: GithubRepository[];
+}
+
+export interface SetGithubRepositoriesRequest {
+	githubRepositoryIds: number[];
+	projectGroupId: number;
+}


### PR DESCRIPTION
<!-- codex-server-api-sync-to-client -->

Summary
- Sync the Client OpenAPI contract with the latest Server TeamSpace GitHub repository endpoints.
- Add typed API functions, TanStack Query hooks, and MSW handlers for available, registered, and saved repository lists.
- Wire the real Team Space GitHub panel to read and save repository selections.

Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build (passes; Vite warns local Node 20.15.0 is below 20.19+)

Closes #73