### PR TITLE
feat(team-space): sync server dev-guide API

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -622,6 +622,29 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /team-space/{projectGroupId}/dev-guide:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get AI development guide for a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: AI development guide
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevGuideContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /team-space/{projectGroupId}/github/status:
     get:
       tags: [TeamSpace]
@@ -1377,6 +1400,106 @@ components:
           items:
             type: integer
             format: int64
+    DevGuideContent:
+      type: object
+      additionalProperties: false
+      required: [overview, techStack, mvpPriorities, decisionPoints, milestones]
+      properties:
+        overview:
+          type: string
+        techStack:
+          type: array
+          minItems: 5
+          maxItems: 7
+          items:
+            $ref: '#/components/schemas/DevGuideTechStackItem'
+        mvpPriorities:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            $ref: '#/components/schemas/DevGuideMvpPriority'
+        decisionPoints:
+          type: array
+          minItems: 3
+          maxItems: 5
+          items:
+            $ref: '#/components/schemas/DevGuideDecisionPoint'
+        milestones:
+          type: array
+          minItems: 12
+          maxItems: 12
+          items:
+            $ref: '#/components/schemas/DevGuideMilestone'
+    DevGuideTechStackItem:
+      type: object
+      additionalProperties: false
+      required: [category, recommendation, reason]
+      properties:
+        category:
+          type: string
+        recommendation:
+          type: string
+        reason:
+          type: string
+    DevGuideMvpPriority:
+      type: object
+      additionalProperties: false
+      required: [priority, feature, rationale, subFeatures]
+      properties:
+        priority:
+          type: integer
+          minimum: 1
+          maximum: 3
+        feature:
+          type: string
+        rationale:
+          type: string
+        subFeatures:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            type: string
+    DevGuideDecisionPoint:
+      type: object
+      additionalProperties: false
+      required: [topic, options, consideration]
+      properties:
+        topic:
+          type: string
+        options:
+          type: array
+          minItems: 2
+          maxItems: 3
+          items:
+            type: string
+        consideration:
+          type: string
+    DevGuideMilestone:
+      type: object
+      additionalProperties: false
+      required: [week, goal, roleTasks]
+      properties:
+        week:
+          type: integer
+          minimum: 1
+          maximum: 12
+        goal:
+          type: string
+        roleTasks:
+          $ref: '#/components/schemas/DevGuideRoleTasks'
+    DevGuideRoleTasks:
+      type: object
+      additionalProperties: false
+      required: [backend, frontend, design]
+      properties:
+        backend:
+          type: string
+        frontend:
+          type: string
+        design:
+          type: string
   responses:
     BadRequest:
       description: Validation failed or business rule rejected the request

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -12,6 +12,7 @@ import {
 	MessageSquareText,
 	PencilLine,
 	Plus,
+	RefreshCw,
 	Save,
 	SendHorizontal,
 	Settings2,
@@ -1026,7 +1027,27 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 						title="AI 개발 가이드라인"
 					/>
 					<div className="p-5">
-						<RealInlineStatus message="팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다." />
+						<div className="grid gap-3">
+							<RealInlineStatus message="팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다. 잠시 후 자동으로 다시 확인합니다." />
+							<div>
+								<Button
+									disabled={devGuideQuery.isFetching}
+									onClick={() => void devGuideQuery.refetch()}
+									type="button"
+									variant="outline"
+								>
+									{devGuideQuery.isFetching ? (
+										<LoaderCircle
+											className="animate-spin"
+											data-icon="inline-start"
+										/>
+									) : (
+										<RefreshCw data-icon="inline-start" />
+									)}
+									다시 확인
+								</Button>
+							</div>
+						</div>
 					</div>
 				</AppPanel>
 			);

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -55,6 +55,7 @@ import {
 	useAvailableGithubRepositoriesQuery,
 	useCompleteGithubAppInstallationMutation,
 	useCreateGithubAppInstallationUrlMutation,
+	useDevGuideQuery,
 	useGithubInstallationStatusQuery,
 	useGithubRepositoriesQuery,
 	useSetGithubRepositoriesMutation,
@@ -71,7 +72,7 @@ import type {
 	MyProjectGroup,
 	ProjectGroupMember,
 } from "@/lib/types/project-group";
-import type { GithubRepository } from "@/lib/types/team-space";
+import type { DevGuideContent, GithubRepository } from "@/lib/types/team-space";
 import type {
 	GithubRepositorySummary,
 	TeamChecklistItem,
@@ -990,46 +991,259 @@ function RealMemberSummaryCard({
 }
 
 function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
-	const guideItems = [
-		{
-			body:
-				projectGroup.projectDescription ??
-				"팀 설명을 기준으로 이번 주 논의할 범위를 좁힙니다.",
-			title: "문제 정의 확인",
-		},
-		{
-			body:
-				projectGroup.projectMvp ??
-				"MVP가 등록되면 우선순위 기준으로 사용합니다.",
-			title: "MVP 우선순위",
-		},
-		{
-			body: "체크리스트와 GitHub 연동 상태를 보고 오늘 바로 실행할 작업을 정합니다.",
-			title: "실행 흐름 정리",
-		},
-	];
+	const devGuideQuery = useDevGuideQuery(projectGroup.projectGroupId);
+	const guide = devGuideQuery.data;
 
+	if (devGuideQuery.isLoading) {
+		return (
+			<AppPanel>
+				<AppPanelHeader
+					action={<Badge variant="neutral">조회 중</Badge>}
+					description="팀 방향, MVP 우선순위, 결정 포인트를 불러오고 있습니다."
+					eyebrow="Guide"
+					title="AI 개발 가이드라인"
+				/>
+				<div className="p-5">
+					<RealInlineStatus
+						icon={
+							<LoaderCircle className="size-4 shrink-0 animate-spin text-primary" />
+						}
+						message="가이드라인을 불러오는 중입니다."
+					/>
+				</div>
+			</AppPanel>
+		);
+	}
+
+	if (devGuideQuery.error) {
+		if (isDevGuideNotFoundError(devGuideQuery.error)) {
+			return (
+				<AppPanel>
+					<AppPanelHeader
+						action={<Badge variant="neutral">대기</Badge>}
+						description="아직 이 팀에 생성된 가이드라인이 없습니다."
+						eyebrow="Guide"
+						title="AI 개발 가이드라인"
+					/>
+					<div className="p-5">
+						<RealInlineStatus message="팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다." />
+					</div>
+				</AppPanel>
+			);
+		}
+
+		return (
+			<AppPanel>
+				<AppPanelHeader
+					action={<Badge variant="neutral">오류</Badge>}
+					description="팀 가이드라인을 불러오지 못했습니다."
+					eyebrow="Guide"
+					title="AI 개발 가이드라인"
+				/>
+				<div className="p-5">
+					<RealInlineStatus
+						message={`가이드라인 조회 실패: ${getApiErrorMessage(devGuideQuery.error)}`}
+					/>
+				</div>
+			</AppPanel>
+		);
+	}
+
+	if (!guide) {
+		return (
+			<AppPanel>
+				<AppPanelHeader
+					action={<Badge variant="neutral">대기</Badge>}
+					description="아직 이 팀에 생성된 가이드라인이 없습니다."
+					eyebrow="Guide"
+					title="AI 개발 가이드라인"
+				/>
+				<div className="p-5">
+					<RealInlineStatus message="팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다." />
+				</div>
+			</AppPanel>
+		);
+	}
+
+	return (
+		<div className="grid gap-5">
+			<AppPanel>
+				<AppPanelHeader
+					action={<Badge variant="brand">생성됨</Badge>}
+					description="팀 방향, MVP 우선순위, 결정 포인트를 한곳에 모았습니다."
+					eyebrow="Guide"
+					title="AI 개발 가이드라인"
+				/>
+				<div className="grid gap-4 p-5">
+					<div className="rounded-lg border border-primary/15 bg-primary/5 p-5">
+						<p className="text-sm font-semibold text-primary">프로젝트 개요</p>
+						<p className="mt-3 text-sm leading-7 text-brand-ink">
+							{guide.overview}
+						</p>
+					</div>
+					<div className="grid gap-4 md:grid-cols-3">
+						{guide.mvpPriorities.map((priority) => (
+							<div
+								className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp"
+								key={priority.priority}
+							>
+								<div className="flex items-start justify-between gap-3">
+									<h3 className="text-base font-semibold text-brand-ink">
+										{priority.feature}
+									</h3>
+									<Badge variant="brand">P{priority.priority}</Badge>
+								</div>
+								<p className="mt-3 text-sm leading-6 text-muted-foreground">
+									{priority.rationale}
+								</p>
+								<ul className="mt-4 grid gap-2 text-sm text-brand-ink">
+									{priority.subFeatures.map((subFeature) => (
+										<li className="flex gap-2" key={subFeature}>
+											<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-primary" />
+											<span>{subFeature}</span>
+										</li>
+									))}
+								</ul>
+							</div>
+						))}
+					</div>
+				</div>
+			</AppPanel>
+
+			<div className="grid gap-5 lg:grid-cols-[0.95fr_1.05fr]">
+				<RealDevGuideTechStackPanel guide={guide} />
+				<RealDevGuideDecisionPanel guide={guide} />
+			</div>
+
+			<RealDevGuideMilestonePanel guide={guide} />
+		</div>
+	);
+}
+
+function isDevGuideNotFoundError(error: unknown) {
+	if (typeof error !== "object" || error === null || !("code" in error)) {
+		return false;
+	}
+
+	return error.code === "DEV_GUIDE_NOT_FOUND";
+}
+
+function RealDevGuideTechStackPanel({ guide }: { guide: DevGuideContent }) {
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="팀 정보와 체크리스트를 바탕으로 먼저 맞출 대화를 정리합니다."
-				eyebrow="Guide"
-				title="팀 운영 가이드"
+				description="역할별로 우선 검토할 기술 선택지를 정리했습니다."
+				eyebrow="Stack"
+				title="기술 스택"
 			/>
-			<div className="grid gap-4 p-5 md:grid-cols-3">
-				{guideItems.map((item) => (
+			<div className="grid gap-3 p-5">
+				{guide.techStack.map((item) => (
 					<div
-						className="rounded-lg border border-border/70 bg-brand-warm p-5"
-						key={item.title}
+						className="rounded-lg border border-border/70 bg-brand-warm p-4"
+						key={`${item.category}-${item.recommendation}`}
 					>
-						<h3 className="text-lg font-semibold">{item.title}</h3>
-						<p className="mt-2 text-sm leading-7 text-muted-foreground">
-							{item.body}
+						<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+							<p className="font-semibold text-brand-ink">{item.category}</p>
+							<Badge variant="neutral">{item.recommendation}</Badge>
+						</div>
+						<p className="mt-2 text-sm leading-6 text-muted-foreground">
+							{item.reason}
 						</p>
 					</div>
 				))}
 			</div>
 		</AppPanel>
+	);
+}
+
+function RealDevGuideDecisionPanel({ guide }: { guide: DevGuideContent }) {
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				description="팀이 초기에 합의해야 할 선택지를 모았습니다."
+				eyebrow="Decision"
+				title="결정 포인트"
+			/>
+			<div className="grid gap-3 p-5">
+				{guide.decisionPoints.map((decision) => (
+					<div
+						className="rounded-lg border border-border/70 bg-white p-4 shadow-crisp"
+						key={decision.topic}
+					>
+						<h3 className="font-semibold text-brand-ink">{decision.topic}</h3>
+						<div className="mt-3 flex flex-wrap gap-2">
+							{decision.options.map((option) => (
+								<Badge key={option} variant="warm">
+									{option}
+								</Badge>
+							))}
+						</div>
+						<p className="mt-3 text-sm leading-6 text-muted-foreground">
+							{decision.consideration}
+						</p>
+					</div>
+				))}
+			</div>
+		</AppPanel>
+	);
+}
+
+function RealDevGuideMilestonePanel({ guide }: { guide: DevGuideContent }) {
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				description="12주 흐름을 주차별 목표와 역할 작업으로 나눴습니다."
+				eyebrow="Roadmap"
+				title="마일스톤"
+			/>
+			<div className="grid gap-3 p-5 md:grid-cols-2 xl:grid-cols-3">
+				{guide.milestones.map((milestone) => (
+					<div
+						className="rounded-lg border border-border/70 bg-white p-4 shadow-crisp"
+						key={milestone.week}
+					>
+						<div className="flex items-start justify-between gap-3">
+							<h3 className="font-semibold text-brand-ink">
+								{milestone.week}주차
+							</h3>
+							<Badge variant="neutral">W{milestone.week}</Badge>
+						</div>
+						<p className="mt-2 text-sm leading-6 text-muted-foreground">
+							{milestone.goal}
+						</p>
+						<dl className="mt-4 grid gap-2 text-xs leading-5">
+							<RealDevGuideRoleTask
+								label="BE"
+								value={milestone.roleTasks.backend}
+							/>
+							<RealDevGuideRoleTask
+								label="FE"
+								value={milestone.roleTasks.frontend}
+							/>
+							<RealDevGuideRoleTask
+								label="Design"
+								value={milestone.roleTasks.design}
+							/>
+						</dl>
+					</div>
+				))}
+			</div>
+		</AppPanel>
+	);
+}
+
+function RealDevGuideRoleTask({
+	label,
+	value,
+}: {
+	label: string;
+	value: string;
+}) {
+	return (
+		<div className="grid grid-cols-[4rem_1fr] gap-2">
+			<dt className="font-semibold text-primary">{label}</dt>
+			<dd className="min-w-0 text-muted-foreground">{value}</dd>
+		</div>
 	);
 }
 

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { ApiError } from "@/lib/api/client";
 import {
 	completeGithubAppInstallation,
 	createGithubAppInstallationUrl,
@@ -29,6 +30,7 @@ export const teamSpaceQueryKeys = {
 const githubStatusStaleTimeMs = 15_000;
 const githubRepositoryStaleTimeMs = 15_000;
 const devGuideStaleTimeMs = 60_000;
+const pendingDevGuideRefetchIntervalMs = 5_000;
 
 function requireProjectGroupId(projectGroupId: number | undefined) {
 	if (typeof projectGroupId !== "number") {
@@ -67,10 +69,18 @@ export function useDevGuideQuery(
 			typeof projectGroupId === "number"
 				? teamSpaceQueryKeys.devGuide(projectGroupId)
 				: teamSpaceQueryKeys.all,
+		refetchInterval: (query) =>
+			isDevGuidePendingError(query.state.error)
+				? pendingDevGuideRefetchIntervalMs
+				: false,
 		refetchOnWindowFocus: false,
 		retry: false,
 		staleTime: devGuideStaleTimeMs,
 	});
+}
+
+function isDevGuidePendingError(error: unknown) {
+	return error instanceof ApiError && error.code === "DEV_GUIDE_NOT_FOUND";
 }
 
 export function useCreateGithubAppInstallationUrlMutation() {

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -4,6 +4,7 @@ import {
 	completeGithubAppInstallation,
 	createGithubAppInstallationUrl,
 	getAvailableGithubRepositories,
+	getDevGuide,
 	getGithubInstallationStatus,
 	getGithubRepositories,
 	setGithubRepositories,
@@ -15,6 +16,8 @@ import type {
 
 export const teamSpaceQueryKeys = {
 	all: ["team-space"] as const,
+	devGuide: (projectGroupId: number) =>
+		["team-space", projectGroupId, "dev-guide"] as const,
 	githubAvailableRepositories: (projectGroupId: number) =>
 		["team-space", projectGroupId, "github", "available-repositories"] as const,
 	githubRepositories: (projectGroupId: number) =>
@@ -25,6 +28,7 @@ export const teamSpaceQueryKeys = {
 
 const githubStatusStaleTimeMs = 15_000;
 const githubRepositoryStaleTimeMs = 15_000;
+const devGuideStaleTimeMs = 60_000;
 
 function requireProjectGroupId(projectGroupId: number | undefined) {
 	if (typeof projectGroupId !== "number") {
@@ -49,6 +53,23 @@ export function useGithubInstallationStatusQuery(
 		refetchOnWindowFocus: false,
 		retry: false,
 		staleTime: githubStatusStaleTimeMs,
+	});
+}
+
+export function useDevGuideQuery(
+	projectGroupId: number | undefined,
+	enabled = true,
+) {
+	return useQuery({
+		enabled: enabled && typeof projectGroupId === "number",
+		queryFn: () => getDevGuide(requireProjectGroupId(projectGroupId)),
+		queryKey:
+			typeof projectGroupId === "number"
+				? teamSpaceQueryKeys.devGuide(projectGroupId)
+				: teamSpaceQueryKeys.all,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: devGuideStaleTimeMs,
 	});
 }
 

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -28,6 +28,7 @@ import type {
 } from "@/lib/types/project-checklist";
 import type { MyProjectGroup } from "@/lib/types/project-group";
 import type {
+	DevGuideContent,
 	GithubAppInstallationCompleteRequest,
 	GithubInstallationStatus,
 	GithubRepository,
@@ -47,6 +48,8 @@ let activeMatchMembers: MatchMemberResponse["members"] = [];
 let activeMatchProject: MatchProjectResponse | null = null;
 let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
 let activeProjectChecklists: ProjectChecklist[] = createMockProjectChecklists();
+let activeDevGuide: DevGuideContent | null =
+	createMockDevGuide(activeProjectGroup);
 let nextProjectChecklistId = 103;
 let githubInstallationStatus: GithubInstallationStatus =
 	createDisconnectedGithubStatus();
@@ -232,6 +235,7 @@ function resetTeamSpaceApiState() {
 	activeProjectChecklists = activeProjectGroup
 		? createMockProjectChecklists()
 		: [];
+	activeDevGuide = createMockDevGuide(activeProjectGroup);
 	nextProjectChecklistId = 103;
 	githubInstallationStatus = createDisconnectedGithubStatus();
 	pendingGithubInstallationState = null;
@@ -267,6 +271,104 @@ function createMockAvailableGithubRepositories(): GithubRepository[] {
 }
 
 const availableGithubRepositories = createMockAvailableGithubRepositories();
+
+function createMockDevGuide(
+	projectGroup: MyProjectGroup | null,
+): DevGuideContent | null {
+	if (!projectGroup) {
+		return null;
+	}
+
+	return {
+		decisionPoints: [
+			{
+				consideration: "초기 구현 비용과 인증 유지보수 범위를 함께 비교합니다.",
+				options: ["JWT", "Session"],
+				topic: "인증 방식",
+			},
+			{
+				consideration:
+					"팀 생성 직후 바로 사용할 수 있는 관리 흐름을 우선합니다.",
+				options: ["자동 생성", "방장 승인"],
+				topic: "팀 스페이스 생성 정책",
+			},
+			{
+				consideration: "API 비용과 사용자가 기대하는 최신성을 함께 맞춥니다.",
+				options: ["생성 시 1회", "수동 재생성", "주기 재생성"],
+				topic: "AI 가이드 갱신 방식",
+			},
+		],
+		milestones: Array.from({ length: 12 }, (_, index) => {
+			const week = index + 1;
+
+			return {
+				goal:
+					week <= 4
+						? "핵심 API와 화면 흐름을 연결합니다."
+						: week <= 8
+							? "팀 운영 데이터와 GitHub 연동 품질을 다듬습니다."
+							: "릴리스 안정성과 회고 지표를 정리합니다.",
+				roleTasks: {
+					backend: "계약에 맞는 API 응답과 예외 처리를 점검합니다.",
+					design: "반복 사용 화면의 정보 밀도와 상태 표현을 정리합니다.",
+					frontend: "TanStack Query 상태와 사용자 피드백을 연결합니다.",
+				},
+				week,
+			};
+		}),
+		mvpPriorities: [
+			{
+				feature: "매칭 요청과 팀 생성",
+				priority: 1,
+				rationale: "서비스의 첫 가치가 팀 구성 완료 여부에서 결정됩니다.",
+				subFeatures: ["프로필 기반 요청", "수락/거절", "팀 스페이스 생성"],
+			},
+			{
+				feature: "팀 운영 체크리스트",
+				priority: 2,
+				rationale: "팀이 바로 실행할 작업을 공유해야 이탈을 줄일 수 있습니다.",
+				subFeatures: ["담당자 지정", "상태 변경", "AI 조언 조회"],
+			},
+			{
+				feature: "GitHub 저장소 연결",
+				priority: 3,
+				rationale: "개발 활동을 팀 스페이스 지표로 확장하는 기반입니다.",
+				subFeatures: ["App 설치", "저장소 선택", "연결 상태 확인"],
+			},
+		],
+		overview: `${projectGroup.projectTitle} 팀은 MVP 범위를 작게 유지하고 매칭 이후 바로 실행 가능한 협업 루틴을 만드는 데 집중합니다. ${
+			projectGroup.projectDescription ??
+			"팀 설명이 구체화되면 가이드의 우선순위도 함께 조정합니다."
+		}`,
+		techStack: [
+			{
+				category: "Backend",
+				reason: "인증, 매칭, 팀 스페이스 API를 빠르게 구성하기 좋습니다.",
+				recommendation: "Spring Boot",
+			},
+			{
+				category: "Frontend",
+				reason: "상태 기반 화면 전환과 컴포넌트 재사용에 적합합니다.",
+				recommendation: "React + TypeScript",
+			},
+			{
+				category: "Database",
+				reason: "팀, 멤버, 체크리스트 관계를 명확하게 저장할 수 있습니다.",
+				recommendation: "MySQL",
+			},
+			{
+				category: "Infra",
+				reason: "팀원이 같은 실행 환경에서 API와 UI를 검증할 수 있습니다.",
+				recommendation: "Docker",
+			},
+			{
+				category: "CI/CD",
+				reason: "PR마다 타입, 린트, 빌드 상태를 자동 확인합니다.",
+				recommendation: "GitHub Actions",
+			},
+		],
+	};
+}
 
 function parseGithubRepositoryIds(value: unknown): number[] | null {
 	if (!value || typeof value !== "object") {
@@ -1762,6 +1864,39 @@ export const handlers = [
 				aiAdvice,
 				checklistId,
 			});
+		},
+	),
+
+	http.get(
+		getPath("/team-space/:projectGroupId/dev-guide"),
+		async ({ params, request }) => {
+			await delay(300);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			if (activeProjectGroup?.projectTitle.includes("서버 오류")) {
+				return buildErrorResponse(
+					500,
+					"Gemini API 응답 형식이 올바르지 않습니다.",
+					"GEMINI_INVALID_RESPONSE",
+				);
+			}
+
+			if (!activeDevGuide) {
+				return buildErrorResponse(
+					404,
+					"개발 가이드라인이 존재하지 않습니다.",
+					"DEV_GUIDE_NOT_FOUND",
+				);
+			}
+
+			return HttpResponse.json(activeDevGuide);
 		},
 	),
 

--- a/src/lib/api/team-space.ts
+++ b/src/lib/api/team-space.ts
@@ -1,11 +1,16 @@
 import { apiRequest } from "@/lib/api/client";
 import type {
+	DevGuideContent,
 	GithubAppInstallationCompleteRequest,
 	GithubAppInstallationUrl,
 	GithubInstallationStatus,
 	GithubRepositoryListResponse,
 	SetGithubRepositoriesRequest,
 } from "@/lib/types/team-space";
+
+export function getDevGuide(projectGroupId: number) {
+	return apiRequest<DevGuideContent>(`/team-space/${projectGroupId}/dev-guide`);
+}
 
 export function getGithubInstallationStatus(projectGroupId: number) {
 	return apiRequest<GithubInstallationStatus>(

--- a/src/lib/types/team-space.ts
+++ b/src/lib/types/team-space.ts
@@ -29,3 +29,42 @@ export interface SetGithubRepositoriesRequest {
 	githubRepositoryIds: number[];
 	projectGroupId: number;
 }
+
+export interface DevGuideTechStackItem {
+	category: string;
+	reason: string;
+	recommendation: string;
+}
+
+export interface DevGuideMvpPriority {
+	feature: string;
+	priority: number;
+	rationale: string;
+	subFeatures: string[];
+}
+
+export interface DevGuideDecisionPoint {
+	consideration: string;
+	options: string[];
+	topic: string;
+}
+
+export interface DevGuideRoleTasks {
+	backend: string;
+	design: string;
+	frontend: string;
+}
+
+export interface DevGuideMilestone {
+	goal: string;
+	roleTasks: DevGuideRoleTasks;
+	week: number;
+}
+
+export interface DevGuideContent {
+	decisionPoints: DevGuideDecisionPoint[];
+	milestones: DevGuideMilestone[];
+	mvpPriorities: DevGuideMvpPriority[];
+	overview: string;
+	techStack: DevGuideTechStackItem[];
+}


### PR DESCRIPTION
<!-- codex-server-api-sync-to-client -->

## Summary
- Add `GET /team-space/{projectGroupId}/dev-guide` to the Client OpenAPI contract.
- Add dev-guide response types, API request, TanStack Query hook, and MSW mock handler.
- Render the real team-space guide tab from the Server dev-guide response with loading, pending, and error states.

## Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build
- Browser check: team-space guide tab on desktop and mobile

Closes #75