### PR TITLE
fix(match): sync Client with Server match API

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -359,14 +359,14 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
-  /match/{matchId}/members:
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /match/members:
     get:
       tags: [Match]
       security:
         - bearerAuth: []
-      summary: Get members in a match session
-      parameters:
-        - $ref: '#/components/parameters/MatchId'
+      summary: Get members in the current user's active match session
       responses:
         '200':
           description: Match members
@@ -374,20 +374,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MatchMemberResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
-  /match/{matchId}/project:
+  /match/project:
     get:
       tags: [Match]
       security:
         - bearerAuth: []
-      summary: Get the host project details for a match session
-      parameters:
-        - $ref: '#/components/parameters/MatchId'
+      summary: Get the host project details for the current user's active match session
       responses:
         '200':
           description: Match project
@@ -395,22 +391,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MatchProjectResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /match/{matchId}/accept:
+  /match/accept:
     post:
       tags: [Match]
       security:
         - bearerAuth: []
-      summary: Accept a match session
-      parameters:
-        - $ref: '#/components/parameters/MatchId'
+      summary: Accept the current user's active match session
       responses:
         '200':
           description: Match accepted
@@ -420,14 +412,12 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
-  /match/{matchId}/reject:
+  /match/reject:
     post:
       tags: [Match]
       security:
         - bearerAuth: []
-      summary: Reject a match session
-      parameters:
-        - $ref: '#/components/parameters/MatchId'
+      summary: Reject the current user's active match session
       responses:
         '200':
           description: Match rejected
@@ -789,13 +779,6 @@ components:
       scheme: bearer
       bearerFormat: JWT
   parameters:
-    MatchId:
-      in: path
-      name: matchId
-      required: true
-      schema:
-        type: integer
-        format: int64
     ProjectGroupId:
       in: path
       name: projectGroupId
@@ -1064,23 +1047,17 @@ components:
     ProjectRequestStatus:
       type: object
       additionalProperties: false
-      required: [status, matchId]
+      required: [status, role]
       properties:
         status:
           $ref: '#/components/schemas/MatchStatus'
-        matchId:
-          type:
-            - integer
-            - 'null'
-          format: int64
+        role:
+          $ref: '#/components/schemas/MatchRole'
     MatchMemberResponse:
       type: object
       additionalProperties: false
-      required: [matchId, members]
+      required: [members]
       properties:
-        matchId:
-          type: integer
-          format: int64
         members:
           type: array
           items:
@@ -1114,11 +1091,8 @@ components:
     MatchProjectResponse:
       type: object
       additionalProperties: false
-      required: [matchId, projectTitle, projectDescription, projectMvp]
+      required: [projectTitle, projectDescription, projectMvp]
       properties:
-        matchId:
-          type: integer
-          format: int64
         projectTitle:
           type: string
         projectDescription:

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -140,14 +140,12 @@ export function MatchRequestView() {
 	const projectRequestStatus = isSignedIn ? statusQuery.data : null;
 	const noActiveRequest = projectRequestStatus === null;
 	const status = projectRequestStatus?.status;
-	const activeMatchId =
-		projectRequestStatus?.status === "MATCHING"
-			? projectRequestStatus.matchId
-			: null;
-	const matchMembersQuery = useMatchMembersQuery(activeMatchId);
-	const matchProjectQuery = useMatchProjectQuery(activeMatchId);
-	const acceptMutation = useAcceptMatchMutation(activeMatchId);
-	const rejectMutation = useRejectMatchMutation(activeMatchId);
+	const selectedRole = projectRequestStatus?.role ?? form.role;
+	const hasActiveMatch = projectRequestStatus?.status === "MATCHING";
+	const matchMembersQuery = useMatchMembersQuery(hasActiveMatch);
+	const matchProjectQuery = useMatchProjectQuery(hasActiveMatch);
+	const acceptMutation = useAcceptMatchMutation();
+	const rejectMutation = useRejectMatchMutation();
 	const currentProjectGroup = isSignedIn
 		? (projectGroupQuery.data ?? undefined)
 		: undefined;
@@ -167,11 +165,11 @@ export function MatchRequestView() {
 		(status === "WAITING" || status === "MATCHING");
 	const canRespondToMatch = Boolean(
 		!isMatchingAccessBlocked &&
-			activeMatchId &&
+			hasActiveMatch &&
 			(!currentMatchMember ||
 				(!currentMatchMember.isHost && currentMatchMember.isAccepted !== true)),
 	);
-	const hasLiveMatch = Boolean(activeMatchId && !isMatchingAccessBlocked);
+	const hasLiveMatch = hasActiveMatch && !isMatchingAccessBlocked;
 	const isSubmitDisabled =
 		!isSignedIn ||
 		isMatchingAccessBlocked ||
@@ -197,7 +195,7 @@ export function MatchRequestView() {
 	}
 
 	async function handleAcceptMatch() {
-		if (!activeMatchId) {
+		if (!hasActiveMatch) {
 			return;
 		}
 
@@ -287,7 +285,7 @@ export function MatchRequestView() {
 											: "없음"
 						}
 					/>
-					<MetricCard label="선택 역할" value={roleLabels[form.role]} />
+					<MetricCard label="선택 역할" value={roleLabels[selectedRole]} />
 					<MetricCard
 						label="제안 상태"
 						tone={
@@ -375,12 +373,11 @@ export function MatchRequestView() {
 					</AppPanel>
 				) : null}
 
-				{activeMatchId && !isMatchingAccessBlocked ? (
+				{hasActiveMatch && !isMatchingAccessBlocked ? (
 					<div id="match-session">
 						<MatchSessionCard
 							canRespond={canRespondToMatch}
 							currentMember={currentMatchMember}
-							matchId={activeMatchId}
 							members={matchMembersQuery.data?.members}
 							membersError={matchMembersQuery.error}
 							membersLoading={matchMembersQuery.isLoading}
@@ -1103,7 +1100,6 @@ function DecisionBadge({ decision }: { decision: MatchDecisionStatus }) {
 interface MatchSessionCardProps {
 	canRespond: boolean;
 	currentMember?: MatchMember;
-	matchId: number;
 	members?: MatchMember[];
 	membersError: unknown;
 	membersLoading: boolean;
@@ -1119,7 +1115,6 @@ interface MatchSessionCardProps {
 function MatchSessionCard({
 	canRespond,
 	currentMember,
-	matchId,
 	members,
 	membersError,
 	membersLoading,
@@ -1139,7 +1134,6 @@ function MatchSessionCard({
 						<Badge variant={canRespond ? "warm" : "brand"}>
 							{canRespond ? "응답 필요" : "응답 완료"}
 						</Badge>
-						<Badge variant="brand">#{matchId}</Badge>
 					</div>
 				}
 				description="팀원과 프로젝트 정보를 확인한 뒤 이 카드에서 바로 수락 또는 거절할 수 있습니다."

--- a/src/features/match/hooks/use-match-queries.ts
+++ b/src/features/match/hooks/use-match-queries.ts
@@ -20,8 +20,8 @@ import type {
 
 export const matchQueryKeys = {
 	all: ["match"] as const,
-	members: (matchId: number) => ["match", matchId, "members"] as const,
-	project: (matchId: number) => ["match", matchId, "project"] as const,
+	members: ["match", "members"] as const,
+	project: ["match", "project"] as const,
 	status: ["match", "status"] as const,
 };
 
@@ -44,24 +44,20 @@ export function useProjectRequestStatusQuery() {
 	});
 }
 
-export function useMatchMembersQuery(matchId: number | null | undefined) {
+export function useMatchMembersQuery(enabled: boolean) {
 	return useQuery<MatchMemberResponse>({
-		enabled: Boolean(getAuthSession() && matchId),
-		queryFn: () => getMatchMembers(matchId as number),
-		queryKey: matchId
-			? matchQueryKeys.members(matchId)
-			: ["match", "members", "idle"],
+		enabled: Boolean(getAuthSession() && enabled),
+		queryFn: () => getMatchMembers(),
+		queryKey: matchQueryKeys.members,
 		retry: false,
 	});
 }
 
-export function useMatchProjectQuery(matchId: number | null | undefined) {
+export function useMatchProjectQuery(enabled: boolean) {
 	return useQuery<MatchProjectResponse>({
-		enabled: Boolean(getAuthSession() && matchId),
-		queryFn: () => getMatchProject(matchId as number),
-		queryKey: matchId
-			? matchQueryKeys.project(matchId)
-			: ["match", "project", "idle"],
+		enabled: Boolean(getAuthSession() && enabled),
+		queryFn: () => getMatchProject(),
+		queryKey: matchQueryKeys.project,
 		retry: false,
 	});
 }
@@ -73,6 +69,8 @@ export function useCreateProjectRequestMutation() {
 		mutationFn: (payload: ProjectRequestPayload) =>
 			createProjectRequest(payload),
 		onSuccess: () => {
+			queryClient.removeQueries({ queryKey: matchQueryKeys.members });
+			queryClient.removeQueries({ queryKey: matchQueryKeys.project });
 			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
 		},
 	});
@@ -88,39 +86,35 @@ export function useCancelProjectRequestMutation() {
 				matchQueryKeys.status,
 				null,
 			);
+			queryClient.removeQueries({ queryKey: matchQueryKeys.members });
+			queryClient.removeQueries({ queryKey: matchQueryKeys.project });
 			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
 		},
 	});
 }
 
-export function useAcceptMatchMutation(matchId: number | null | undefined) {
+export function useAcceptMatchMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: () => acceptMatch(matchId as number),
+		mutationFn: () => acceptMatch(),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
-			if (matchId) {
-				queryClient.invalidateQueries({
-					queryKey: matchQueryKeys.members(matchId),
-				});
-			}
+			queryClient.invalidateQueries({ queryKey: matchQueryKeys.members });
+			queryClient.invalidateQueries({ queryKey: matchQueryKeys.project });
 		},
 	});
 }
 
-export function useRejectMatchMutation(matchId: number | null | undefined) {
+export function useRejectMatchMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: () => rejectMatch(matchId as number),
+		mutationFn: () => rejectMatch(),
 		onSuccess: () => {
+			queryClient.removeQueries({ queryKey: matchQueryKeys.members });
+			queryClient.removeQueries({ queryKey: matchQueryKeys.project });
 			queryClient.invalidateQueries({ queryKey: matchQueryKeys.status });
-			if (matchId) {
-				queryClient.invalidateQueries({
-					queryKey: matchQueryKeys.members(matchId),
-				});
-			}
 		},
 	});
 }

--- a/src/lib/api/match.ts
+++ b/src/lib/api/match.ts
@@ -23,22 +23,22 @@ export function getProjectRequestStatus() {
 	return apiRequest<ProjectRequestStatusResponse>("/match/status");
 }
 
-export function getMatchMembers(matchId: number) {
-	return apiRequest<MatchMemberResponse>(`/match/${matchId}/members`);
+export function getMatchMembers() {
+	return apiRequest<MatchMemberResponse>("/match/members");
 }
 
-export function getMatchProject(matchId: number) {
-	return apiRequest<MatchProjectResponse>(`/match/${matchId}/project`);
+export function getMatchProject() {
+	return apiRequest<MatchProjectResponse>("/match/project");
 }
 
-export function acceptMatch(matchId: number) {
-	return apiRequest<void>(`/match/${matchId}/accept`, {
+export function acceptMatch() {
+	return apiRequest<void>("/match/accept", {
 		method: "POST",
 	});
 }
 
-export function rejectMatch(matchId: number) {
-	return apiRequest<void>(`/match/${matchId}/reject`, {
+export function rejectMatch() {
+	return apiRequest<void>("/match/reject", {
 		method: "POST",
 	});
 }

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -43,7 +43,7 @@ let currentUser: UserProfile | null = createPreviewUser();
 let currentUserId = 1;
 let currentPassword = previewAuthSeed.password;
 let matchStatus: MatchStatus | null = null;
-let activeMatchId: number | null = null;
+let activeProjectRequestRole: MatchRole | null = null;
 let activeMatchMembers: MatchMemberResponse["members"] = [];
 let activeMatchProject: MatchProjectResponse | null = null;
 let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
@@ -226,7 +226,7 @@ function resetDeleteEmailState() {
 
 function resetMatchState() {
 	matchStatus = null;
-	activeMatchId = null;
+	activeProjectRequestRole = null;
 	activeMatchMembers = [];
 	activeMatchProject = null;
 }
@@ -506,9 +506,7 @@ function assertProjectGroupHost(projectGroupId: number) {
 function createMockMatchSession(body: ProjectRequestPayload) {
 	const isCurrentUserLastResponder = currentUser?.isGithubLogin === true;
 
-	activeMatchId = 42;
 	activeMatchProject = {
-		matchId: activeMatchId,
 		projectDescription:
 			body.projectDescription ??
 			"개발자 사이드 프로젝트 팀을 빠르게 구성하는 서비스를 만듭니다.",
@@ -1308,7 +1306,7 @@ export const handlers = [
 		currentUser = null;
 		resetDeleteEmailState();
 		matchStatus = null;
-		activeMatchId = null;
+		activeProjectRequestRole = null;
 		activeMatchMembers = [];
 		activeMatchProject = null;
 		activeProjectGroup = null;
@@ -1337,8 +1335,16 @@ export const handlers = [
 			);
 		}
 
+		if (!activeProjectRequestRole) {
+			return buildErrorResponse(
+				500,
+				"매칭 데이터가 정합하지 않습니다.",
+				"MATCH_DATA_ERROR",
+			);
+		}
+
 		return HttpResponse.json({
-			matchId: matchStatus === "MATCHING" ? activeMatchId : null,
+			role: activeProjectRequestRole,
 			status: matchStatus,
 		});
 	}),
@@ -1375,10 +1381,11 @@ export const handlers = [
 
 		if (hasCompleteProjectInfo(body)) {
 			matchStatus = "MATCHING";
+			activeProjectRequestRole = body.role;
 			createMockMatchSession(body);
 		} else {
 			matchStatus = "WAITING";
-			activeMatchId = null;
+			activeProjectRequestRole = body.role;
 			activeMatchMembers = [];
 			activeMatchProject = null;
 		}
@@ -1406,16 +1413,14 @@ export const handlers = [
 		}
 
 		matchStatus = null;
-		activeMatchId = null;
+		activeProjectRequestRole = null;
 		activeMatchMembers = [];
 		activeMatchProject = null;
 
 		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.get(getPath("/match/:matchId/members"), ({ params }) => {
-		const matchId = Number(params.matchId);
-
+	http.get(getPath("/match/members"), () => {
 		if (!currentUser) {
 			return buildErrorResponse(
 				401,
@@ -1424,7 +1429,7 @@ export const handlers = [
 			);
 		}
 
-		if (!activeMatchId || matchId !== activeMatchId) {
+		if (matchStatus !== "MATCHING" || activeMatchMembers.length === 0) {
 			return buildErrorResponse(
 				404,
 				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
@@ -1433,14 +1438,11 @@ export const handlers = [
 		}
 
 		return HttpResponse.json({
-			matchId: activeMatchId,
 			members: activeMatchMembers,
 		} satisfies MatchMemberResponse);
 	}),
 
-	http.get(getPath("/match/:matchId/project"), ({ params }) => {
-		const matchId = Number(params.matchId);
-
+	http.get(getPath("/match/project"), () => {
 		if (!currentUser) {
 			return buildErrorResponse(
 				401,
@@ -1449,7 +1451,7 @@ export const handlers = [
 			);
 		}
 
-		if (!activeMatchId || matchId !== activeMatchId || !activeMatchProject) {
+		if (matchStatus !== "MATCHING" || !activeMatchProject) {
 			return buildErrorResponse(
 				404,
 				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
@@ -1460,13 +1462,12 @@ export const handlers = [
 		return HttpResponse.json(activeMatchProject);
 	}),
 
-	http.post(getPath("/match/:matchId/accept"), ({ params }) => {
-		const matchId = Number(params.matchId);
+	http.post(getPath("/match/accept"), () => {
 		const member = activeMatchMembers.find(
 			(candidate) => candidate.userId === currentUserId,
 		);
 
-		if (!activeMatchId || matchId !== activeMatchId || !member) {
+		if (matchStatus !== "MATCHING" || !member) {
 			return buildErrorResponse(
 				404,
 				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
@@ -1487,13 +1488,12 @@ export const handlers = [
 		return new HttpResponse(null, { status: 200 });
 	}),
 
-	http.post(getPath("/match/:matchId/reject"), ({ params }) => {
-		const matchId = Number(params.matchId);
+	http.post(getPath("/match/reject"), () => {
 		const member = activeMatchMembers.find(
 			(candidate) => candidate.userId === currentUserId,
 		);
 
-		if (!activeMatchId || matchId !== activeMatchId || !member) {
+		if (matchStatus !== "MATCHING" || !member) {
 			return buildErrorResponse(
 				404,
 				"이미 완료되었거나 존재하지 않는 매칭 세션입니다.",
@@ -1511,7 +1511,7 @@ export const handlers = [
 
 		member.isAccepted = false;
 		matchStatus = "WAITING";
-		activeMatchId = null;
+		activeProjectRequestRole = member.role;
 		activeMatchMembers = [];
 		activeMatchProject = null;
 

--- a/src/lib/types/match.ts
+++ b/src/lib/types/match.ts
@@ -10,7 +10,7 @@ export interface ProjectRequestPayload {
 }
 
 export interface ProjectRequestStatusResponse {
-	matchId: number | null;
+	role: MatchRole;
 	status: MatchStatus;
 }
 
@@ -26,12 +26,10 @@ export interface MatchMember {
 }
 
 export interface MatchMemberResponse {
-	matchId: number;
 	members: MatchMember[];
 }
 
 export interface MatchProjectResponse {
-	matchId: number;
 	projectDescription: string;
 	projectMvp: string;
 	projectTitle: string;


### PR DESCRIPTION
<!-- codex-server-api-sync-to-client -->

## Summary
- sync Client OpenAPI and request functions with Server current-user scoped match endpoints
- remove matchId from match status/member/project response types and UI
- update MSW match handlers and query cache cleanup for the new contract

## Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build
- Browser checked desktop and mobile match request/session flows; screenshot capture timed out in Browser plugin, DOM snapshots and console checks passed

Closes #79