### PR TITLE
feat(team-space): sync Server GitHub contribution API

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Team-po Server API
-  version: 0.4.0
+  version: 0.5.0
   summary: Client-facing contract mirrored from the current Spring controllers.
 servers:
   - url: /api
@@ -772,6 +772,50 @@ paths:
           $ref: '#/components/responses/NotFound'
         '502':
           $ref: '#/components/responses/BadGateway'
+  /team-space/{projectGroupId}/github/repositories/{githubRepositoryId}/contributions:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get GitHub repository contribution totals for a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/GithubRepositoryId'
+      responses:
+        '200':
+          description: GitHub repository contribution totals
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GithubRepositoryContributionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /team-space/{projectGroupId}/github/repositories/{githubRepositoryId}/pull-request-contributions/sync:
+    post:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Sync merged GitHub pull request contributions for a repository
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/GithubRepositoryId'
+      responses:
+        '200':
+          description: GitHub pull request contributions synced
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '502':
+          $ref: '#/components/responses/BadGateway'
 components:
   securitySchemes:
     bearerAuth:
@@ -796,6 +840,13 @@ components:
     ChecklistId:
       in: path
       name: checklistId
+      required: true
+      schema:
+        type: integer
+        format: int64
+    GithubRepositoryId:
+      in: path
+      name: githubRepositoryId
       required: true
       schema:
         type: integer
@@ -1374,6 +1425,62 @@ components:
           items:
             type: integer
             format: int64
+    GithubRepositoryContributionResponse:
+      type: object
+      additionalProperties: false
+      required: [githubRepositoryId, repoName, fullName, contributors]
+      properties:
+        githubRepositoryId:
+          type: integer
+          format: int64
+        repoName:
+          type: string
+        fullName:
+          type: string
+        contributors:
+          type: array
+          items:
+            $ref: '#/components/schemas/GithubRepositoryContributor'
+    GithubRepositoryContributor:
+      type: object
+      additionalProperties: false
+      required:
+        - userId
+        - githubUserId
+        - githubUsername
+        - mergedPrCount
+        - linkedIssueCount
+        - additions
+        - deletions
+        - changedFiles
+        - contributionScore
+      properties:
+        userId:
+          type: integer
+          format: int64
+        githubUserId:
+          type: integer
+          format: int64
+        githubUsername:
+          type: string
+        mergedPrCount:
+          type: integer
+          format: int64
+        linkedIssueCount:
+          type: integer
+          format: int64
+        additions:
+          type: integer
+          format: int64
+        deletions:
+          type: integer
+          format: int64
+        changedFiles:
+          type: integer
+          format: int64
+        contributionScore:
+          type: integer
+          format: int64
     DevGuideContent:
       type: object
       additionalProperties: false

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -59,7 +59,9 @@ import {
 	useDevGuideQuery,
 	useGithubInstallationStatusQuery,
 	useGithubRepositoriesQuery,
+	useGithubRepositoryContributionsQuery,
 	useSetGithubRepositoriesMutation,
+	useSyncGithubPullRequestContributionsMutation,
 } from "@/features/team/hooks/use-team-space-queries";
 import { demoTeamSpace } from "@/features/team/lib/demo-team-space";
 import { getAuthSession } from "@/lib/api/auth-session";
@@ -73,7 +75,11 @@ import type {
 	MyProjectGroup,
 	ProjectGroupMember,
 } from "@/lib/types/project-group";
-import type { DevGuideContent, GithubRepository } from "@/lib/types/team-space";
+import type {
+	DevGuideContent,
+	GithubRepository,
+	GithubRepositoryContributor,
+} from "@/lib/types/team-space";
 import type {
 	GithubRepositorySummary,
 	TeamChecklistItem,
@@ -158,6 +164,7 @@ const contributionLevelClass = [
 	"bg-emerald-500",
 	"bg-emerald-700",
 ] as const;
+const contributionNumberFormatter = new Intl.NumberFormat("ko-KR");
 
 export function TeamSpaceView() {
 	const [isSignedIn] = useState(() => Boolean(getAuthSession()));
@@ -2522,8 +2529,10 @@ function RealGithubInstallationPanel({
 								) : null}
 
 								{connectedRepositories.map((repository) => (
-									<RealGithubRepositoryItem
+									<RealGithubRepositoryContributionCard
+										canManageGithubInstallation={canManageGithubInstallation}
 										key={repository.githubRepositoryId}
+										projectGroupId={projectGroup.projectGroupId}
 										repository={repository}
 									/>
 								))}
@@ -2663,28 +2672,218 @@ function RealGithubStatusCard({
 	);
 }
 
-function RealGithubRepositoryItem({
+function RealGithubRepositoryContributionCard({
+	canManageGithubInstallation,
+	projectGroupId,
 	repository,
 }: {
+	canManageGithubInstallation: boolean;
+	projectGroupId: number;
 	repository: GithubRepository;
 }) {
+	const contributionsQuery = useGithubRepositoryContributionsQuery(
+		projectGroupId,
+		repository.githubRepositoryId,
+	);
+	const syncContributionsMutation =
+		useSyncGithubPullRequestContributionsMutation();
+	const contributors = contributionsQuery.data?.contributors ?? [];
+	const sortedContributors = useMemo(
+		() =>
+			[...contributors].sort(
+				(left, right) => right.contributionScore - left.contributionScore,
+			),
+		[contributors],
+	);
+	const totals = useMemo(
+		() => calculateGithubContributionTotals(contributors),
+		[contributors],
+	);
+	const isSyncingCurrentRepository =
+		syncContributionsMutation.isPending &&
+		syncContributionsMutation.variables?.githubRepositoryId ===
+			repository.githubRepositoryId;
+
+	function handleSyncContributions() {
+		syncContributionsMutation.mutate({
+			githubRepositoryId: repository.githubRepositoryId,
+			projectGroupId,
+		});
+	}
+
 	return (
-		<a
-			className="flex flex-col gap-2 rounded-lg border border-primary/15 bg-white p-4 transition-colors hover:border-primary/30 sm:flex-row sm:items-center sm:justify-between"
-			href={`https://github.com/${repository.fullName}`}
-			rel="noreferrer"
-			target="_blank"
-		>
+		<div className="rounded-lg border border-primary/15 bg-white p-4 shadow-crisp">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<a
+					className="min-w-0"
+					href={`https://github.com/${repository.fullName}`}
+					rel="noreferrer"
+					target="_blank"
+				>
+					<span className="flex min-w-0 items-center gap-2">
+						<span className="truncate font-mono text-sm font-semibold text-primary">
+							{repository.fullName}
+						</span>
+						<ExternalLink className="size-4 shrink-0 text-primary" />
+					</span>
+					<span className="mt-1 block text-xs text-muted-foreground">
+						{repository.repoName}
+					</span>
+				</a>
+				<Button
+					disabled={!canManageGithubInstallation || isSyncingCurrentRepository}
+					onClick={handleSyncContributions}
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					{isSyncingCurrentRepository ? (
+						<LoaderCircle className="animate-spin" data-icon="inline-start" />
+					) : (
+						<RefreshCw data-icon="inline-start" />
+					)}
+					PR 동기화
+				</Button>
+			</div>
+
+			{contributionsQuery.isLoading ? (
+				<RealInlineStatus
+					className="mt-4"
+					icon={<LoaderCircle className="size-4 animate-spin" />}
+					message="저장소 기여도를 불러오고 있습니다."
+				/>
+			) : null}
+
+			{contributionsQuery.error ? (
+				<RealInlineStatus
+					className="mt-4"
+					message={getApiErrorMessage(contributionsQuery.error)}
+				/>
+			) : null}
+
+			{syncContributionsMutation.error &&
+			syncContributionsMutation.variables?.githubRepositoryId ===
+				repository.githubRepositoryId ? (
+				<RealInlineStatus
+					className="mt-4"
+					message={getApiErrorMessage(syncContributionsMutation.error)}
+				/>
+			) : null}
+
+			{contributionsQuery.isSuccess ? (
+				<div className="mt-4 grid gap-4">
+					<div className="grid gap-2 sm:grid-cols-4">
+						<RealGithubContributionStat
+							label="Merged PR"
+							value={totals.mergedPrCount}
+						/>
+						<RealGithubContributionStat
+							label="Linked issues"
+							value={totals.linkedIssueCount}
+						/>
+						<RealGithubContributionStat
+							label="Changed files"
+							value={totals.changedFiles}
+						/>
+						<RealGithubContributionStat
+							label="Score"
+							value={totals.contributionScore}
+						/>
+					</div>
+
+					{sortedContributors.length > 0 ? (
+						<div className="grid gap-2">
+							{sortedContributors.map((contributor) => (
+								<RealGithubContributorRow
+									contributor={contributor}
+									key={`${contributor.userId}-${contributor.githubUserId}`}
+								/>
+							))}
+						</div>
+					) : (
+						<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4">
+							<p className="text-sm leading-6 text-muted-foreground">
+								아직 동기화된 PR 기여도가 없습니다.
+							</p>
+						</div>
+					)}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function calculateGithubContributionTotals(
+	contributors: GithubRepositoryContributor[],
+) {
+	return contributors.reduce(
+		(totals, contributor) => ({
+			changedFiles: totals.changedFiles + contributor.changedFiles,
+			contributionScore:
+				totals.contributionScore + contributor.contributionScore,
+			linkedIssueCount: totals.linkedIssueCount + contributor.linkedIssueCount,
+			mergedPrCount: totals.mergedPrCount + contributor.mergedPrCount,
+		}),
+		{
+			changedFiles: 0,
+			contributionScore: 0,
+			linkedIssueCount: 0,
+			mergedPrCount: 0,
+		},
+	);
+}
+
+function RealGithubContributionStat({
+	label,
+	value,
+}: {
+	label: string;
+	value: number;
+}) {
+	return (
+		<div className="rounded-lg border border-border/70 bg-secondary/25 p-3">
+			<p className="text-[11px] font-semibold uppercase text-muted-foreground">
+				{label}
+			</p>
+			<p className="mt-2 text-sm font-semibold text-brand-ink">
+				{contributionNumberFormatter.format(value)}
+			</p>
+		</div>
+	);
+}
+
+function RealGithubContributorRow({
+	contributor,
+}: {
+	contributor: GithubRepositoryContributor;
+}) {
+	return (
+		<div className="grid gap-3 rounded-lg border border-border/70 bg-secondary/20 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
 			<div className="min-w-0">
-				<p className="truncate font-mono text-sm font-semibold text-primary">
-					{repository.fullName}
+				<p className="truncate text-sm font-semibold text-brand-ink">
+					@{contributor.githubUsername}
 				</p>
 				<p className="mt-1 text-xs text-muted-foreground">
-					{repository.repoName}
+					PR {contributionNumberFormatter.format(contributor.mergedPrCount)} ·
+					이슈{" "}
+					{contributionNumberFormatter.format(contributor.linkedIssueCount)}
 				</p>
 			</div>
-			<ExternalLink className="size-4 shrink-0 text-primary" />
-		</a>
+			<div className="flex flex-wrap gap-2 text-xs text-muted-foreground sm:justify-end">
+				<span>
+					+{contributionNumberFormatter.format(contributor.additions)}
+				</span>
+				<span>
+					-{contributionNumberFormatter.format(contributor.deletions)}
+				</span>
+				<span>
+					{contributionNumberFormatter.format(contributor.changedFiles)} files
+				</span>
+				<Badge variant="brand">
+					{contributionNumberFormatter.format(contributor.contributionScore)}
+				</Badge>
+			</div>
+		</div>
 	);
 }
 
@@ -2750,14 +2949,21 @@ function RealActionFeedback({ feedback }: { feedback: ActionFeedback | null }) {
 }
 
 function RealInlineStatus({
+	className,
 	icon,
 	message,
 }: {
+	className?: string;
 	icon?: ReactNode;
 	message: string;
 }) {
 	return (
-		<div className="flex items-center gap-2 rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
+		<div
+			className={cn(
+				"flex items-center gap-2 rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground",
+				className,
+			)}
+		>
 			{icon}
 			<span>{message}</span>
 		</div>

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -8,10 +8,13 @@ import {
 	getDevGuide,
 	getGithubInstallationStatus,
 	getGithubRepositories,
+	getGithubRepositoryContributions,
 	setGithubRepositories,
+	syncGithubPullRequestContributions,
 } from "@/lib/api/team-space";
 import type {
 	GithubAppInstallationCompleteRequest,
+	GithubRepositoryContributionRequest,
 	SetGithubRepositoriesRequest,
 } from "@/lib/types/team-space";
 
@@ -23,12 +26,25 @@ export const teamSpaceQueryKeys = {
 		["team-space", projectGroupId, "github", "available-repositories"] as const,
 	githubRepositories: (projectGroupId: number) =>
 		["team-space", projectGroupId, "github", "repositories"] as const,
+	githubRepositoryContributions: (
+		projectGroupId: number,
+		githubRepositoryId: number,
+	) =>
+		[
+			"team-space",
+			projectGroupId,
+			"github",
+			"repositories",
+			githubRepositoryId,
+			"contributions",
+		] as const,
 	githubStatus: (projectGroupId: number) =>
 		["team-space", projectGroupId, "github", "status"] as const,
 };
 
 const githubStatusStaleTimeMs = 15_000;
 const githubRepositoryStaleTimeMs = 15_000;
+const githubContributionStaleTimeMs = 15_000;
 const devGuideStaleTimeMs = 60_000;
 const pendingDevGuideRefetchIntervalMs = 5_000;
 
@@ -125,6 +141,34 @@ export function useGithubRepositoriesQuery(
 	});
 }
 
+export function useGithubRepositoryContributionsQuery(
+	projectGroupId: number | undefined,
+	githubRepositoryId: number | undefined,
+	enabled = true,
+) {
+	const hasIds =
+		typeof projectGroupId === "number" &&
+		typeof githubRepositoryId === "number";
+
+	return useQuery({
+		enabled: enabled && hasIds,
+		queryFn: () =>
+			getGithubRepositoryContributions({
+				githubRepositoryId: requireProjectGroupId(githubRepositoryId),
+				projectGroupId: requireProjectGroupId(projectGroupId),
+			}),
+		queryKey: hasIds
+			? teamSpaceQueryKeys.githubRepositoryContributions(
+					projectGroupId,
+					githubRepositoryId,
+				)
+			: teamSpaceQueryKeys.all,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: githubContributionStaleTimeMs,
+	});
+}
+
 export function useCompleteGithubAppInstallationMutation() {
 	const queryClient = useQueryClient();
 
@@ -167,6 +211,23 @@ export function useSetGithubRepositoriesMutation() {
 			queryClient.invalidateQueries({
 				queryKey: teamSpaceQueryKeys.githubAvailableRepositories(
 					variables.projectGroupId,
+				),
+			});
+		},
+	});
+}
+
+export function useSyncGithubPullRequestContributionsMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: GithubRepositoryContributionRequest) =>
+			syncGithubPullRequestContributions(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.githubRepositoryContributions(
+					variables.projectGroupId,
+					variables.githubRepositoryId,
 				),
 			});
 		},

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -32,6 +32,7 @@ import type {
 	GithubAppInstallationCompleteRequest,
 	GithubInstallationStatus,
 	GithubRepository,
+	GithubRepositoryContributionResponse,
 } from "@/lib/types/team-space";
 import type {
 	EditPasswordRequest,
@@ -55,9 +56,15 @@ let githubInstallationStatus: GithubInstallationStatus =
 	createDisconnectedGithubStatus();
 let pendingGithubInstallationState: string | null = null;
 let selectedGithubRepositories: GithubRepository[] = [];
+let githubRepositoryContributions = new Map<
+	number,
+	GithubRepositoryContributionResponse
+>();
 let deleteEmailAuthSentUserId: number | null = null;
 let deleteEmailVerifiedUserId: number | null = null;
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
+const pendingGithubInstallationStateStorageKey =
+	"team-po.mock.github-installation-state";
 
 function createGithubLoginUser() {
 	return createPreviewUser({
@@ -238,8 +245,9 @@ function resetTeamSpaceApiState() {
 	activeDevGuide = createMockDevGuide(activeProjectGroup);
 	nextProjectChecklistId = 103;
 	githubInstallationStatus = createDisconnectedGithubStatus();
-	pendingGithubInstallationState = null;
+	clearPendingGithubInstallationState();
 	selectedGithubRepositories = [];
+	githubRepositoryContributions = new Map();
 }
 
 function createDisconnectedGithubStatus(): GithubInstallationStatus {
@@ -402,6 +410,120 @@ function syncGithubRepositoryCount() {
 		...githubInstallationStatus,
 		repositoryCount: selectedGithubRepositories.length,
 	};
+}
+
+function setPendingGithubInstallationState(state: string) {
+	pendingGithubInstallationState = state;
+	getSessionStorage()?.setItem(pendingGithubInstallationStateStorageKey, state);
+}
+
+function getPendingGithubInstallationState() {
+	if (pendingGithubInstallationState) {
+		return pendingGithubInstallationState;
+	}
+
+	pendingGithubInstallationState =
+		getSessionStorage()?.getItem(pendingGithubInstallationStateStorageKey) ??
+		null;
+
+	return pendingGithubInstallationState;
+}
+
+function clearPendingGithubInstallationState() {
+	pendingGithubInstallationState = null;
+	getSessionStorage()?.removeItem(pendingGithubInstallationStateStorageKey);
+}
+
+function getSessionStorage() {
+	return typeof window === "undefined" ? null : window.sessionStorage;
+}
+
+function syncGithubRepositoryContributionState() {
+	const nextContributions = new Map<
+		number,
+		GithubRepositoryContributionResponse
+	>();
+
+	for (const repository of selectedGithubRepositories) {
+		nextContributions.set(
+			repository.githubRepositoryId,
+			githubRepositoryContributions.get(repository.githubRepositoryId) ??
+				createEmptyGithubRepositoryContribution(repository),
+		);
+	}
+
+	githubRepositoryContributions = nextContributions;
+}
+
+function createEmptyGithubRepositoryContribution(
+	repository: GithubRepository,
+): GithubRepositoryContributionResponse {
+	return {
+		contributors: [],
+		fullName: repository.fullName,
+		githubRepositoryId: repository.githubRepositoryId,
+		repoName: repository.repoName,
+	};
+}
+
+function createSyncedGithubRepositoryContribution(
+	repository: GithubRepository,
+): GithubRepositoryContributionResponse {
+	const baseContributors = [
+		{
+			additions: 860,
+			changedFiles: 34,
+			contributionScore: 40,
+			deletions: 190,
+			githubUserId: 501,
+			githubUsername: "dev-a",
+			linkedIssueCount: 2,
+			mergedPrCount: 3,
+			userId: 1,
+		},
+		{
+			additions: 420,
+			changedFiles: 18,
+			contributionScore: 25,
+			deletions: 80,
+			githubUserId: 502,
+			githubUsername: "dev-b",
+			linkedIssueCount: 1,
+			mergedPrCount: 2,
+			userId: 2,
+		},
+	];
+
+	if (repository.githubRepositoryId === 200) {
+		return {
+			...createEmptyGithubRepositoryContribution(repository),
+			contributors: [
+				{
+					additions: 1240,
+					changedFiles: 42,
+					contributionScore: 55,
+					deletions: 310,
+					githubUserId: 503,
+					githubUsername: "server-runner",
+					linkedIssueCount: 3,
+					mergedPrCount: 4,
+					userId: 1,
+				},
+				...baseContributors.slice(1),
+			],
+		};
+	}
+
+	return {
+		...createEmptyGithubRepositoryContribution(repository),
+		contributors: baseContributors,
+	};
+}
+
+function findSelectedGithubRepository(githubRepositoryId: number) {
+	return selectedGithubRepositories.find(
+		(repository) => repository.githubRepositoryId === githubRepositoryId,
+	);
 }
 
 function isValidMatchRole(value: string): value is MatchRole {
@@ -1938,10 +2060,11 @@ export const handlers = [
 				);
 			}
 
-			pendingGithubInstallationState = crypto.randomUUID();
+			const installationState = crypto.randomUUID();
+			setPendingGithubInstallationState(installationState);
 
 			return HttpResponse.json({
-				installUrl: `https://github.com/apps/team-po/installations/new?state=${pendingGithubInstallationState}`,
+				installUrl: `https://github.com/apps/team-po/installations/new?state=${installationState}`,
 			});
 		},
 	),
@@ -1962,10 +2085,12 @@ export const handlers = [
 				return hostError;
 			}
 
+			const expectedInstallationState = getPendingGithubInstallationState();
+
 			if (
 				body.setupAction !== "install" ||
-				!pendingGithubInstallationState ||
-				body.state !== pendingGithubInstallationState
+				!expectedInstallationState ||
+				body.state !== expectedInstallationState
 			) {
 				return buildErrorResponse(
 					400,
@@ -1990,8 +2115,9 @@ export const handlers = [
 				);
 			}
 
-			pendingGithubInstallationState = null;
+			clearPendingGithubInstallationState();
 			selectedGithubRepositories = [];
+			githubRepositoryContributions = new Map();
 			githubInstallationStatus = {
 				connected: true,
 				organizationLogin: "team-po-labs",
@@ -2110,6 +2236,83 @@ export const handlers = [
 					Boolean(repository),
 				);
 			syncGithubRepositoryCount();
+			syncGithubRepositoryContributionState();
+
+			return new HttpResponse(null, { status: 200 });
+		},
+	),
+
+	http.get(
+		getPath(
+			"/team-space/:projectGroupId/github/repositories/:githubRepositoryId/contributions",
+		),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const githubRepositoryId = Number(params.githubRepositoryId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			const repository = findSelectedGithubRepository(githubRepositoryId);
+
+			if (!repository) {
+				return buildErrorResponse(
+					400,
+					"팀 스페이스에 등록된 Github Repository가 아닙니다.",
+					"GITHUB_REPOSITORY_NOT_ACCESSIBLE",
+				);
+			}
+
+			return HttpResponse.json(
+				githubRepositoryContributions.get(githubRepositoryId) ??
+					createEmptyGithubRepositoryContribution(repository),
+			);
+		},
+	),
+
+	http.post(
+		getPath(
+			"/team-space/:projectGroupId/github/repositories/:githubRepositoryId/pull-request-contributions/sync",
+		),
+		async ({ params, request }) => {
+			await delay(450);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const githubRepositoryId = Number(params.githubRepositoryId);
+			const hostError = assertProjectGroupHost(projectGroupId);
+
+			if (hostError) {
+				return hostError;
+			}
+
+			const repository = findSelectedGithubRepository(githubRepositoryId);
+
+			if (!repository) {
+				return buildErrorResponse(
+					400,
+					"팀 스페이스에 등록된 Github Repository가 아닙니다.",
+					"GITHUB_REPOSITORY_NOT_ACCESSIBLE",
+				);
+			}
+
+			if (githubRepositoryId === 300) {
+				return buildErrorResponse(
+					502,
+					"GitHub API 요청에 실패했습니다.",
+					"GITHUB_API_REQUEST_FAILED",
+				);
+			}
+
+			githubRepositoryContributions.set(
+				githubRepositoryId,
+				createSyncedGithubRepositoryContribution(repository),
+			);
 
 			return new HttpResponse(null, { status: 200 });
 		},

--- a/src/lib/api/team-space.ts
+++ b/src/lib/api/team-space.ts
@@ -4,6 +4,8 @@ import type {
 	GithubAppInstallationCompleteRequest,
 	GithubAppInstallationUrl,
 	GithubInstallationStatus,
+	GithubRepositoryContributionRequest,
+	GithubRepositoryContributionResponse,
 	GithubRepositoryListResponse,
 	SetGithubRepositoriesRequest,
 } from "@/lib/types/team-space";
@@ -68,4 +70,25 @@ export function setGithubRepositories({
 		},
 		method: "PUT",
 	});
+}
+
+export function getGithubRepositoryContributions({
+	githubRepositoryId,
+	projectGroupId,
+}: GithubRepositoryContributionRequest) {
+	return apiRequest<GithubRepositoryContributionResponse>(
+		`/team-space/${projectGroupId}/github/repositories/${githubRepositoryId}/contributions`,
+	);
+}
+
+export function syncGithubPullRequestContributions({
+	githubRepositoryId,
+	projectGroupId,
+}: GithubRepositoryContributionRequest) {
+	return apiRequest<void>(
+		`/team-space/${projectGroupId}/github/repositories/${githubRepositoryId}/pull-request-contributions/sync`,
+		{
+			method: "POST",
+		},
+	);
 }

--- a/src/lib/types/team-space.ts
+++ b/src/lib/types/team-space.ts
@@ -30,6 +30,30 @@ export interface SetGithubRepositoriesRequest {
 	projectGroupId: number;
 }
 
+export interface GithubRepositoryContributionRequest {
+	githubRepositoryId: number;
+	projectGroupId: number;
+}
+
+export interface GithubRepositoryContributor {
+	additions: number;
+	changedFiles: number;
+	contributionScore: number;
+	deletions: number;
+	githubUserId: number;
+	githubUsername: string;
+	linkedIssueCount: number;
+	mergedPrCount: number;
+	userId: number;
+}
+
+export interface GithubRepositoryContributionResponse {
+	contributors: GithubRepositoryContributor[];
+	fullName: string;
+	githubRepositoryId: number;
+	repoName: string;
+}
+
 export interface DevGuideTechStackItem {
 	category: string;
 	reason: string;


### PR DESCRIPTION
<!-- codex-server-api-sync-to-client -->

## Summary
- Mirror Server commit 8ccf456 team-space GitHub contribution endpoints in Client OpenAPI, types, and API request functions.
- Add TanStack Query hooks, MSW handlers, and GitHub tab UI for repository contribution totals and PR contribution sync.
- Persist the MSW GitHub App install state across redirect callbacks so the mock flow matches the Server callback contract.

## Validation
- pnpm typecheck
- pnpm biome lint .
- pnpm build
- Browser checked GitHub App connection, repository selection, contribution sync success, and sync 502 error state; Browser screenshot capture timed out twice, but DOM snapshots and console error/warn checks passed.

## Closes
Closes #81