### PR TITLE
fix(team-space): sync DevGuide API contract

### DIFF
--- a/docs/team-space-api-spec.md
+++ b/docs/team-space-api-spec.md
@@ -1,468 +1,72 @@
-# 팀 스페이스 API 명세 초안
+# 팀 스페이스 API 계약 메모
 
-## 목적
+상세 계약의 단일 기준은 `openapi/openapi.yaml`이다. 이 문서는 팀 스페이스 화면에서 사용하는 서버 API의 현재 적용 범위를 빠르게 확인하기 위한 메모다.
 
-프론트엔드 `/team` 라우트가 real 모드에서 실제 팀 데이터를 표시할 수 있도록 필요한 API를 정리한다.
-현재 서버에는 매칭 요청, 매칭 세션 조회, 매칭 수락/거절, 팀 관리자 권한 변경 API만 있으며, 팀 스페이스 조회와 운영 기능 API는 아직 없다.
+## 현재 구현된 API
 
-## 전제
+Base URL은 `/api`이며, 아래 경로는 모두 인증 토큰을 사용한다.
 
-- Base URL: `/api`
-- 인증: 기존 `Authorization: Bearer {accessToken}` 사용
-- 응답 Content-Type: `application/json`
-- 팀 스페이스는 매칭 전원 수락 후 생성된 `project_group`을 기준으로 한다.
-- 기존 서버의 `ProjectGroupStatus`(`ACTIVE`, `FINISHED`)는 팀 공간의 존속 상태로 보고, 화면에서 쓰는 프로젝트 진행 단계는 별도 필드 `lifecycleStatus`로 관리한다.
-
-## 기존 API
-
-| Method | Path | 용도 | 상태 |
-| --- | --- | --- | --- |
-| `PATCH` | `/project-groups/{projectGroupId}/admins/{targetUserId}` | 관리자 권한 부여 | 구현됨 |
-| `DELETE` | `/project-groups/{projectGroupId}/admins/{targetUserId}` | 관리자 권한 회수 | 구현됨 |
-
-## 필요한 API 요약
-
-| Method | Path | 용도 | 우선순위 |
-| --- | --- | --- | --- |
-| `GET` | `/project-groups/me/current` | 내 현재 팀 스페이스 조회 | P0 |
-| `PATCH` | `/project-groups/{projectGroupId}` | 팀 이름, 프로젝트 단계 수정 | P1 |
-| `GET` | `/project-groups/{projectGroupId}/rules` | 팀 규칙 조회 | P1 |
-| `PUT` | `/project-groups/{projectGroupId}/rules` | 팀 규칙 저장 | P1 |
-| `GET` | `/project-groups/{projectGroupId}/checklist-items` | 체크리스트 조회 | P1 |
-| `POST` | `/project-groups/{projectGroupId}/checklist-items` | 체크리스트 항목 추가 | P1 |
-| `PATCH` | `/project-groups/{projectGroupId}/checklist-items/{itemId}` | 체크리스트 항목 수정 | P1 |
-| `DELETE` | `/project-groups/{projectGroupId}/checklist-items/{itemId}` | 체크리스트 항목 삭제 | P1 |
-| `GET` | `/project-groups/{projectGroupId}/github/summary` | GitHub 활동 요약 조회 | P2 |
-| `PUT` | `/project-groups/{projectGroupId}/github/repository` | GitHub 저장소 연결/변경 | P2 |
-| `DELETE` | `/project-groups/{projectGroupId}/github/repository` | GitHub 저장소 연결 해제 | P2 |
-| `GET` | `/project-groups/{projectGroupId}/messages` | 팀 채팅 메시지 조회 | P2 |
-| `POST` | `/project-groups/{projectGroupId}/messages` | 팀 채팅 메시지 전송 | P2 |
-
-## 공통 에러
-
-```json
-{
-  "code": "PROJECT_GROUP_NOT_FOUND",
-  "message": "팀 스페이스를 찾을 수 없습니다.",
-  "fieldErrors": {}
-}
-```
-
-| Status | Code 예시 | 의미 |
+| Method | Path | 용도 |
 | --- | --- | --- |
-| `401` | `NO_AUTHENTICATED_USER` | 로그인 필요 |
-| `403` | `PROJECT_GROUP_PERMISSION_DENIED` | 팀 멤버가 아니거나 권한 부족 |
-| `404` | `PROJECT_GROUP_NOT_FOUND` | 현재 팀 또는 요청한 팀 없음 |
-| `409` | `PROJECT_GROUP_CONFLICT` | 이미 변경된 데이터 또는 중복 요청 |
-| `422` | `INVALID_PROJECT_GROUP_REQUEST` | 요청 값 검증 실패 |
+| `GET` | `/project-groups/me` | 내 활성 팀 스페이스 조회 |
+| `PATCH` | `/project-groups/{projectGroupId}/admins/{targetUserId}` | 팀 스페이스 관리자 권한 부여 |
+| `DELETE` | `/project-groups/{projectGroupId}/admins/{targetUserId}` | 팀 스페이스 관리자 권한 회수 |
+| `GET` | `/project-groups/{projectGroupId}/checklists` | 체크리스트 목록 조회 |
+| `POST` | `/project-groups/{projectGroupId}/checklists` | 체크리스트 생성 |
+| `PATCH` | `/project-groups/{projectGroupId}/checklists/{checklistId}` | 체크리스트 수정 |
+| `DELETE` | `/project-groups/{projectGroupId}/checklists/{checklistId}` | 체크리스트 삭제 |
+| `POST` | `/project-groups/{projectGroupId}/checklists/{checklistId}/advice` | 체크리스트 AI 조언 생성 |
+| `GET` | `/team-space/{projectGroupId}/dev-guide` | AI 개발 가이드라인 조회 |
+| `POST` | `/team-space/{projectGroupId}/dev-guide/regenerate` | AI 개발 가이드라인 재생성 |
+| `GET` | `/team-space/{projectGroupId}/github/status` | GitHub App 설치 상태 조회 |
+| `POST` | `/team-space/{projectGroupId}/github/install-url` | GitHub App 설치 URL 생성 |
+| `POST` | `/team-space/{projectGroupId}/github/installations/complete` | GitHub App 설치 완료 처리 |
+| `GET` | `/team-space/{projectGroupId}/github/available-repositories` | 접근 가능한 GitHub Repository 목록 조회 |
+| `GET` | `/team-space/{projectGroupId}/github/repositories` | 등록된 GitHub Repository 목록 조회 |
+| `PUT` | `/team-space/{projectGroupId}/github/repositories` | 등록 Repository 목록 교체 |
+| `GET` | `/team-space/{projectGroupId}/github/repositories/{githubRepositoryId}/contributions` | Repository 기여도 조회 |
+| `POST` | `/team-space/{projectGroupId}/github/repositories/{githubRepositoryId}/pull-request-contributions/sync` | PR 기여도 동기화 |
 
-## 1. 내 현재 팀 스페이스 조회
+## DevGuide 상태 계약
 
-```http
-GET /api/project-groups/me/current
-```
-
-현재 로그인한 사용자가 속한 활성 팀 스페이스를 반환한다.
-활성 팀이 없으면 `404 PROJECT_GROUP_NOT_FOUND`를 반환한다.
-
-### Response 200
+`GET /team-space/{projectGroupId}/dev-guide`는 콘텐츠만 반환하지 않는다. 서버 응답은 `generationStatus`를 항상 포함하고, 콘텐츠가 있으면 `overview`, `techStack`, `mvpPriorities`, `decisionPoints`, `milestones`가 최상위에 펼쳐진다. 아래 JSON은 필드 형태를 보여주는 축약 예시이며, 배열 길이 제약은 `openapi/openapi.yaml`을 따른다.
 
 ```json
 {
-  "projectGroupId": 12,
-  "projectName": "Blue Sprint",
-  "projectTitle": "Team-po 팀 운영 MVP",
-  "projectDescription": "랜덤 팀 매칭 이후 팀이 바로 움직일 수 있도록 운영하는 서비스입니다.",
-  "projectMvp": "매칭 제안 수락/거절, 팀 스페이스 홈, 규칙 템플릿, 체크리스트",
-  "groupStatus": "ACTIVE",
-  "lifecycleStatus": "ACTIVE",
-  "nextMeetingLabel": "오늘 21:00 첫 규칙 정하기",
-  "myRole": "HOST",
-  "members": [
-    {
-      "userId": 1,
-      "nickname": "조하늘",
-      "memberRole": "FRONTEND",
-      "groupRole": "HOST",
-      "isAdmin": true,
-      "level": 4,
-      "temperature": 41.8,
-      "profileImage": null,
-      "responsibility": "React 화면 흐름과 상태 관리"
-    }
-  ],
-  "metrics": {
-    "checklistDoneCount": 3,
-    "checklistTotalCount": 8,
-    "openPullRequestCount": 3,
-    "teamTemperature": 41.2
-  }
+  "generationStatus": "COMPLETED",
+  "remainingRegenerationCount": 2,
+  "overview": "프로젝트 개요",
+  "techStack": [],
+  "mvpPriorities": [],
+  "decisionPoints": [],
+  "milestones": []
 }
 ```
 
-### Field Notes
-
-- `groupStatus`: 서버의 팀 공간 상태. `ACTIVE | FINISHED`
-- `lifecycleStatus`: 화면의 프로젝트 진행 단계. `FORMING | ACTIVE | SHIPPING | COMPLETED | PAUSED`
-- `responsibility`: MVP에서는 nullable 허용. 없으면 프론트에서 역할명만 표시한다.
-- `metrics`: GitHub 연동 전이면 GitHub 관련 값은 `0` 또는 `null` 허용.
-
-## 2. 팀 기본 정보 수정
-
-```http
-PATCH /api/project-groups/{projectGroupId}
-```
-
-팀 이름, 프로젝트 진행 단계, 다음 회의 라벨 등 팀 운영 기본값을 수정한다.
-관리자 이상만 수정 가능하도록 권장한다.
-
-### Request
+초기 생성 중이거나 실패했지만 아직 확정 가이드가 없는 경우에는 콘텐츠 필드 없이 상태만 내려올 수 있다.
 
 ```json
 {
-  "projectName": "Blue Sprint",
-  "lifecycleStatus": "SHIPPING",
-  "nextMeetingLabel": "목요일 21:00 진행 공유"
+  "generationStatus": "GENERATING"
 }
 ```
 
-### Response 200
+재생성 API 응답은 콘텐츠를 `content` 필드 안에 감싸고, 생성 타입과 남은 수동 재생성 횟수를 함께 반환한다.
 
 ```json
 {
-  "projectGroupId": 12,
-  "projectName": "Blue Sprint",
-  "lifecycleStatus": "SHIPPING",
-  "nextMeetingLabel": "목요일 21:00 진행 공유",
-  "updatedAt": "2026-05-05T18:30:00+09:00"
-}
-```
-
-## 3. 팀 규칙
-
-### 조회
-
-```http
-GET /api/project-groups/{projectGroupId}/rules
-```
-
-### Response 200
-
-```json
-{
-  "projectGroupId": 12,
-  "rulesMarkdown": "# 팀 규칙\n\n- PR은 최소 1명 리뷰 후 머지\n- 막힌 일은 24시간 안에 공유",
-  "updatedAt": "2026-05-05T18:30:00+09:00",
-  "updatedBy": {
-    "userId": 1,
-    "nickname": "조하늘"
-  }
-}
-```
-
-### 저장
-
-```http
-PUT /api/project-groups/{projectGroupId}/rules
-```
-
-### Request
-
-```json
-{
-  "rulesMarkdown": "# 팀 규칙\n\n- PR은 최소 1명 리뷰 후 머지"
-}
-```
-
-### Response 200
-
-```json
-{
-  "projectGroupId": 12,
-  "rulesMarkdown": "# 팀 규칙\n\n- PR은 최소 1명 리뷰 후 머지",
-  "updatedAt": "2026-05-05T18:35:00+09:00"
-}
-```
-
-## 4. 체크리스트
-
-### 목록 조회
-
-```http
-GET /api/project-groups/{projectGroupId}/checklist-items
-```
-
-### Response 200
-
-```json
-{
-  "items": [
-    {
-      "itemId": 101,
-      "title": "첫 회의 규칙 확정",
-      "assigneeUserId": 1,
-      "assigneeNickname": "조하늘",
-      "dueLabel": "D-3",
-      "status": "TODO",
-      "createdAt": "2026-05-05T18:00:00+09:00",
-      "updatedAt": "2026-05-05T18:00:00+09:00"
-    }
-  ]
-}
-```
-
-### 추가
-
-```http
-POST /api/project-groups/{projectGroupId}/checklist-items
-```
-
-### Request
-
-```json
-{
-  "title": "GitHub 저장소 정리",
-  "assigneeUserId": 2,
-  "dueLabel": "D-7"
-}
-```
-
-### Response 201
-
-```json
-{
-  "itemId": 102,
-  "title": "GitHub 저장소 정리",
-  "assigneeUserId": 2,
-  "assigneeNickname": "박상혁",
-  "dueLabel": "D-7",
-  "status": "TODO",
-  "createdAt": "2026-05-05T18:40:00+09:00",
-  "updatedAt": "2026-05-05T18:40:00+09:00"
-}
-```
-
-### 수정
-
-```http
-PATCH /api/project-groups/{projectGroupId}/checklist-items/{itemId}
-```
-
-### Request
-
-```json
-{
-  "title": "GitHub 저장소 정리",
-  "assigneeUserId": 2,
-  "dueLabel": "D-5",
-  "status": "DOING"
-}
-```
-
-### Response 200
-
-```json
-{
-  "itemId": 102,
-  "title": "GitHub 저장소 정리",
-  "assigneeUserId": 2,
-  "assigneeNickname": "박상혁",
-  "dueLabel": "D-5",
-  "status": "DOING",
-  "updatedAt": "2026-05-05T18:45:00+09:00"
-}
-```
-
-### 삭제
-
-```http
-DELETE /api/project-groups/{projectGroupId}/checklist-items/{itemId}
-```
-
-### Response 204
-
-본문 없음.
-
-### Status Enum
-
-- `TODO`
-- `DOING`
-- `DONE`
-
-## 5. GitHub 저장소와 활동 요약
-
-### 저장소 연결/변경
-
-```http
-PUT /api/project-groups/{projectGroupId}/github/repository
-```
-
-### Request
-
-```json
-{
-  "owner": "team-po",
-  "name": "app",
-  "url": "https://github.com/team-po/app"
-}
-```
-
-### Response 200
-
-```json
-{
-  "owner": "team-po",
-  "name": "app",
-  "url": "https://github.com/team-po/app",
-  "defaultBranch": "main",
-  "visibility": "private",
-  "syncedAt": "2026-05-05T18:50:00+09:00"
-}
-```
-
-### 요약 조회
-
-```http
-GET /api/project-groups/{projectGroupId}/github/summary
-```
-
-GitHub OAuth와 저장소 연결이 없으면 `connectedRepo`는 `null`, 나머지 집계 값은 빈 배열 또는 `0`을 반환한다.
-
-### Response 200
-
-```json
-{
-  "oauthStatus": "CONNECTED",
-  "connectedRepo": {
-    "owner": "team-po",
-    "name": "app",
-    "url": "https://github.com/team-po/app",
-    "defaultBranch": "main",
-    "visibility": "private",
-    "syncedAt": "2026-05-05T18:50:00+09:00"
+  "content": {
+    "overview": "재생성된 프로젝트 개요",
+    "techStack": [],
+    "mvpPriorities": [],
+    "decisionPoints": [],
+    "milestones": []
   },
-  "openPullRequestCount": 3,
-  "weeklySummary": "이번 주는 인증 API 연결과 매칭 화면 구현이 가장 많이 진행됐습니다.",
-  "contributionDays": [
-    {
-      "date": "2026-05-01",
-      "level": 3
-    }
-  ],
-  "memberContributions": [
-    {
-      "userId": 1,
-      "commits": 18,
-      "pullRequests": 5,
-      "reviews": 3,
-      "issues": 4,
-      "level": 4
-    }
-  ],
-  "recentActivities": [
-    {
-      "activityId": "github-activity-1",
-      "type": "PULL_REQUEST",
-      "title": "team-space-view 반응형 카드 정리",
-      "actorUserId": 1,
-      "actorNickname": "조하늘",
-      "occurredAt": "2026-05-05T16:30:00+09:00"
-    }
-  ]
+  "generationType": "MANUAL",
+  "remainingRegenerationCount": 2
 }
 ```
 
-### 저장소 연결 해제
+## 아직 구현하지 않는 초안 기능
 
-```http
-DELETE /api/project-groups/{projectGroupId}/github/repository
-```
-
-### Response 204
-
-본문 없음.
-
-## 6. 팀 채팅
-
-MVP에서는 폴링 기반 HTTP API로 시작하고, 실시간성이 필요해지면 WebSocket 또는 SSE를 별도 논의한다.
-
-### 메시지 조회
-
-```http
-GET /api/project-groups/{projectGroupId}/messages?cursor=message-100&limit=30
-```
-
-### Response 200
-
-```json
-{
-  "items": [
-    {
-      "messageId": "message-101",
-      "authorUserId": 1,
-      "authorNickname": "조하늘",
-      "message": "브랜치 네이밍만 먼저 합의하면 바로 개발을 시작할 수 있어요.",
-      "createdAt": "2026-05-05T18:55:00+09:00"
-    }
-  ],
-  "nextCursor": "message-101"
-}
-```
-
-### 메시지 전송
-
-```http
-POST /api/project-groups/{projectGroupId}/messages
-```
-
-### Request
-
-```json
-{
-  "message": "오늘 회의 전에 체크리스트만 한 번 정리해둘게요."
-}
-```
-
-### Response 201
-
-```json
-{
-  "messageId": "message-102",
-  "authorUserId": 1,
-  "authorNickname": "조하늘",
-  "message": "오늘 회의 전에 체크리스트만 한 번 정리해둘게요.",
-  "createdAt": "2026-05-05T18:58:00+09:00"
-}
-```
-
-## 7. 개발 가이드
-
-프론트의 `가이드` 탭은 생성형/템플릿 성격이 강하므로 P2 이후로 분리한다.
-초기에는 `GET /project-groups/me/current`의 프로젝트 정보와 팀 규칙만으로 홈을 구성하고, 서버에서 가이드가 필요해지면 아래 API를 추가한다.
-
-```http
-GET /api/project-groups/{projectGroupId}/guide
-```
-
-### Response 200
-
-```json
-{
-  "title": "AI 개발 가이드라인 초안",
-  "sections": [
-    {
-      "sectionId": "guide-1",
-      "title": "첫 사용자 여정 고정",
-      "body": "매칭 이후 사용자가 가장 먼저 마주치는 흐름을 안정화합니다."
-    }
-  ]
-}
-```
-
-## 프론트 연결 순서 제안
-
-1. `GET /project-groups/me/current`를 먼저 구현해 real 모드 `/team`의 빈 상태를 실제 팀 홈으로 바꾼다.
-2. 팀 기본 정보 수정과 규칙 저장을 연결한다.
-3. 체크리스트 CRUD를 연결한다.
-4. GitHub 요약과 채팅은 별도 배포 단위로 연결한다.
-
+이전 초안에 있던 팀 규칙, 팀 채팅, 프로젝트 진행 단계 수정, GitHub summary 단일 조회 API는 현재 서버 계약에 없다. 화면에서는 해당 기능을 데모/비활성 상태로 유지한다.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -626,13 +626,48 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DevGuideContent'
+                $ref: '#/components/schemas/DevGuideQueryResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /team-space/{projectGroupId}/dev-guide/regenerate:
+    post:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Regenerate AI development guide for a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DevGuideRegenerateRequest'
+      responses:
+        '200':
+          description: AI development guide regenerated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevGuideRegenerateResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /team-space/{projectGroupId}/github/status:
@@ -1481,6 +1516,71 @@ components:
         contributionScore:
           type: integer
           format: int64
+    DevGuideGenerationStatus:
+      type: string
+      enum: [GENERATING, COMPLETED, FAILED]
+    DevGuideGenerationType:
+      type: string
+      enum: [INITIAL, RECOVERY, MANUAL]
+    DevGuideQueryResponse:
+      type: object
+      additionalProperties: false
+      required: [generationStatus]
+      properties:
+        generationStatus:
+          $ref: '#/components/schemas/DevGuideGenerationStatus'
+        remainingRegenerationCount:
+          type:
+            - integer
+            - 'null'
+        overview:
+          type: string
+        techStack:
+          type: array
+          minItems: 5
+          maxItems: 7
+          items:
+            $ref: '#/components/schemas/DevGuideTechStackItem'
+        mvpPriorities:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            $ref: '#/components/schemas/DevGuideMvpPriority'
+        decisionPoints:
+          type: array
+          minItems: 3
+          maxItems: 5
+          items:
+            $ref: '#/components/schemas/DevGuideDecisionPoint'
+        milestones:
+          type: array
+          minItems: 12
+          maxItems: 12
+          items:
+            $ref: '#/components/schemas/DevGuideMilestone'
+    DevGuideRegenerateRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        feedback:
+          type:
+            - string
+            - 'null'
+          maxLength: 500
+    DevGuideRegenerateResponse:
+      type: object
+      additionalProperties: false
+      required: [content, generationType]
+      properties:
+        content:
+          $ref: '#/components/schemas/DevGuideContent'
+        generationType:
+          $ref: '#/components/schemas/DevGuideGenerationType'
+        remainingRegenerationCount:
+          type:
+            - integer
+            - 'null'
     DevGuideContent:
       type: object
       additionalProperties: false
@@ -1608,6 +1708,12 @@ components:
             $ref: '#/components/schemas/ApiError'
     NotFound:
       description: Requested resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+    TooManyRequests:
+      description: The request exceeded a server-side usage limit
       content:
         application/json:
           schema:

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -60,6 +60,7 @@ import {
 	useGithubInstallationStatusQuery,
 	useGithubRepositoriesQuery,
 	useGithubRepositoryContributionsQuery,
+	useRegenerateDevGuideMutation,
 	useSetGithubRepositoriesMutation,
 	useSyncGithubPullRequestContributionsMutation,
 } from "@/features/team/hooks/use-team-space-queries";
@@ -77,6 +78,8 @@ import type {
 } from "@/lib/types/project-group";
 import type {
 	DevGuideContent,
+	DevGuideGenerationStatus,
+	DevGuideQueryResponse,
 	GithubRepository,
 	GithubRepositoryContributor,
 } from "@/lib/types/team-space";
@@ -1007,7 +1010,18 @@ function RealMemberSummaryCard({
 
 function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 	const devGuideQuery = useDevGuideQuery(projectGroup.projectGroupId);
-	const guide = devGuideQuery.data;
+	const regenerateDevGuideMutation = useRegenerateDevGuideMutation();
+	const guideResponse = devGuideQuery.data;
+	const guide = getDevGuideContent(guideResponse);
+	const generationStatus = guideResponse?.generationStatus;
+	const remainingRegenerationCount =
+		guideResponse?.remainingRegenerationCount ?? null;
+
+	const handleRegenerateDevGuide = () => {
+		regenerateDevGuideMutation.mutate({
+			projectGroupId: projectGroup.projectGroupId,
+		});
+	};
 
 	if (devGuideQuery.isLoading) {
 		return (
@@ -1085,16 +1099,53 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 	}
 
 	if (!guide) {
+		const isGenerating = generationStatus === "GENERATING";
+		const isFailed = generationStatus === "FAILED";
+
 		return (
 			<AppPanel>
 				<AppPanelHeader
-					action={<Badge variant="neutral">대기</Badge>}
-					description="아직 이 팀에 생성된 가이드라인이 없습니다."
+					action={
+						<DevGuideHeaderAction
+							generationStatus={generationStatus ?? "GENERATING"}
+							isFetching={devGuideQuery.isFetching}
+							isRegenerating={regenerateDevGuideMutation.isPending}
+							onRefresh={() => void devGuideQuery.refetch()}
+							onRegenerate={handleRegenerateDevGuide}
+							remainingRegenerationCount={remainingRegenerationCount}
+							showRegenerate={isFailed}
+						/>
+					}
+					description={
+						isFailed
+							? "가이드라인 생성에 실패했습니다."
+							: "아직 이 팀에 생성된 가이드라인이 없습니다."
+					}
 					eyebrow="Guide"
 					title="AI 개발 가이드라인"
 				/>
 				<div className="p-5">
-					<RealInlineStatus message="팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다." />
+					<div className="grid gap-3">
+						<RealInlineStatus
+							icon={
+								isGenerating ? (
+									<LoaderCircle className="size-4 shrink-0 animate-spin text-primary" />
+								) : undefined
+							}
+							message={
+								isFailed
+									? "재생성을 실행하면 서버가 팀 정보를 바탕으로 가이드라인을 다시 생성합니다."
+									: "팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다."
+							}
+						/>
+						{regenerateDevGuideMutation.error ? (
+							<RealInlineStatus
+								message={`가이드라인 재생성 실패: ${getApiErrorMessage(
+									regenerateDevGuideMutation.error,
+								)}`}
+							/>
+						) : null}
+					</div>
 				</div>
 			</AppPanel>
 		);
@@ -1104,12 +1155,29 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 		<div className="grid gap-5">
 			<AppPanel>
 				<AppPanelHeader
-					action={<Badge variant="brand">생성됨</Badge>}
-					description="팀 방향, MVP 우선순위, 결정 포인트를 한곳에 모았습니다."
+					action={
+						<DevGuideHeaderAction
+							generationStatus={generationStatus ?? "COMPLETED"}
+							isFetching={devGuideQuery.isFetching}
+							isRegenerating={regenerateDevGuideMutation.isPending}
+							onRefresh={() => void devGuideQuery.refetch()}
+							onRegenerate={handleRegenerateDevGuide}
+							remainingRegenerationCount={remainingRegenerationCount}
+							showRegenerate={generationStatus !== "GENERATING"}
+						/>
+					}
+					description={getDevGuidePanelDescription(generationStatus)}
 					eyebrow="Guide"
 					title="AI 개발 가이드라인"
 				/>
 				<div className="grid gap-4 p-5">
+					{regenerateDevGuideMutation.error ? (
+						<RealInlineStatus
+							message={`가이드라인 재생성 실패: ${getApiErrorMessage(
+								regenerateDevGuideMutation.error,
+							)}`}
+						/>
+					) : null}
 					<div className="rounded-lg border border-primary/15 bg-primary/5 p-5">
 						<p className="text-sm font-semibold text-primary">프로젝트 개요</p>
 						<p className="mt-3 text-sm leading-7 text-brand-ink">
@@ -1153,6 +1221,129 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 			<RealDevGuideMilestonePanel guide={guide} />
 		</div>
 	);
+}
+
+function getDevGuideContent(
+	response: DevGuideQueryResponse | undefined,
+): DevGuideContent | null {
+	if (
+		!response ||
+		typeof response.overview !== "string" ||
+		!Array.isArray(response.techStack) ||
+		!Array.isArray(response.mvpPriorities) ||
+		!Array.isArray(response.decisionPoints) ||
+		!Array.isArray(response.milestones)
+	) {
+		return null;
+	}
+
+	return {
+		decisionPoints: response.decisionPoints,
+		milestones: response.milestones,
+		mvpPriorities: response.mvpPriorities,
+		overview: response.overview,
+		techStack: response.techStack,
+	};
+}
+
+function getDevGuidePanelDescription(
+	generationStatus: DevGuideGenerationStatus | undefined,
+) {
+	if (generationStatus === "GENERATING") {
+		return "기존 가이드라인을 표시하는 동안 새 가이드라인을 생성 중입니다.";
+	}
+
+	if (generationStatus === "FAILED") {
+		return "최근 생성이 실패해 기존 가이드라인을 표시하고 있습니다.";
+	}
+
+	return "팀 방향, MVP 우선순위, 결정 포인트를 한곳에 모았습니다.";
+}
+
+function DevGuideHeaderAction({
+	generationStatus,
+	isFetching,
+	isRegenerating,
+	onRefresh,
+	onRegenerate,
+	remainingRegenerationCount,
+	showRegenerate,
+}: {
+	generationStatus: DevGuideGenerationStatus;
+	isFetching: boolean;
+	isRegenerating: boolean;
+	onRefresh: () => void;
+	onRegenerate: () => void;
+	remainingRegenerationCount: number | null;
+	showRegenerate: boolean;
+}) {
+	const hasNoManualRegenerationCount =
+		generationStatus === "COMPLETED" && remainingRegenerationCount === 0;
+	const isGenerating = generationStatus === "GENERATING";
+
+	return (
+		<div className="flex flex-wrap items-center justify-end gap-2">
+			<Badge variant={getDevGuideStatusBadgeVariant(generationStatus)}>
+				{getDevGuideStatusLabel(generationStatus)}
+			</Badge>
+			{remainingRegenerationCount !== null ? (
+				<Badge variant="neutral">남은 {remainingRegenerationCount}</Badge>
+			) : null}
+			{showRegenerate ? (
+				<Button
+					disabled={isRegenerating || hasNoManualRegenerationCount}
+					onClick={onRegenerate}
+					type="button"
+					variant="outline"
+				>
+					{isRegenerating ? (
+						<LoaderCircle className="animate-spin" data-icon="inline-start" />
+					) : (
+						<RefreshCw data-icon="inline-start" />
+					)}
+					재생성
+				</Button>
+			) : (
+				<Button
+					disabled={isFetching || isGenerating}
+					onClick={onRefresh}
+					type="button"
+					variant="outline"
+				>
+					{isFetching || isGenerating ? (
+						<LoaderCircle className="animate-spin" data-icon="inline-start" />
+					) : (
+						<RefreshCw data-icon="inline-start" />
+					)}
+					다시 확인
+				</Button>
+			)}
+		</div>
+	);
+}
+
+function getDevGuideStatusLabel(status: DevGuideGenerationStatus) {
+	if (status === "GENERATING") {
+		return "생성 중";
+	}
+
+	if (status === "FAILED") {
+		return "실패";
+	}
+
+	return "생성됨";
+}
+
+function getDevGuideStatusBadgeVariant(status: DevGuideGenerationStatus) {
+	if (status === "COMPLETED") {
+		return "brand";
+	}
+
+	if (status === "FAILED") {
+		return "warm";
+	}
+
+	return "neutral";
 }
 
 function isDevGuideNotFoundError(error: unknown) {

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -9,12 +9,15 @@ import {
 	getGithubInstallationStatus,
 	getGithubRepositories,
 	getGithubRepositoryContributions,
+	regenerateDevGuide,
 	setGithubRepositories,
 	syncGithubPullRequestContributions,
 } from "@/lib/api/team-space";
 import type {
+	DevGuideQueryResponse,
 	GithubAppInstallationCompleteRequest,
 	GithubRepositoryContributionRequest,
+	RegenerateDevGuideRequest,
 	SetGithubRepositoriesRequest,
 } from "@/lib/types/team-space";
 
@@ -86,6 +89,7 @@ export function useDevGuideQuery(
 				? teamSpaceQueryKeys.devGuide(projectGroupId)
 				: teamSpaceQueryKeys.all,
 		refetchInterval: (query) =>
+			isDevGuideGenerating(query.state.data) ||
 			isDevGuidePendingError(query.state.error)
 				? pendingDevGuideRefetchIntervalMs
 				: false,
@@ -95,8 +99,32 @@ export function useDevGuideQuery(
 	});
 }
 
+function isDevGuideGenerating(response: DevGuideQueryResponse | undefined) {
+	return response?.generationStatus === "GENERATING";
+}
+
 function isDevGuidePendingError(error: unknown) {
 	return error instanceof ApiError && error.code === "DEV_GUIDE_NOT_FOUND";
+}
+
+export function useRegenerateDevGuideMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: RegenerateDevGuideRequest) =>
+			regenerateDevGuide(payload),
+		onSuccess: (response, variables) => {
+			queryClient.setQueryData<DevGuideQueryResponse>(
+				teamSpaceQueryKeys.devGuide(variables.projectGroupId),
+				{
+					...response.content,
+					generationStatus: "COMPLETED",
+					remainingRegenerationCount:
+						response.remainingRegenerationCount ?? null,
+				},
+			);
+		},
+	});
 }
 
 export function useCreateGithubAppInstallationUrlMutation() {

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -29,10 +29,13 @@ import type {
 import type { MyProjectGroup } from "@/lib/types/project-group";
 import type {
 	DevGuideContent,
+	DevGuideGenerationStatus,
+	DevGuideQueryResponse,
 	GithubAppInstallationCompleteRequest,
 	GithubInstallationStatus,
 	GithubRepository,
 	GithubRepositoryContributionResponse,
+	RegenerateDevGuideResponse,
 } from "@/lib/types/team-space";
 import type {
 	EditPasswordRequest,
@@ -51,6 +54,11 @@ let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
 let activeProjectChecklists: ProjectChecklist[] = createMockProjectChecklists();
 let activeDevGuide: DevGuideContent | null =
 	createMockDevGuide(activeProjectGroup);
+let activeDevGuideGenerationStatus: DevGuideGenerationStatus | null =
+	activeDevGuide ? "COMPLETED" : null;
+let remainingDevGuideRegenerationCount: number | null = activeDevGuide
+	? 3
+	: null;
 let nextProjectChecklistId = 103;
 let githubInstallationStatus: GithubInstallationStatus =
 	createDisconnectedGithubStatus();
@@ -243,6 +251,8 @@ function resetTeamSpaceApiState() {
 		? createMockProjectChecklists()
 		: [];
 	activeDevGuide = createMockDevGuide(activeProjectGroup);
+	activeDevGuideGenerationStatus = activeDevGuide ? "COMPLETED" : null;
+	remainingDevGuideRegenerationCount = activeDevGuide ? 3 : null;
 	nextProjectChecklistId = 103;
 	githubInstallationStatus = createDisconnectedGithubStatus();
 	clearPendingGithubInstallationState();
@@ -376,6 +386,43 @@ function createMockDevGuide(
 			},
 		],
 	};
+}
+
+function createMockDevGuideQueryResponse(): DevGuideQueryResponse | null {
+	if (!activeDevGuide && !activeDevGuideGenerationStatus) {
+		return null;
+	}
+
+	return {
+		...(activeDevGuide ?? {}),
+		generationStatus: activeDevGuideGenerationStatus ?? "COMPLETED",
+		...(remainingDevGuideRegenerationCount !== null
+			? { remainingRegenerationCount: remainingDevGuideRegenerationCount }
+			: {}),
+	};
+}
+
+function createRegeneratedMockDevGuide(feedback: string | undefined) {
+	const guide = createMockDevGuide(activeProjectGroup);
+
+	if (!guide) {
+		return null;
+	}
+
+	return {
+		...guide,
+		overview: feedback
+			? `${guide.overview} 최근 재생성 요청에서 전달한 피드백도 함께 반영했습니다: ${feedback}`
+			: `${guide.overview} 최근 팀 정보를 기준으로 가이드라인을 다시 생성했습니다.`,
+	} satisfies DevGuideContent;
+}
+
+async function readOptionalJsonBody<T>(request: Request) {
+	try {
+		return (await request.json()) as T;
+	} catch {
+		return null;
+	}
 }
 
 function parseGithubRepositoryIds(value: unknown): number[] | null {
@@ -2010,7 +2057,9 @@ export const handlers = [
 				);
 			}
 
-			if (!activeDevGuide) {
+			const response = createMockDevGuideQueryResponse();
+
+			if (!response) {
 				return buildErrorResponse(
 					404,
 					"개발 가이드라인이 존재하지 않습니다.",
@@ -2018,7 +2067,84 @@ export const handlers = [
 				);
 			}
 
-			return HttpResponse.json(activeDevGuide);
+			return HttpResponse.json(response);
+		},
+	),
+
+	http.post(
+		getPath("/team-space/:projectGroupId/dev-guide/regenerate"),
+		async ({ params, request }) => {
+			const body = await readOptionalJsonBody<{ feedback?: string }>(request);
+
+			await delay(650);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			if (activeDevGuideGenerationStatus === "GENERATING") {
+				return buildErrorResponse(
+					409,
+					"개발 가이드라인이 생성 중입니다.",
+					"DEV_GUIDE_GENERATING",
+				);
+			}
+
+			if (
+				activeDevGuide &&
+				activeDevGuideGenerationStatus === "COMPLETED" &&
+				remainingDevGuideRegenerationCount === 0
+			) {
+				return buildErrorResponse(
+					429,
+					"재생성 횟수를 초과했습니다.",
+					"DEV_GUIDE_REGENERATION_LIMIT_EXCEEDED",
+				);
+			}
+
+			if (activeProjectGroup?.projectTitle.includes("서버 오류")) {
+				activeDevGuideGenerationStatus = "FAILED";
+				return buildErrorResponse(
+					500,
+					"Gemini API 응답 형식이 올바르지 않습니다.",
+					"GEMINI_INVALID_RESPONSE",
+				);
+			}
+
+			const generationType = activeDevGuide ? "MANUAL" : "RECOVERY";
+			const regeneratedGuide = createRegeneratedMockDevGuide(
+				body?.feedback?.trim() || undefined,
+			);
+
+			if (!regeneratedGuide) {
+				return buildErrorResponse(
+					404,
+					"개발 가이드라인이 존재하지 않습니다.",
+					"DEV_GUIDE_NOT_FOUND",
+				);
+			}
+
+			activeDevGuide = regeneratedGuide;
+			activeDevGuideGenerationStatus = "COMPLETED";
+			if (generationType === "MANUAL") {
+				remainingDevGuideRegenerationCount = Math.max(
+					(remainingDevGuideRegenerationCount ?? 3) - 1,
+					0,
+				);
+			} else {
+				remainingDevGuideRegenerationCount =
+					remainingDevGuideRegenerationCount ?? 3;
+			}
+
+			return HttpResponse.json({
+				content: activeDevGuide,
+				generationType,
+				remainingRegenerationCount: remainingDevGuideRegenerationCount,
+			} satisfies RegenerateDevGuideResponse);
 		},
 	),
 

--- a/src/lib/api/team-space.ts
+++ b/src/lib/api/team-space.ts
@@ -1,17 +1,36 @@
 import { apiRequest } from "@/lib/api/client";
 import type {
-	DevGuideContent,
+	DevGuideQueryResponse,
 	GithubAppInstallationCompleteRequest,
 	GithubAppInstallationUrl,
 	GithubInstallationStatus,
 	GithubRepositoryContributionRequest,
 	GithubRepositoryContributionResponse,
 	GithubRepositoryListResponse,
+	RegenerateDevGuideRequest,
+	RegenerateDevGuideResponse,
 	SetGithubRepositoriesRequest,
 } from "@/lib/types/team-space";
 
 export function getDevGuide(projectGroupId: number) {
-	return apiRequest<DevGuideContent>(`/team-space/${projectGroupId}/dev-guide`);
+	return apiRequest<DevGuideQueryResponse>(
+		`/team-space/${projectGroupId}/dev-guide`,
+	);
+}
+
+export function regenerateDevGuide({
+	feedback,
+	projectGroupId,
+}: RegenerateDevGuideRequest) {
+	const trimmedFeedback = feedback?.trim();
+
+	return apiRequest<RegenerateDevGuideResponse>(
+		`/team-space/${projectGroupId}/dev-guide/regenerate`,
+		{
+			json: trimmedFeedback ? { feedback: trimmedFeedback } : undefined,
+			method: "POST",
+		},
+	);
 }
 
 export function getGithubInstallationStatus(projectGroupId: number) {

--- a/src/lib/types/team-space.ts
+++ b/src/lib/types/team-space.ts
@@ -54,6 +54,10 @@ export interface GithubRepositoryContributionResponse {
 	repoName: string;
 }
 
+export type DevGuideGenerationStatus = "GENERATING" | "COMPLETED" | "FAILED";
+
+export type DevGuideGenerationType = "INITIAL" | "RECOVERY" | "MANUAL";
+
 export interface DevGuideTechStackItem {
 	category: string;
 	reason: string;
@@ -91,4 +95,20 @@ export interface DevGuideContent {
 	mvpPriorities: DevGuideMvpPriority[];
 	overview: string;
 	techStack: DevGuideTechStackItem[];
+}
+
+export type DevGuideQueryResponse = Partial<DevGuideContent> & {
+	generationStatus: DevGuideGenerationStatus;
+	remainingRegenerationCount?: number | null;
+};
+
+export interface RegenerateDevGuideRequest {
+	feedback?: string | null;
+	projectGroupId: number;
+}
+
+export interface RegenerateDevGuideResponse {
+	content: DevGuideContent;
+	generationType: DevGuideGenerationType;
+	remainingRegenerationCount?: number | null;
 }


### PR DESCRIPTION
Summary
- Sync the DevGuide query response with generationStatus and remainingRegenerationCount.
- Add client support for DevGuide regeneration, including React Query mutation and MSW handlers.
- Update OpenAPI and replace outdated team-space API draft notes with the current contract memo.

Validation
- pnpm tsc --noEmit
- pnpm biome lint .
- pnpm build

Closes #85