### PR TITLE
Improve UX writing across service screens

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -39,3 +39,6 @@
 ## 2026-05-11
 - GitHub OAuth flow: start authentication through the backend OAuth2 endpoint, receive the short-lived code at `/oauth/github/callback`, and exchange it through `src/lib/api/auth.ts` so email login and GitHub login share the same session storage and API client behavior
 - GitHub OAuth onboarding: request only the required development level for first-time GitHub users because the backend derives email and nickname from GitHub
+
+## 2026-06-02
+- UX writing approach: use concise Korean 해요체 for customer-facing guidance, lead with the user's next action, avoid internal planning terms in UI copy, and keep feature-critical labels such as `AI 개발 가이드` when they communicate product behavior.

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -214,13 +214,13 @@ function AppSidebar() {
 	const flowHref = hasProjectGroup ? "/team" : "/match";
 	const flowLabel = hasProjectGroup ? "팀 스페이스 열기" : "매칭 요청하기";
 	const flowDescription = isCheckingProjectGroup
-		? "내 팀 스페이스 상태를 확인한 뒤 가능한 다음 흐름을 안내합니다."
+		? "팀 상태를 확인하고 있어요."
 		: hasProjectGroup
-			? "이미 소속된 팀이 있어 팀 스페이스에서 현재 협업 흐름을 이어가세요."
-			: "프로필을 정리하고 매칭 요청을 보낸 뒤 팀 스페이스에서 바로 협업을 시작하세요.";
+			? "참여 중인 팀이 있어요. 팀 스페이스에서 이어가세요."
+			: "프로필을 확인하고 매칭을 요청해요.";
 	const matchingDisabledTitle = isCheckingProjectGroup
-		? "팀 스페이스 상태를 확인하는 중입니다."
-		: "이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다.";
+		? "팀 상태를 확인하고 있어요."
+		: "참여 중인 팀이 있어 새 매칭을 시작할 수 없어요.";
 
 	function handleLogout() {
 		clearAuthSession();
@@ -315,7 +315,7 @@ function AppSidebar() {
 									title={matchingDisabledTitle}
 								>
 									<Icon className="size-4" />
-									<span className="sr-only">{item.label} 비활성화</span>
+									<span className="sr-only">{item.label} 사용할 수 없음</span>
 								</span>
 							);
 						}
@@ -338,7 +338,7 @@ function AppSidebar() {
 				<div className="rounded-lg border border-border/70 bg-brand-warm p-4">
 					<div className="flex items-center gap-2 text-sm font-semibold text-brand-ink">
 						<LayoutDashboard className="size-4 text-primary" />
-						오늘의 흐름
+						오늘 할 일
 					</div>
 					<p className="mt-2 text-sm leading-6 text-muted-foreground">
 						{flowDescription}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -5,7 +5,7 @@ export function SiteFooter() {
 		<footer className="border-t border-border/60 bg-white/70 py-8">
 			<Container className="flex flex-col items-start justify-between gap-2 text-xs text-muted-foreground md:flex-row md:items-center">
 				<p>2026 Team-po. 사이드 프로젝트 팀 매칭 서비스.</p>
-				<p>랜덤 매칭, 팀 운영, 주간 진척 리포트를 한곳에서 관리합니다.</p>
+				<p>매칭부터 팀 운영까지 한곳에서 이어가요.</p>
 			</Container>
 		</footer>
 	);

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -28,8 +28,8 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 	const isMatchingLinkDisabled =
 		isSignedIn && (hasProjectGroup || projectGroupQuery.isLoading);
 	const matchingDisabledTitle = projectGroupQuery.isLoading
-		? "팀 스페이스 상태를 확인하는 중입니다."
-		: "이미 팀 스페이스가 있어 새 매칭을 시작할 수 없습니다.";
+		? "팀 상태를 확인하고 있어요."
+		: "참여 중인 팀이 있어 새 매칭을 시작할 수 없어요.";
 
 	useEffect(() => {
 		function syncAuthState() {
@@ -67,7 +67,7 @@ export function SiteHeader({ showMyPageLink = true }: SiteHeaderProps) {
 					<div>
 						<p className="font-display text-lg leading-none">Team-po</p>
 						<p className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
-							dev team project builder
+							team matching
 						</p>
 					</div>
 				</Link>

--- a/src/features/auth/components/auth-shell.tsx
+++ b/src/features/auth/components/auth-shell.tsx
@@ -12,17 +12,17 @@ interface AuthShellProps {
 
 const journeySteps = [
 	{
-		description: "이메일 인증과 기본 프로필을 먼저 준비합니다.",
+		description: "이메일을 확인하고 프로필을 만들어요.",
 		icon: ShieldCheck,
 		label: "계정 준비",
 	},
 	{
-		description: "역할과 프로젝트 힌트를 입력하고 팀 후보를 기다립니다.",
+		description: "역할을 고르고 매칭을 기다려요.",
 		icon: Sparkles,
 		label: "매칭 요청",
 	},
 	{
-		description: "수락 후 팀 규칙, 체크리스트, GitHub 활동을 관리합니다.",
+		description: "규칙, 체크리스트, GitHub 활동을 이어가요.",
 		icon: UsersRound,
 		label: "팀 운영",
 	},
@@ -36,7 +36,7 @@ export function AuthShell({
 }: AuthShellProps) {
 	return (
 		<AppShell
-			description="계정 준비부터 매칭 요청까지 한 흐름으로 이어집니다."
+			description="계정을 준비하면 바로 매칭을 요청할 수 있어요."
 			eyebrow="Account"
 			title="Team-po 시작하기"
 		>

--- a/src/features/auth/components/email-verification-view.tsx
+++ b/src/features/auth/components/email-verification-view.tsx
@@ -8,8 +8,8 @@ export function EmailVerificationView() {
 	return (
 		<AuthShell
 			badge="Verified"
-			description="이제 로그인하고 매칭에 사용할 프로필을 확인할 수 있습니다."
-			title="계정 준비가 끝났습니다"
+			description="이제 로그인해서 프로필을 확인할 수 있어요."
+			title="계정 준비가 끝났어요"
 		>
 			<div className="rounded-lg border border-emerald-500/25 bg-emerald-50 p-5">
 				<div className="flex items-center gap-3">
@@ -18,10 +18,10 @@ export function EmailVerificationView() {
 					</div>
 					<div>
 						<p className="font-semibold text-emerald-800">
-							이메일 인증이 완료되었습니다
+							이메일 인증을 마쳤어요
 						</p>
 						<p className="mt-1 text-sm leading-6 text-emerald-800/75">
-							로그인 후 프로필을 정리하면 매칭 카드가 더 명확해집니다.
+							프로필을 채우면 팀원이 나를 더 쉽게 이해해요.
 						</p>
 					</div>
 				</div>
@@ -31,8 +31,7 @@ export function EmailVerificationView() {
 				<div className="flex items-start gap-3">
 					<ShieldCheck className="mt-0.5 size-5 text-primary" />
 					<p className="text-sm leading-6 text-muted-foreground">
-						프로필 이미지, 닉네임, 레벨은 팀 후보가 나를 빠르게 이해하는 데
-						사용됩니다.
+						프로필 이미지, 닉네임, 레벨은 매칭 카드에 먼저 보여요.
 					</p>
 				</div>
 			</div>

--- a/src/features/auth/components/github-oauth-callback-view.tsx
+++ b/src/features/auth/components/github-oauth-callback-view.tsx
@@ -102,17 +102,17 @@ export function GithubOAuthCallbackView() {
 			description={
 				githubLinkResult
 					? githubLinkResult.linked
-						? "GitHub 계정 연동이 완료되었습니다."
-						: "GitHub 계정 연동을 완료하지 못했습니다."
+						? "GitHub 계정을 연결했어요."
+						: "GitHub 계정을 연결하지 못했어요."
 					: onboardingRequired
-						? "GitHub 계정으로 팀 매칭에 합류하기 전에 현재 개발 레벨만 선택해 주세요."
-						: "GitHub 인증 결과를 확인하고 Team-po 세션을 준비하고 있습니다."
+						? "매칭에 쓸 개발 레벨만 선택해 주세요."
+						: "GitHub 인증 결과를 확인하고 있어요."
 			}
 			title={
 				githubLinkResult
 					? githubLinkResult.linked
-						? "GitHub 연동 완료"
-						: "GitHub 연동 실패"
+						? "GitHub 연결 완료"
+						: "GitHub 연결 실패"
 					: onboardingRequired
 						? "거의 다 왔어요"
 						: "GitHub 로그인 중"
@@ -134,7 +134,7 @@ export function GithubOAuthCallbackView() {
 						)}
 						<p className="text-sm text-muted-foreground">
 							{githubLinkResult.linked
-								? "프로필에서 연결된 GitHub 계정을 확인할 수 있습니다."
+								? "내 정보에서 연결된 계정을 확인할 수 있어요."
 								: getGithubLinkErrorMessage(githubLinkResult.errorCode)}
 						</p>
 					</div>
@@ -147,7 +147,7 @@ export function GithubOAuthCallbackView() {
 			) : isCallbackInvalid ? (
 				<div className="flex flex-col gap-5">
 					<FieldError>
-						GitHub 인증 정보가 없습니다. 로그인 화면에서 다시 시작해 주세요.
+						GitHub 인증 정보가 없어요. 로그인 화면에서 다시 시작해 주세요.
 					</FieldError>
 					<Button asChild size="lg">
 						<Link to="/login">
@@ -188,7 +188,7 @@ export function GithubOAuthCallbackView() {
 								<FieldError>{levelError}</FieldError>
 							) : (
 								<FieldDescription>
-									GitHub 닉네임과 이메일로 계정이 만들어집니다.
+									GitHub 닉네임과 이메일로 계정을 만들어요.
 								</FieldDescription>
 							)}
 						</Field>
@@ -223,7 +223,7 @@ export function GithubOAuthCallbackView() {
 							<Github className="size-5 text-primary" aria-hidden="true" />
 						)}
 						<p className="text-sm text-muted-foreground">
-							인증 코드를 세션 토큰으로 교환하고 있습니다.
+							인증 정보를 확인하고 있어요.
 						</p>
 					</div>
 
@@ -261,12 +261,12 @@ export function GithubOAuthCallbackView() {
 function getGithubLinkErrorMessage(errorCode: string | null) {
 	switch (errorCode) {
 		case "GITHUB_ACCOUNT_ALREADY_LINKED":
-			return "이미 GitHub 계정이 연동되어 있습니다.";
+			return "이미 GitHub 계정이 연결되어 있어요.";
 		case "GITHUB_ACCOUNT_LINKED_TO_ANOTHER_USER":
-			return "이미 다른 사용자에게 연동된 GitHub 계정입니다.";
+			return "다른 사용자가 연결한 GitHub 계정이에요.";
 		case "INVALID_GITHUB_OAUTH_LINK_STATE":
-			return "GitHub 계정 연동 요청이 만료되었거나 올바르지 않습니다.";
+			return "GitHub 연결 요청이 만료되었거나 올바르지 않아요.";
 		default:
-			return "GitHub 계정 연동 결과를 확인할 수 없습니다.";
+			return "GitHub 연결 결과를 확인할 수 없어요.";
 	}
 }

--- a/src/features/auth/components/login-view.tsx
+++ b/src/features/auth/components/login-view.tsx
@@ -63,13 +63,13 @@ export function LoginView() {
 	return (
 		<AuthShell
 			badge="Login"
-			description="로그인 후 내 정보, 매칭 상태, 팀 스페이스를 바로 확인할 수 있습니다."
-			title="팀 프로젝트를 이어서 관리하세요"
+			description="내 프로필과 팀 상태를 확인할 수 있어요."
+			title="다시 이어서 시작해요"
 		>
 			<div className="mb-6 rounded-lg border border-primary/15 bg-primary/5 p-4">
-				<p className="text-sm font-semibold text-primary">다음 액션</p>
+				<p className="text-sm font-semibold text-primary">로그인 후 할 일</p>
 				<p className="mt-1 text-sm leading-6 text-muted-foreground">
-					내 정보 화면에서 프로필 완성도와 현재 팀 상태를 확인합니다.
+					내 정보에서 프로필과 현재 팀을 확인해요.
 				</p>
 			</div>
 
@@ -123,7 +123,7 @@ export function LoginView() {
 										password: event.target.value,
 									}));
 								}}
-								placeholder="비밀번호를 입력하세요"
+								placeholder="비밀번호 입력"
 								required
 								type="password"
 								value={form.password}
@@ -133,7 +133,7 @@ export function LoginView() {
 							<FieldError>{errors.password}</FieldError>
 						) : (
 							<FieldDescription>
-								가입할 때 설정한 비밀번호를 입력해 주세요.
+								가입할 때 만든 비밀번호를 입력해 주세요.
 							</FieldDescription>
 						)}
 					</Field>
@@ -170,8 +170,7 @@ export function LoginView() {
 
 			<div className="mt-6 grid gap-3 rounded-lg border border-border/70 bg-brand-warm p-4 text-sm">
 				<p className="text-muted-foreground">
-					처음이라면 회원가입에서 이메일 인증과 프로필 설정을 먼저 진행해
-					주세요.
+					처음이라면 이메일을 확인하고 프로필을 먼저 만들어 주세요.
 				</p>
 				<div className="flex flex-wrap items-center gap-4">
 					<Button asChild className="h-auto px-0" variant="link">

--- a/src/features/auth/components/profile-view.tsx
+++ b/src/features/auth/components/profile-view.tsx
@@ -327,8 +327,8 @@ export function ProfileView() {
 			}
 			description={
 				showMockTeamPreview
-					? "팀 후보에게 보이는 정보와 현재 팀, 계정 보안을 한 화면에서 관리합니다."
-					: "팀 후보에게 보이는 정보와 계정 보안을 한 화면에서 관리합니다."
+					? "매칭 카드에 보일 정보와 현재 팀을 확인해요."
+					: "매칭 카드에 보일 정보와 계정 보안을 확인해요."
 			}
 			eyebrow="Profile"
 			title={isSignedIn ? "내 정보" : "로그인 후 프로필을 관리하세요"}
@@ -338,10 +338,10 @@ export function ProfileView() {
 					<NoticePanel
 						description={
 							showMockTeamPreview
-								? "내 프로필과 팀 상태를 불러오고 있습니다."
-								: "내 프로필을 불러오고 있습니다."
+								? "내 프로필과 팀 상태를 불러오고 있어요."
+								: "내 프로필을 불러오고 있어요."
 						}
-						title="내 정보를 불러오는 중입니다"
+						title="내 정보를 불러오고 있어요"
 					/>
 				) : null}
 
@@ -350,10 +350,10 @@ export function ProfileView() {
 						<div className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
 							<div>
 								<h2 className="text-xl font-semibold text-brand-ink">
-									내 정보 조회에 실패했습니다
+									내 정보를 불러오지 못했어요
 								</h2>
 								<p className="mt-1 text-sm leading-6 text-muted-foreground">
-									로그인이 만료되었거나 서버 응답을 받을 수 없습니다.
+									로그인이 만료됐거나 서버 응답을 받지 못했어요.
 								</p>
 							</div>
 							<div className="flex flex-wrap gap-2">
@@ -386,10 +386,10 @@ export function ProfileView() {
 						}
 						description={
 							showMockTeamPreview
-								? "샘플 팀 스페이스는 둘러볼 수 있지만, 프로필 수정과 매칭 요청은 로그인 후 사용할 수 있습니다."
-								: "프로필 수정과 매칭 요청은 로그인 후 사용할 수 있습니다."
+								? "샘플 팀 스페이스는 둘러볼 수 있어요. 프로필 수정과 매칭 요청은 로그인 후 사용할 수 있어요."
+								: "프로필 수정과 매칭 요청은 로그인 후 사용할 수 있어요."
 						}
-						title="로그인이 필요합니다"
+						title="로그인이 필요해요"
 					/>
 				) : null}
 
@@ -447,7 +447,7 @@ export function ProfileView() {
 												소개
 											</p>
 											<p className="mt-2 text-sm leading-6 text-muted-foreground">
-												{currentUser.description || "아직 소개가 없습니다."}
+												{currentUser.description || "아직 소개가 없어요."}
 											</p>
 										</div>
 										<div className="grid gap-3 sm:grid-cols-2">
@@ -585,7 +585,7 @@ function getCurrentTeamMetric({
 	if (isLoading) {
 		return {
 			tone: "primary" as const,
-			trend: "팀 조회 중",
+			trend: "팀 확인 중",
 			value: "...",
 		};
 	}
@@ -600,7 +600,7 @@ function getCurrentTeamMetric({
 
 	return {
 		tone: "amber" as const,
-		trend: "매칭 완료 후 생성",
+		trend: "매칭 후 생성",
 		value: "0",
 	};
 }
@@ -617,7 +617,7 @@ function MockCurrentTeamPanel() {
 						</Link>
 					</Button>
 				}
-				description="참여 중인 팀과 다음 일정을 바로 확인하세요."
+				description="참여 중인 팀과 다음 일정을 확인해요."
 				eyebrow="Current team"
 				title={demoTeamSpace.name}
 			/>
@@ -663,7 +663,7 @@ function RealCurrentTeamPanel({
 						</Button>
 					}
 					description={
-						projectGroup.projectDescription ?? "프로젝트 설명이 아직 없습니다."
+						projectGroup.projectDescription ?? "프로젝트 설명이 아직 없어요."
 					}
 					eyebrow="Current team"
 					title={projectGroup.projectName}
@@ -675,7 +675,7 @@ function RealCurrentTeamPanel({
 						</p>
 						<p className="mt-2 text-sm leading-6 text-muted-foreground">
 							{projectGroup.projectDescription ??
-								"프로젝트 설명이 아직 없습니다."}
+								"프로젝트 설명이 아직 없어요."}
 						</p>
 					</div>
 					<div className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-center">
@@ -693,14 +693,14 @@ function RealCurrentTeamPanel({
 		return (
 			<AppPanel>
 				<AppPanelHeader
-					description="내 팀 스페이스 정보를 서버에서 불러오고 있습니다."
+					description="내 팀 정보를 불러오고 있어요."
 					eyebrow="Team workspace"
-					title="팀 정보를 확인하는 중입니다"
+					title="팀 정보를 확인하고 있어요"
 				/>
 				<div className="grid gap-4 p-5">
 					<div className="flex items-center gap-2 rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
 						<LoaderCircle className="size-4 animate-spin" />
-						<span>내 팀 스페이스를 불러오고 있습니다.</span>
+						<span>내 팀 스페이스를 불러오고 있어요.</span>
 					</div>
 				</div>
 			</AppPanel>
@@ -722,14 +722,14 @@ function RealCurrentTeamPanel({
 				}
 				description={
 					isLookupError
-						? "서버 응답을 확인하지 못했습니다. 잠시 후 다시 시도하세요."
-						: "아직 활성 팀 스페이스가 없으면 매칭 상태를 먼저 확인하세요."
+						? "서버 응답을 받지 못했어요. 잠시 후 다시 시도해 주세요."
+						: "아직 팀 스페이스가 없어요. 매칭 상태를 먼저 확인해 주세요."
 				}
 				eyebrow="Team workspace"
 				title={
 					isLookupError
-						? "팀 정보를 불러오지 못했습니다"
-						: "활성 팀 스페이스가 없습니다"
+						? "팀 정보를 불러오지 못했어요"
+						: "활성 팀 스페이스가 없어요"
 				}
 			/>
 			<div className="grid gap-4 p-5">
@@ -737,8 +737,8 @@ function RealCurrentTeamPanel({
 					{getApiErrorMessage(
 						error,
 						isLookupError
-							? "팀 정보를 불러오지 못했습니다."
-							: "소속된 팀 스페이스를 찾을 수 없습니다.",
+							? "팀 정보를 불러오지 못했어요."
+							: "소속된 팀 스페이스를 찾을 수 없어요.",
 					)}
 				</div>
 				<div className="flex flex-wrap gap-2">
@@ -809,7 +809,7 @@ function EditableProfilePanel({
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="팀 후보가 확인할 이름, 소개, 레벨을 수정합니다."
+				description="매칭 카드에 보일 이름, 소개, 레벨을 수정해요."
 				eyebrow="Profile editor"
 				title="내 정보 수정"
 			/>
@@ -838,7 +838,7 @@ function EditableProfilePanel({
 							{form.nickname || "닉네임"}
 						</p>
 						<p className="mt-1 text-sm leading-6 text-muted-foreground">
-							프로필 이미지는 매칭 카드와 팀원 목록에 표시됩니다.
+							프로필 이미지는 매칭 카드와 팀원 목록에 보여요.
 						</p>
 						{touched.profileImage && formErrors.profileImage ? (
 							<FieldError>{formErrors.profileImage}</FieldError>
@@ -903,7 +903,7 @@ function EditableProfilePanel({
 									description: event.target.value,
 								}));
 							}}
-							placeholder="함께 일할 팀원에게 보여줄 소개를 입력하세요."
+							placeholder="함께 일할 팀원에게 보여줄 소개 입력"
 							value={form.description}
 						/>
 						{touched.description && formErrors.description ? (
@@ -954,7 +954,7 @@ function EditableProfilePanel({
 
 				{updateCurrentUserMutation.isSuccess ? (
 					<div className="rounded-lg border border-emerald-500/25 bg-emerald-50 p-3 text-sm font-semibold text-emerald-700">
-						프로필 정보가 저장되었습니다.
+						프로필 정보를 저장했어요.
 					</div>
 				) : null}
 
@@ -989,7 +989,7 @@ function SecurityPanel({
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="변경 후에는 다시 로그인해야 합니다."
+				description="변경한 뒤에는 다시 로그인해 주세요."
 				eyebrow="Security"
 				title="비밀번호 변경"
 			/>
@@ -1077,9 +1077,9 @@ function AccountLinksPanel({
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="팀 협업에 사용할 GitHub 계정 연결 상태입니다."
+				description="팀 활동에 사용할 GitHub 계정을 확인해요."
 				eyebrow="Connected accounts"
-				title="GitHub 연동"
+				title="GitHub 연결"
 			/>
 			<div className="grid gap-4 p-5">
 				<div className="flex flex-col gap-4 rounded-lg border border-border/70 bg-brand-warm p-4 sm:flex-row sm:items-center sm:justify-between">
@@ -1099,7 +1099,7 @@ function AccountLinksPanel({
 							<p className="mt-1 truncate text-sm text-muted-foreground">
 								{currentUser.githubUsername
 									? `@${currentUser.githubUsername}`
-									: "연결된 GitHub 계정이 없습니다."}
+									: "연결된 GitHub 계정이 없어요."}
 							</p>
 						</div>
 					</div>
@@ -1119,7 +1119,7 @@ function AccountLinksPanel({
 							) : (
 								<Unlink data-icon="inline-start" />
 							)}
-							연동 해제
+							연결 해제
 						</Button>
 					) : (
 						<Button
@@ -1135,14 +1135,14 @@ function AccountLinksPanel({
 							) : (
 								<Github data-icon="inline-start" />
 							)}
-							GitHub 연동
+							GitHub 연결
 						</Button>
 					)}
 				</div>
 
 				{currentUser.isGithubLogin ? (
 					<p className="text-sm leading-6 text-muted-foreground">
-						GitHub 로그인 계정은 GitHub 연동을 해제할 수 없습니다.
+						GitHub로 로그인한 계정은 연결을 해제할 수 없어요.
 					</p>
 				) : null}
 
@@ -1152,7 +1152,7 @@ function AccountLinksPanel({
 
 				{unlinkGithubAccountMutation.isSuccess ? (
 					<p className="text-sm font-medium text-emerald-700">
-						GitHub 연동을 해제했습니다.
+						GitHub 연결을 해제했어요.
 					</p>
 				) : null}
 			</div>
@@ -1204,7 +1204,7 @@ function DangerPanel({
 	return (
 		<AppPanel className="border-rose-200">
 			<AppPanelHeader
-				description="이메일 인증번호 확인 후 계정을 삭제합니다."
+				description="이메일 인증번호를 확인한 뒤 계정을 삭제해요."
 				eyebrow="Danger zone"
 				title="회원 탈퇴"
 			/>
@@ -1215,7 +1215,7 @@ function DangerPanel({
 				<div className="flex gap-3 rounded-lg border border-rose-200 bg-rose-50 p-3 text-rose-700">
 					<ShieldAlert className="mt-0.5 size-4 shrink-0" />
 					<p className="text-sm leading-6">
-						삭제 후에는 프로필, 매칭 요청, 팀 연결 정보를 되돌릴 수 없습니다.
+						삭제 후에는 프로필, 매칭 요청, 팀 연결 정보를 되돌릴 수 없어요.
 					</p>
 				</div>
 				<FieldGroup>
@@ -1300,7 +1300,7 @@ function DangerPanel({
 								{getApiErrorMessage(validateDeleteUserEmailMutation.error)}
 							</FieldError>
 						) : isDeleteEmailVerified ? (
-							<FieldDescription>이메일 인증이 완료되었습니다.</FieldDescription>
+							<FieldDescription>이메일 인증을 마쳤어요.</FieldDescription>
 						) : isDeleteEmailSent ? (
 							<FieldDescription>
 								메일로 받은 6자리 숫자를 입력해 주세요.

--- a/src/features/auth/components/signup-view.tsx
+++ b/src/features/auth/components/signup-view.tsx
@@ -194,8 +194,8 @@ export function SignupView() {
 	return (
 		<AuthShell
 			badge="Signup"
-			description="이메일 인증과 프로필 설정을 마치면 바로 매칭 요청을 보낼 수 있습니다."
-			title="매칭에 필요한 정보를 준비하세요"
+			description="이메일을 확인하고 팀원에게 보일 프로필을 만들어요."
+			title="매칭에 쓸 정보를 준비해요"
 		>
 			<div className="mb-6 grid gap-3 sm:grid-cols-3">
 				<SetupStatus
@@ -240,7 +240,7 @@ export function SignupView() {
 							</p>
 						</div>
 						<p className="mt-1 text-sm leading-6 text-muted-foreground">
-							닉네임과 레벨은 팀 후보가 가장 먼저 확인하는 정보입니다.
+							닉네임과 레벨은 매칭 카드에 먼저 보여요.
 						</p>
 						{touched.profileImage && errors.profileImage ? (
 							<FieldError>{errors.profileImage}</FieldError>
@@ -407,14 +407,14 @@ export function SignupView() {
 								{getApiErrorMessage(validateSignupAuthNumberMutation.error)}
 							</FieldError>
 						) : isEmailVerified ? (
-							<FieldDescription>이메일 인증이 완료되었습니다.</FieldDescription>
+							<FieldDescription>이메일 인증을 마쳤어요.</FieldDescription>
 						) : isVerificationSent ? (
 							<FieldDescription>
 								메일로 받은 6자리 숫자를 입력해 주세요.
 							</FieldDescription>
 						) : !isEmailChecked ? (
 							<FieldDescription>
-								중복 확인 후 인증번호를 받을 수 있습니다.
+								중복 확인 후 인증번호를 받을 수 있어요.
 							</FieldDescription>
 						) : (
 							<FieldDescription>
@@ -509,7 +509,7 @@ export function SignupView() {
 							<FieldError>{errors.nickname}</FieldError>
 						) : (
 							<FieldDescription>
-								매칭 카드와 팀 스페이스에 표시되는 이름입니다.
+								매칭 카드와 팀 스페이스에 보여요.
 							</FieldDescription>
 						)}
 					</Field>
@@ -553,9 +553,7 @@ export function SignupView() {
 				{signupMutation.error ? (
 					<FieldError>{getApiErrorMessage(signupMutation.error)}</FieldError>
 				) : touched.authNumber && !isEmailVerified ? (
-					<FieldError>
-						이메일 인증을 완료해야 회원가입할 수 있습니다.
-					</FieldError>
+					<FieldError>이메일 인증을 완료해야 회원가입할 수 있어요.</FieldError>
 				) : null}
 
 				<Button disabled={isSubmitDisabled} size="lg" type="submit">
@@ -570,7 +568,7 @@ export function SignupView() {
 
 			<div className="mt-6 rounded-lg border border-border/70 bg-brand-warm p-4 text-sm">
 				<p className="text-muted-foreground">
-					이미 계정이 있다면 로그인하고 진행 중인 매칭을 이어가세요.
+					이미 계정이 있다면 로그인해서 매칭을 이어가세요.
 				</p>
 				<Button
 					asChild

--- a/src/features/landing/components/cta-section.tsx
+++ b/src/features/landing/components/cta-section.tsx
@@ -15,22 +15,21 @@ export function CtaSection() {
 							지금 시작하기
 						</p>
 						<h2 className="relative max-w-3xl text-balance font-display text-3xl leading-tight md:text-4xl">
-							팀원 모집 부담은 줄이고, 프로젝트를 끝까지 이어갈 루틴을
-							만들어보세요.
+							팀원 찾는 시간은 줄이고, 만드는 일에 집중해요.
 						</h2>
 						<p className="relative max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
-							랜덤 매칭, 일정 관리, 주간 리포트, 회고까지 하나의 흐름으로 연결된
-							개발자 사이드 프로젝트 플랫폼입니다.
+							매칭 요청부터 팀 스페이스까지 사이드 프로젝트 시작에 필요한 과정을
+							이어줘요.
 						</p>
 						<div className="relative flex flex-wrap gap-3">
 							<Button asChild size="lg" className="gap-2">
 								<Link to="/match">
-									매칭 대기열 등록
+									매칭 요청하기
 									<ArrowRight className="size-4" />
 								</Link>
 							</Button>
 							<Button asChild variant="outline" size="lg">
-								<Link to="/team">팀 스페이스 데모 보기</Link>
+								<Link to="/team">팀 스페이스 둘러보기</Link>
 							</Button>
 						</div>
 					</div>

--- a/src/features/landing/components/hero-section.tsx
+++ b/src/features/landing/components/hero-section.tsx
@@ -12,17 +12,17 @@ const heroFlowSteps = [
 	{
 		label: "01",
 		title: "역할 선택",
-		description: "내가 맡을 파트를 고릅니다.",
+		description: "맡고 싶은 파트를 골라요.",
 	},
 	{
 		label: "02",
 		title: "제안 확인",
-		description: "팀 후보와 프로젝트를 봅니다.",
+		description: "함께할 팀과 주제를 봐요.",
 	},
 	{
 		label: "03",
 		title: "팀 스페이스",
-		description: "수락 후 바로 협업을 시작합니다.",
+		description: "수락하면 바로 시작해요.",
 	},
 ] as const;
 
@@ -55,7 +55,7 @@ export function HeroSection() {
 						className="w-fit gap-2 px-3.5 py-1.5 text-[11px]"
 					>
 						<Sparkles className="size-3.5" />
-						Random Matching for Dev Learners
+						사이드 프로젝트 팀 매칭
 					</Badge>
 
 					<div className="space-y-4">
@@ -64,13 +64,12 @@ export function HeroSection() {
 								팀 프로젝트,
 							</span>
 							<span className="ds-title-gradient mt-1.5 block font-semibold md:mt-2">
-								모집 대신 매칭으로 시작
+								모집 글 없이 시작해요
 							</span>
 						</h1>
 						<p className="max-w-xl text-pretty text-base leading-relaxed text-muted-foreground md:text-[17px]">
-							역할과 기술 스택을 등록하면 조건이 맞는 팀원을 연결합니다. 팀이
-							만들어진 뒤에는 규칙, 체크리스트, GitHub 활동, 채팅까지 한 팀
-							스페이스에서 관리합니다.
+							역할과 기술 스택만 등록하면 함께할 팀을 찾아요. 팀이 만들어지면
+							규칙, 체크리스트, GitHub 활동을 한곳에서 이어갈 수 있어요.
 						</p>
 					</div>
 
@@ -83,7 +82,7 @@ export function HeroSection() {
 							<Link to="/match">
 								<span className="absolute inset-0 z-0 -translate-x-[150%] skew-x-[-20deg] bg-gradient-to-r from-transparent via-white/20 to-transparent motion-safe:group-hover:animate-[shine_1.5s_ease-in-out_infinite]" />
 								<span className="relative z-10 flex items-center gap-2">
-									대기열 등록 시작
+									매칭 요청하기
 									<ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
 								</span>
 							</Link>
@@ -94,7 +93,7 @@ export function HeroSection() {
 							size="lg"
 							className="transition-all hover:-translate-y-0.5 hover:bg-white/80"
 						>
-							<Link to="/team">팀 스페이스 보기</Link>
+							<Link to="/team">팀 스페이스 둘러보기</Link>
 						</Button>
 					</div>
 
@@ -127,10 +126,10 @@ export function HeroSection() {
 							</p>
 							<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 								<p className="font-display text-2xl leading-tight">
-									내 역할을 입력하면 팀 후보를 찾기 시작합니다
+									내 역할을 고르면 팀을 찾기 시작해요
 								</p>
 								<Badge variant="warm" className="w-fit">
-									응답까지 한 흐름
+									제안 응답까지
 								</Badge>
 							</div>
 						</div>

--- a/src/features/landing/components/how-it-works-section.tsx
+++ b/src/features/landing/components/how-it-works-section.tsx
@@ -12,9 +12,9 @@ export function HowItWorksSection() {
 		<section className="py-20 md:py-24">
 			<Container className="space-y-10">
 				<SectionHeading
-					label="How it works"
-					title="모집 글 없이 팀 프로젝트를 시작하는 3단계"
-					description="긴 자기소개와 선발 과정 대신, 필요한 정보만 입력하고 매칭을 기다립니다."
+					label="시작 방법"
+					title="필요한 정보만 입력하고 기다려요"
+					description="긴 자기소개와 선발 과정 없이 매칭 요청을 보낼 수 있어요."
 				/>
 
 				<div className="grid gap-4 md:grid-cols-3">

--- a/src/features/landing/components/lifecycle-section.tsx
+++ b/src/features/landing/components/lifecycle-section.tsx
@@ -9,9 +9,9 @@ export function LifecycleSection() {
 		<section className="py-20 md:py-24">
 			<Container className="space-y-10">
 				<SectionHeading
-					label="Project lifecycle"
-					title="팀 결성부터 완료까지 진행 상태를 한눈에 관리"
-					description="프로젝트가 어디까지 왔는지 분명해야 다음에 할 일이 흔들리지 않습니다."
+					label="프로젝트 상태"
+					title="어디까지 왔는지 바로 보여줘요"
+					description="현재 상태가 분명해야 다음 할 일도 빨리 정할 수 있어요."
 				/>
 
 				<Surface variant="subtle" spacing="spacious" className="space-y-4">

--- a/src/features/landing/components/system-section.tsx
+++ b/src/features/landing/components/system-section.tsx
@@ -13,9 +13,9 @@ const colorTokens = [
 ];
 
 const principles = [
-	"프로젝트 상태와 다음 액션을 같은 화면에서 확인합니다.",
-	"팀 규칙, 체크리스트, GitHub 활동을 팀 스페이스에 모읍니다.",
-	"진척 리포트와 회고 질문으로 매주 다음 행동을 정할 근거를 제공합니다.",
+	"프로젝트 상태와 다음 할 일을 같이 봐요.",
+	"팀 규칙, 체크리스트, GitHub 활동을 한곳에 모아요.",
+	"주간 리포트와 회고 질문으로 다음 행동을 정해요.",
 ];
 
 export function SystemSection() {
@@ -24,9 +24,9 @@ export function SystemSection() {
 			<Container className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
 				<Surface variant="glass" spacing="spacious" className="space-y-6">
 					<SectionHeading
-						label="Operating model"
-						title="팀이 같은 기준으로 움직이도록 운영 흐름을 정리합니다"
-						description="처음 만난 팀도 상태, 역할, 다음 액션을 같은 방식으로 확인하게 만듭니다."
+						label="운영 기준"
+						title="처음 만난 팀도 같은 기준으로 움직여요"
+						description="상태, 역할, 다음 할 일을 같은 방식으로 확인해요."
 					/>
 
 					<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -46,7 +46,7 @@ export function SystemSection() {
 
 				<Surface spacing="spacious" className="space-y-5">
 					<p className="font-display text-2xl leading-tight">
-						팀 운영은 단순하고 예측 가능하게
+						팀 운영은 단순하게
 					</p>
 					<div className="space-y-3">
 						{principles.map((item) => (
@@ -60,7 +60,7 @@ export function SystemSection() {
 						))}
 					</div>
 					<div className="pt-2">
-						<Badge variant="brand">Matching + team operations</Badge>
+						<Badge variant="brand">매칭부터 팀 운영까지</Badge>
 					</div>
 				</Surface>
 			</Container>

--- a/src/features/landing/components/value-section.tsx
+++ b/src/features/landing/components/value-section.tsx
@@ -13,9 +13,9 @@ export function ValueSection() {
 		<section className="py-20 md:py-24">
 			<Container className="space-y-10">
 				<SectionHeading
-					label="Continuous push"
-					title="매칭 이후에도 프로젝트가 멈추지 않도록 돕습니다"
-					description="주간 리포트, 회고 질문, 지연 신호를 한곳에 모아 팀이 다음 행동을 정하기 쉽게 만듭니다."
+					label="팀 운영 루틴"
+					title="매칭 뒤에도 계속 움직이게 해요"
+					description="주간 리포트, 회고 질문, 지연 신호를 모아 다음 할 일을 정하기 쉽게 해요."
 				/>
 
 				<div className="grid gap-4 md:grid-cols-3">
@@ -28,7 +28,7 @@ export function ValueSection() {
 									<div className="flex size-10 items-center justify-center rounded-xl bg-accent/15 text-accent shadow-sm">
 										<Icon className="size-5" />
 									</div>
-									<Badge variant="brand">AI Assist</Badge>
+									<Badge variant="brand">추천</Badge>
 								</div>
 								<h3 className="font-display text-xl leading-tight">
 									{feature.title}

--- a/src/features/landing/constants.ts
+++ b/src/features/landing/constants.ts
@@ -1,37 +1,36 @@
 export const heroStats = [
 	{
 		value: "3분",
-		label: "프로필 완성까지 평균 시간",
-		caption: "역할, 기술 스택, 가능 시간을 입력하면 매칭을 시작할 수 있습니다.",
+		label: "프로필 작성 시간",
+		caption: "역할, 기술 스택, 가능 시간만 입력하면 돼요.",
 	},
 	{
 		value: "5단계",
-		label: "프로젝트 라이프사이클 관리",
-		caption:
-			"팀 결성, 진행, 출시 준비, 완료, 일시 중지 상태를 한 흐름으로 관리합니다.",
+		label: "프로젝트 상태",
+		caption: "팀 결성부터 완료까지 같은 기준으로 봐요.",
 	},
 	{
 		value: "주간",
 		label: "진척 리포트",
-		caption: "이슈와 커밋을 바탕으로 이번 주 진행 상황을 정리합니다.",
+		caption: "이슈와 커밋을 바탕으로 이번 주를 정리해요.",
 	},
 ] as const;
 
 export const matchingSteps = [
 	{
-		title: "역량 카드 작성",
+		title: "프로필 작성",
 		description:
-			"기술 스택, 관심 도메인, 가능한 시간대를 입력합니다. 긴 자기소개 없이도 매칭을 시작할 수 있습니다.",
+			"기술 스택, 관심 분야, 가능한 시간을 입력해요. 긴 자기소개는 필요 없어요.",
 	},
 	{
-		title: "랜덤 매칭 대기열",
+		title: "매칭 대기",
 		description:
-			"조건이 맞는 사람들을 대기열에서 팀으로 연결합니다. 모집 글을 쓰거나 선발을 기다리는 부담을 줄입니다.",
+			"함께 일하기 좋은 팀원을 찾아요. 모집 글을 쓰거나 선발을 기다리지 않아도 돼요.",
 	},
 	{
-		title: "프로젝트 킥오프",
+		title: "프로젝트 시작",
 		description:
-			"팀이 만들어지면 목표, 일정, 역할을 템플릿으로 정리하고 첫 스프린트를 시작합니다.",
+			"팀이 만들어지면 목표, 일정, 역할을 정하고 첫 스프린트를 시작해요.",
 	},
 ] as const;
 
@@ -39,49 +38,41 @@ export const lifecycleStages = [
 	{
 		status: "forming",
 		title: "팀 형성",
-		description:
-			"팀원 조합과 프로젝트 목표를 확정하고 첫 회의에서 볼 브리프를 만듭니다.",
+		description: "팀원과 프로젝트 목표를 정하고 첫 회의 준비를 해요.",
 	},
 	{
 		status: "active",
 		title: "개발 진행",
-		description:
-			"주간 목표와 이슈를 기준으로 진행도를 측정하며 협업 리듬을 만듭니다.",
+		description: "주간 목표와 이슈를 보며 협업 리듬을 맞춰요.",
 	},
 	{
 		status: "shipping",
 		title: "출시 준비",
-		description:
-			"릴리즈 체크리스트, 버그 우선순위, 데모 리허설을 중심으로 마무리합니다.",
+		description: "릴리즈 체크리스트와 버그 우선순위를 확인해요.",
 	},
 	{
 		status: "completed",
 		title: "완료",
-		description:
-			"성과 리포트와 회고를 정리해 다음 프로젝트에서도 참고할 수 있게 남깁니다.",
+		description: "성과와 회고를 남겨 다음 프로젝트에 참고해요.",
 	},
 	{
 		status: "paused",
 		title: "일시 중지",
-		description:
-			"중단 사유와 재개 조건을 기록해 팀이 다시 시작할 수 있게 돕습니다.",
+		description: "중단 이유와 다시 시작할 조건을 남겨요.",
 	},
 ] as const;
 
 export const supportFeatures = [
 	{
-		title: "주간 진척 리포트 자동 생성",
-		description:
-			"GitHub 커밋, PR, 이슈 흐름을 바탕으로 이번 주 진척도와 다음 액션을 정리합니다.",
+		title: "주간 리포트 초안",
+		description: "커밋, PR, 이슈를 모아 이번 주 진행 상황을 보여줘요.",
 	},
 	{
-		title: "AI 회고 코파일럿",
-		description:
-			"팀 대화 로그와 이슈 타임라인을 읽어 회고 질문을 자동으로 제시하고 개선 항목을 정리해 줍니다.",
+		title: "회고 질문 추천",
+		description: "팀 대화와 이슈 기록을 바탕으로 다음 회고 질문을 제안해요.",
 	},
 	{
-		title: "프로젝트 완주 지원",
-		description:
-			"진행이 늦어지는 신호가 보이면 일정, 담당, 우선순위를 다시 정리할 수 있게 제안합니다.",
+		title: "지연 신호 확인",
+		description: "일정이 밀릴 때 담당자와 우선순위를 다시 볼 수 있게 알려줘요.",
 	},
 ] as const;

--- a/src/features/match/components/match-request-view.tsx
+++ b/src/features/match/components/match-request-view.tsx
@@ -68,19 +68,19 @@ const roleOptions: Array<{
 	value: MatchRole;
 }> = [
 	{
-		description: "인증, 데이터 저장, 배포 등 서비스 기반을 맡습니다.",
+		description: "인증, 데이터 저장, 배포를 맡아요.",
 		icon: ServerCog,
 		label: "Backend",
 		value: "BACKEND",
 	},
 	{
-		description: "화면, 상태 관리, 사용자 흐름을 구현합니다.",
+		description: "화면과 상태 관리를 맡아요.",
 		icon: Code2,
 		label: "Frontend",
 		value: "FRONTEND",
 	},
 	{
-		description: "문제 정의, UX 흐름, 화면 디자인을 정리합니다.",
+		description: "문제 정의, 사용 경험, 화면 디자인을 맡아요.",
 		icon: Palette,
 		label: "Design",
 		value: "DESIGN",
@@ -92,22 +92,22 @@ const statusMeta: Record<
 	{ description: string; label: string; tone: string }
 > = {
 	CANCELED: {
-		description: "요청이 취소되었습니다. 새 요청을 다시 보낼 수 있습니다.",
+		description: "요청을 취소했어요. 새 요청을 보낼 수 있어요.",
 		label: "취소됨",
 		tone: "border-muted-foreground/20 bg-secondary text-muted-foreground",
 	},
 	MATCHED: {
-		description: "팀 구성이 완료되었습니다. 팀 스페이스에서 협업을 시작하세요.",
+		description: "팀이 만들어졌어요. 팀 스페이스에서 시작해요.",
 		label: "매칭 완료",
 		tone: "border-emerald-500/25 bg-emerald-50 text-emerald-700",
 	},
 	MATCHING: {
-		description: "조건에 맞는 팀원을 찾고 있습니다.",
+		description: "함께할 팀원을 찾고 있어요.",
 		label: "매칭 중",
 		tone: "border-primary/25 bg-primary/10 text-primary",
 	},
 	WAITING: {
-		description: "요청이 접수되어 대기열에 올라갔습니다.",
+		description: "요청을 보냈어요. 매칭을 기다리고 있어요.",
 		label: "대기 중",
 		tone: "border-amber-500/25 bg-amber-50 text-amber-700",
 	},
@@ -242,7 +242,7 @@ export function MatchRequestView() {
 					</Button>
 				</>
 			}
-			description="역할을 고르고 프로젝트 힌트를 더하면 조건에 맞는 팀 후보를 찾습니다."
+			description="역할을 고르면 함께할 팀을 찾아요."
 			eyebrow="Matching"
 			title="매칭 요청"
 		>
@@ -264,7 +264,7 @@ export function MatchRequestView() {
 						}
 						trend={
 							isCheckingCurrentTeam
-								? "팀 소속 여부 확인 중"
+								? "팀 확인 중"
 								: hasCurrentTeam
 									? "팀 스페이스에서 진행"
 									: hasAcceptedTeam
@@ -320,12 +320,12 @@ export function MatchRequestView() {
 						}
 						trend={
 							hasCurrentTeam
-								? "이미 팀 스페이스 보유"
+								? "참여 중인 팀 있음"
 								: hasAcceptedTeam
-									? "팀으로 이동 가능"
+									? "팀 스페이스로 이동 가능"
 									: hasLiveMatch
 										? canRespondToMatch
-											? "내 응답 후 생성"
+											? "내가 수락하면 생성"
 											: "팀원 응답 대기"
 										: "수락 후 생성"
 						}
@@ -357,10 +357,10 @@ export function MatchRequestView() {
 						<div className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
 							<div>
 								<h2 className="text-xl font-semibold text-brand-ink">
-									로그인이 필요합니다
+									로그인이 필요해요
 								</h2>
 								<p className="mt-1 text-sm leading-6 text-muted-foreground">
-									매칭 요청은 로그인한 사용자만 등록할 수 있습니다.
+									로그인한 사용자만 매칭 요청을 보낼 수 있어요.
 								</p>
 							</div>
 							<Button asChild>
@@ -410,21 +410,21 @@ export function MatchRequestView() {
 											새로고침
 										</Button>
 									}
-									description="이미 팀이 있거나 진행 중인 요청이 있으면 새 신청 대신 현재 흐름을 먼저 마무리합니다."
+									description="참여 중인 팀이나 진행 중인 요청이 있으면 먼저 마무리해 주세요."
 									eyebrow="Queue status"
 									title="내 매칭 상태"
 								/>
 								<div className="grid gap-4 p-5">
 									{hasAcceptedTeam ? (
 										<StatusPanel
-											description="전원 수락이 완료되어 팀 스페이스가 열렸습니다."
+											description="모두 수락해서 팀 스페이스가 열렸어요."
 											icon={<CheckCircle2 />}
 											label="팀 소속"
 											tone="border-emerald-500/25 bg-emerald-50 text-emerald-700"
 										/>
 									) : statusQuery.isLoading ? (
 										<StatusPanel
-											description="내 요청이 대기 중인지 확인하고 있습니다."
+											description="내 요청 상태를 확인하고 있어요."
 											icon={<LoaderCircle className="animate-spin" />}
 											label="조회 중"
 										/>
@@ -436,7 +436,7 @@ export function MatchRequestView() {
 										/>
 									) : noActiveRequest || !isSignedIn ? (
 										<StatusPanel
-											description="진행 중인 매칭 요청이 없습니다."
+											description="진행 중인 매칭 요청이 없어요."
 											icon={<Square />}
 											label="요청 없음"
 										/>
@@ -501,7 +501,7 @@ export function MatchRequestView() {
 										<Badge variant="neutral">현재 요청 진행 중</Badge>
 									) : null
 								}
-								description="역할만 선택해도 대기열에 등록됩니다. 프로젝트를 제안하려면 제목, 설명, MVP를 모두 입력해 주세요."
+								description="역할만 골라도 요청할 수 있어요. 프로젝트를 제안하려면 제목, 설명, MVP를 함께 입력해 주세요."
 								eyebrow="Request"
 								title="매칭 요청 작성"
 							/>
@@ -574,7 +574,7 @@ export function MatchRequestView() {
 													projectDescription: event.target.value,
 												}))
 											}
-											placeholder="어떤 문제를 해결하고 싶은지 간단히 적어주세요."
+											placeholder="어떤 문제를 해결하고 싶은지 간단히 적어 주세요."
 											value={form.projectDescription}
 										/>
 									</Field>
@@ -628,7 +628,7 @@ export function MatchRequestView() {
 										<Send data-icon="inline-start" />
 									)}
 									{hasAcceptedTeam
-										? "이미 팀에 참여 중입니다"
+										? "이미 팀에 참여 중이에요"
 										: "매칭 요청 보내기"}
 								</Button>
 							</form>
@@ -662,22 +662,22 @@ function MatchProgressPanel({
 	const steps = [
 		{
 			description: isSignedIn
-				? "역할과 프로젝트 힌트를 보내 대기열에 들어갑니다."
-				: "로그인 후 매칭 요청을 보낼 수 있습니다.",
+				? "역할을 고르고 매칭을 기다려요."
+				: "로그인 후 매칭 요청을 보낼 수 있어요.",
 			label: "요청 작성",
 		},
 		{
 			description: hasLiveMatch
 				? needsResponse
-					? "팀 후보가 도착했습니다. 세션에서 응답을 마무리하세요."
-					: "내 응답은 완료됐고 남은 팀원의 응답을 기다립니다."
-				: "조건이 맞는 팀 후보가 생기면 이 단계로 넘어갑니다.",
-			label: "팀 후보 확인",
+					? "매칭 제안이 도착했어요. 수락할지 선택해 주세요."
+					: "내 응답은 끝났어요. 팀원의 응답을 기다려요."
+				: "함께할 팀을 찾으면 이 단계로 넘어가요.",
+			label: "제안 확인",
 		},
 		{
 			description: isTeamReady
-				? "팀 스페이스가 열렸습니다."
-				: "전원이 수락하면 협업 공간이 생성됩니다.",
+				? "팀 스페이스가 열렸어요."
+				: "모두 수락하면 팀 스페이스가 열려요.",
 			label: "팀 생성",
 		},
 	] as const;
@@ -692,7 +692,7 @@ function MatchProgressPanel({
 								? "응답 필요"
 								: hasLiveMatch
 									? "응답 완료"
-									: "매칭 흐름"}
+									: "매칭 진행"}
 						</Badge>
 						{status ? (
 							<Badge variant="neutral">{statusMeta[status].label}</Badge>
@@ -701,16 +701,16 @@ function MatchProgressPanel({
 					<h2 className="mt-3 text-xl font-semibold text-brand-ink">
 						{hasLiveMatch
 							? needsResponse
-								? "도착한 매칭 세션을 확인하고 팀 생성을 결정하세요"
-								: "내 응답은 완료됐고 팀원의 응답을 기다립니다"
-							: "요청 작성부터 팀 생성까지 한 흐름으로 진행됩니다"}
+								? "도착한 제안을 확인해 주세요"
+								: "팀원의 응답을 기다리고 있어요"
+							: "요청부터 팀 생성까지 현재 위치를 보여줘요"}
 					</h2>
 					<p className="mt-1 text-sm leading-6 text-muted-foreground">
 						{hasLiveMatch
 							? needsResponse
-								? "아래 매칭 세션에서 현재 제안의 프로젝트와 팀원 정보를 확인하고 바로 응답합니다."
-								: "매칭 세션에서 현재 제안과 팀원 응답 상태를 확인할 수 있습니다."
-							: "역할 선택, 제안 확인, 팀 스페이스 진입이 끊기지 않도록 현재 위치를 표시합니다."}
+								? "프로젝트와 팀원을 보고 수락할지 거절할지 선택해요."
+								: "현재 제안과 팀원 응답 상태를 확인할 수 있어요."
+							: "역할 선택, 제안 확인, 팀 스페이스 진입까지 이어져요."}
 					</p>
 				</div>
 
@@ -766,26 +766,23 @@ function MatchLiveHintPanel({ canRespond }: { canRespond: boolean }) {
 			<AppPanelHeader
 				action={
 					<Badge variant={canRespond ? "warm" : "neutral"}>
-						{canRespond ? "내 응답 대기" : "응답 확인됨"}
+						{canRespond ? "응답 필요" : "응답 완료"}
 					</Badge>
 				}
-				description="현재 도착한 제안은 위 매칭 세션 카드에서만 응답합니다."
+				description="도착한 제안은 위 카드에서 바로 응답할 수 있어요."
 				eyebrow="Next action"
 				title={
-					canRespond
-						? "매칭 세션에서 결정하세요"
-						: "팀원의 응답을 기다리는 중입니다"
+					canRespond ? "제안을 확인해 주세요" : "팀원의 응답을 기다리고 있어요"
 				}
 			/>
 			<div className="grid gap-3 p-5">
 				<p className="rounded-lg border border-amber-500/20 bg-white p-4 text-sm leading-6 text-amber-800">
-					프로젝트와 팀원 구성을 다시 확인한 뒤 한 번의 응답으로 다음 단계로
-					넘어갑니다.
+					프로젝트와 팀원을 확인한 뒤 수락하거나 거절해 주세요.
 				</p>
 				<Button asChild variant="outline">
 					<a href="#match-session">
 						<ArrowRight data-icon="inline-start" />
-						매칭 세션 보기
+						제안 보기
 					</a>
 				</Button>
 			</div>
@@ -808,9 +805,9 @@ function CurrentTeamMatchLockPanel({
 						</Link>
 					</Button>
 				}
-				description="팀 스페이스가 있는 사용자는 새 매칭을 시작하지 않습니다."
+				description="참여 중인 팀이 있으면 새 매칭을 시작할 수 없어요."
 				eyebrow="Matching locked"
-				title="이미 참여 중인 팀이 있습니다"
+				title="참여 중인 팀이 있어요"
 			/>
 			<div className="grid gap-4 p-5 md:grid-cols-[1fr_auto] md:items-center">
 				<div>
@@ -819,7 +816,7 @@ function CurrentTeamMatchLockPanel({
 					</p>
 					<p className="mt-2 text-sm leading-6 text-muted-foreground">
 						{projectGroup.projectDescription ??
-							"팀 스페이스에서 현재 프로젝트 진행 상황을 확인하세요."}
+							"팀 스페이스에서 현재 프로젝트 진행 상황을 확인해 주세요."}
 					</p>
 				</div>
 				<div className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-center">
@@ -839,10 +836,10 @@ function CurrentTeamCheckPanel() {
 			<div className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
 				<div>
 					<h2 className="text-xl font-semibold text-brand-ink">
-						팀 상태를 확인하고 있습니다
+						팀 상태를 확인하고 있어요
 					</h2>
 					<p className="mt-1 text-sm leading-6 text-muted-foreground">
-						이미 팀 스페이스가 있는지 확인한 뒤 매칭 요청을 열겠습니다.
+						참여 중인 팀이 있는지 확인한 뒤 매칭 요청을 열게요.
 					</p>
 				</div>
 				<LoaderCircle className="size-5 animate-spin text-primary" />
@@ -907,7 +904,7 @@ function getProjectInfoError(values: {
 	const hasCompleteProjectInfo = projectFields.every(Boolean);
 
 	if (hasAnyProjectInfo && !hasCompleteProjectInfo) {
-		return "프로젝트 정보를 입력할 때는 제목, 설명, MVP를 모두 작성해야 합니다.";
+		return "프로젝트 정보를 입력하려면 제목, 설명, MVP를 모두 작성해 주세요.";
 	}
 
 	return null;
@@ -927,14 +924,14 @@ function MatchOfferPlaceholder({
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="요청 후 팀 후보가 잡히면 여기에서 팀원과 주제를 확인합니다."
+				description="매칭이 잡히면 여기에서 팀원과 주제를 확인해요."
 				eyebrow="Offer"
 				title="매칭 제안"
 			/>
 			<div className="grid gap-4 p-5">
 				<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
-					현재 도착한 제안은 없습니다. 요청을 보내면 이 영역에서 팀 후보와 다음
-					단계를 확인하게 됩니다.
+					아직 도착한 제안이 없어요. 요청을 보내면 이곳에서 팀원과 다음 단계를
+					확인할 수 있어요.
 				</div>
 				{showPreviewAction ? (
 					<Button disabled={!canPreview} onClick={onPreview} type="button">
@@ -972,7 +969,7 @@ function MatchOfferPanel({
 								: "응답 대기"}
 					</Badge>
 				}
-				description="모두가 수락해야 팀이 생성되고, 거절하면 다시 매칭 대기열로 돌아갑니다."
+				description="모두 수락하면 팀 스페이스가 열려요. 거절하면 다시 매칭을 기다려요."
 				eyebrow="Offer arrived"
 				title="도착한 매칭 제안"
 			/>
@@ -1021,20 +1018,16 @@ function MatchOfferPanel({
 
 				{status === "accepted" ? (
 					<div className="rounded-lg border border-emerald-500/25 bg-emerald-50 p-4">
-						<p className="font-semibold text-emerald-700">
-							팀이 생성되었습니다.
-						</p>
+						<p className="font-semibold text-emerald-700">팀이 만들어졌어요.</p>
 						<p className="mt-1 text-sm leading-6 text-emerald-700/80">
-							이제 팀 스페이스에서 규칙, 체크리스트, GitHub 요약을 확인하세요.
+							이제 팀 스페이스에서 규칙, 체크리스트, GitHub 요약을 확인해요.
 						</p>
 					</div>
 				) : status === "declined" ? (
 					<div className="rounded-lg border border-destructive/25 bg-destructive/10 p-4">
-						<p className="font-semibold text-destructive">
-							제안을 거절했습니다.
-						</p>
+						<p className="font-semibold text-destructive">제안을 거절했어요.</p>
 						<p className="mt-1 text-sm leading-6 text-destructive/80">
-							재매칭이 필요하면 새 요청을 보내 더 맞는 팀을 찾아볼 수 있습니다.
+							새 요청을 보내 더 맞는 팀을 찾아볼 수 있어요.
 						</p>
 					</div>
 				) : null}
@@ -1136,9 +1129,9 @@ function MatchSessionCard({
 						</Badge>
 					</div>
 				}
-				description="팀원과 프로젝트 정보를 확인한 뒤 이 카드에서 바로 수락 또는 거절할 수 있습니다."
+				description="팀원과 프로젝트를 확인한 뒤 바로 응답할 수 있어요."
 				eyebrow="Live session"
-				title="매칭 세션"
+				title="매칭 제안"
 			/>
 			<div className="grid gap-5 p-5 lg:grid-cols-[0.9fr_1.1fr]">
 				<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
@@ -1149,7 +1142,7 @@ function MatchSessionCard({
 					{projectLoading ? (
 						<p className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
 							<LoaderCircle className="size-4 animate-spin" />
-							프로젝트 정보를 불러오는 중입니다.
+							프로젝트 정보를 불러오고 있어요.
 						</p>
 					) : project ? (
 						<div className="mt-4 grid gap-3">
@@ -1181,7 +1174,7 @@ function MatchSessionCard({
 					{membersLoading ? (
 						<p className="flex items-center gap-2 text-sm text-muted-foreground">
 							<LoaderCircle className="size-4 animate-spin" />
-							팀원 정보를 불러오는 중입니다.
+							팀원 정보를 불러오고 있어요.
 						</p>
 					) : members ? (
 						<div className="grid gap-3 md:grid-cols-2">
@@ -1203,15 +1196,15 @@ function MatchSessionCard({
 							)}
 						>
 							{canRespond
-								? "지금 할 일은 이 매칭을 수락하거나 거절하는 것입니다. 수락하면 팀 스페이스로 이동합니다."
-								: "내 응답은 완료되었습니다. 남은 팀원의 응답이 끝나면 팀 스페이스가 열립니다."}
+								? "이 매칭을 수락하거나 거절해 주세요. 수락하면 팀 스페이스로 이동해요."
+								: "내 응답은 끝났어요. 남은 팀원이 응답하면 팀 스페이스가 열려요."}
 						</div>
 						{currentMember?.isHost ? (
 							<FieldDescription>
-								프로젝트 제안자는 자동으로 수락 처리됩니다.
+								프로젝트 제안자는 자동으로 수락돼요.
 							</FieldDescription>
 						) : currentMember?.isAccepted === true ? (
-							<FieldDescription>이미 이 매칭을 수락했습니다.</FieldDescription>
+							<FieldDescription>이미 이 매칭을 수락했어요.</FieldDescription>
 						) : null}
 						<div className="flex flex-col gap-3 sm:flex-row">
 							<Button

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -221,7 +221,7 @@ function TeamTabList({
 							key={tab.id}
 							onClick={() => onSelectTab(tab.id)}
 							title={
-								disabled ? `${tab.label} 기능은 준비 중입니다.` : undefined
+								disabled ? `${tab.label} 기능은 준비 중이에요.` : undefined
 							}
 							type="button"
 						>
@@ -318,7 +318,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 
 		if (!Number.isFinite(installationId)) {
 			setGithubCompletionFeedback({
-				message: "GitHub App 설치 정보를 확인할 수 없습니다.",
+				message: "GitHub App 설치 정보를 확인할 수 없어요.",
 				tone: "error",
 			});
 			return;
@@ -347,7 +347,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 					nextSearchParams.delete("state");
 					setSearchParams(nextSearchParams, { replace: true });
 					setGithubCompletionFeedback({
-						message: "GitHub App 설치를 팀 스페이스에 연결했습니다.",
+						message: "GitHub App 설치를 팀 스페이스에 연결했어요.",
 						tone: "success",
 					});
 				},
@@ -383,7 +383,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 			onSuccess: () => {
 				setAdminPermissionFeedback({
 					message: `${member.nickname}님의 관리자 권한을 ${
-						isRevoking ? "회수했습니다" : "부여했습니다"
+						isRevoking ? "회수했어요" : "부여했어요"
 					}.`,
 					tone: "success" as const,
 				});
@@ -416,7 +416,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 					</Button>
 				</>
 			}
-			description="팀 홈, 체크리스트, GitHub 연동, 관리 기능을 한 흐름에서 확인합니다."
+			description="팀 홈, 체크리스트, GitHub 활동을 한곳에서 봐요."
 			eyebrow="Team workspace"
 			rail={
 				projectGroup ? (
@@ -438,18 +438,18 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 								<Link to="/login">로그인</Link>
 							</Button>
 						}
-						description="로그인 후 내 팀 스페이스를 불러올 수 있습니다."
+						description="로그인하면 내 팀 스페이스를 불러올 수 있어요."
 						status="인증 필요"
-						title="로그인이 필요합니다"
+						title="로그인이 필요해요"
 					/>
 				) : null}
 
 				{isSignedIn && projectGroupQuery.isLoading ? (
 					<RealTeamNotice
-						description="내 팀 스페이스를 불러오고 있습니다."
+						description="내 팀 스페이스를 불러오고 있어요."
 						icon={<LoaderCircle className="size-4 animate-spin" />}
 						status="조회 중"
-						title="팀 정보를 확인하는 중입니다"
+						title="팀 정보를 확인하고 있어요"
 					/>
 				) : null}
 
@@ -465,7 +465,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 						}
 						description={getApiErrorMessage(projectGroupQuery.error)}
 						status="팀 없음"
-						title="활성 팀 스페이스가 없습니다"
+						title="활성 팀 스페이스가 없어요"
 					/>
 				) : null}
 
@@ -485,7 +485,7 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 						/>
 						{checklistLoadErrorMessage ? (
 							<RealInlineStatus
-								message={`체크리스트를 불러오지 못했습니다. ${checklistLoadErrorMessage}`}
+								message={`체크리스트를 불러오지 못했어요. ${checklistLoadErrorMessage}`}
 							/>
 						) : null}
 						<TeamTabList
@@ -638,10 +638,10 @@ function RealTeamRail({
 						</p>
 						<p className="mt-2 text-sm leading-6 text-brand-ink">
 							{checklistErrorMessage
-								? "체크리스트를 불러오지 못했습니다."
+								? "체크리스트를 불러오지 못했어요."
 								: summary.openCount > 0
-									? `${summary.openCount}개 체크리스트가 남아 있습니다.`
-									: "열린 체크리스트가 없습니다."}
+									? `${summary.openCount}개 체크리스트가 남아 있어요.`
+									: "열린 체크리스트가 없어요."}
 						</p>
 					</div>
 					<div className="grid grid-cols-2 gap-3">
@@ -668,7 +668,7 @@ function RealTeamRail({
 						<span className="font-semibold text-brand-ink">
 							{currentMember?.groupRole ?? "MEMBER"}
 						</span>
-						입니다. 팀 설정과 멤버 권한은 관리 탭에서 확인합니다.
+						예요. 팀 설정과 멤버 권한은 관리 탭에서 확인해요.
 					</div>
 					<div className="grid gap-2">
 						<Button onClick={() => onSelectTab("checklist")} type="button">
@@ -777,9 +777,9 @@ function RealTeamFocusPanel({
 					</div>
 					<h2 className="mt-3 text-xl font-semibold text-brand-ink">
 						{isLoading
-							? "체크리스트를 불러오는 중입니다"
+							? "체크리스트를 불러오고 있어요"
 							: checklistErrorMessage
-								? "체크리스트를 불러오지 못했습니다"
+								? "체크리스트를 불러오지 못했어요"
 								: primaryTask?.title || projectGroup.projectTitle}
 					</h2>
 					<p className="mt-1 text-sm leading-6 text-muted-foreground">
@@ -789,7 +789,7 @@ function RealTeamFocusPanel({
 								? `${primaryTask.assigneeNickname ?? "미지정"} 담당 · 마감 ${
 										primaryTask.dueDate ?? "미정"
 									}`
-								: "체크리스트를 만들면 팀 홈 상단에서 바로 이어서 볼 수 있습니다."}
+								: "체크리스트를 만들면 팀 홈 상단에서 바로 볼 수 있어요."}
 					</p>
 				</div>
 
@@ -861,7 +861,7 @@ function RealOverviewPanel({
 			<AppPanel>
 				<AppPanelHeader
 					description={
-						projectGroup.projectDescription ?? "팀 설명이 아직 없습니다."
+						projectGroup.projectDescription ?? "팀 설명이 아직 없어요."
 					}
 					eyebrow="Team"
 					title={projectGroup.projectTitle}
@@ -872,7 +872,7 @@ function RealOverviewPanel({
 							MVP
 						</p>
 						<p className="mt-2 text-sm leading-6 text-brand-ink">
-							{projectGroup.projectMvp ?? "MVP가 아직 등록되지 않았습니다."}
+							{projectGroup.projectMvp ?? "MVP가 아직 등록되지 않았어요."}
 						</p>
 					</div>
 					<div className="grid gap-3">
@@ -896,7 +896,7 @@ function RealOverviewPanel({
 				<div className="grid gap-4 p-5">
 					{checklistErrorMessage ? (
 						<RealInlineStatus
-							message={`체크리스트를 불러오지 못했습니다. ${checklistErrorMessage}`}
+							message={`체크리스트를 불러오지 못했어요. ${checklistErrorMessage}`}
 						/>
 					) : null}
 					{checklistErrorMessage ? null : (
@@ -937,7 +937,7 @@ function RealOverviewPanel({
 							))}
 							{checklists.length === 0 ? (
 								<p className="rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
-									아직 등록된 체크리스트가 없습니다. 체크리스트 탭에서 첫 작업을
+									아직 등록된 체크리스트가 없어요. 체크리스트 탭에서 첫 작업을
 									만들어 주세요.
 								</p>
 							) : null}
@@ -992,8 +992,8 @@ function RealMemberSummaryCard({
 			<div className="min-w-0">
 				<p className="text-sm leading-6 text-muted-foreground">
 					{member.groupRole === "HOST"
-						? "팀 운영과 관리 권한을 담당합니다."
-						: "팀 작업과 체크리스트를 함께 수행합니다."}
+						? "팀 운영과 관리 권한을 맡고 있어요."
+						: "팀 작업과 체크리스트를 함께 진행해요."}
 				</p>
 				<div className="mt-3 flex flex-wrap gap-2">
 					<Badge variant={member.groupRole === "HOST" ? "brand" : "neutral"}>
@@ -1028,16 +1028,16 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 			<AppPanel>
 				<AppPanelHeader
 					action={<Badge variant="neutral">조회 중</Badge>}
-					description="팀 방향, MVP 우선순위, 결정 포인트를 불러오고 있습니다."
+					description="팀 방향, MVP 우선순위, 결정 포인트를 불러오고 있어요."
 					eyebrow="Guide"
-					title="AI 개발 가이드라인"
+					title="AI 개발 가이드"
 				/>
 				<div className="p-5">
 					<RealInlineStatus
 						icon={
 							<LoaderCircle className="size-4 shrink-0 animate-spin text-primary" />
 						}
-						message="가이드라인을 불러오는 중입니다."
+						message="AI 개발 가이드를 불러오고 있어요."
 					/>
 				</div>
 			</AppPanel>
@@ -1050,13 +1050,13 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 				<AppPanel>
 					<AppPanelHeader
 						action={<Badge variant="neutral">대기</Badge>}
-						description="아직 이 팀에 생성된 가이드라인이 없습니다."
+						description="아직 이 팀에 생성된 AI 개발 가이드가 없어요."
 						eyebrow="Guide"
-						title="AI 개발 가이드라인"
+						title="AI 개발 가이드"
 					/>
 					<div className="p-5">
 						<div className="grid gap-3">
-							<RealInlineStatus message="팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다. 잠시 후 자동으로 다시 확인합니다." />
+							<RealInlineStatus message="팀을 만든 직후라면 AI 개발 가이드 생성이 아직 진행 중일 수 있어요. 잠시 후 다시 확인해요." />
 							<div>
 								<Button
 									disabled={devGuideQuery.isFetching}
@@ -1085,9 +1085,9 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 			<AppPanel>
 				<AppPanelHeader
 					action={<Badge variant="neutral">오류</Badge>}
-					description="팀 가이드라인을 불러오지 못했습니다."
+					description="AI 개발 가이드를 불러오지 못했어요."
 					eyebrow="Guide"
-					title="AI 개발 가이드라인"
+					title="AI 개발 가이드"
 				/>
 				<div className="p-5">
 					<RealInlineStatus
@@ -1118,11 +1118,11 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 					}
 					description={
 						isFailed
-							? "가이드라인 생성에 실패했습니다."
-							: "아직 이 팀에 생성된 가이드라인이 없습니다."
+							? "AI 개발 가이드 생성에 실패했어요."
+							: "아직 이 팀에 생성된 AI 개발 가이드가 없어요."
 					}
 					eyebrow="Guide"
-					title="AI 개발 가이드라인"
+					title="AI 개발 가이드"
 				/>
 				<div className="p-5">
 					<div className="grid gap-3">
@@ -1134,8 +1134,8 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 							}
 							message={
 								isFailed
-									? "재생성을 실행하면 서버가 팀 정보를 바탕으로 가이드라인을 다시 생성합니다."
-									: "팀 생성 직후라면 가이드라인 생성이 아직 진행 중일 수 있습니다."
+									? "재생성을 누르면 AI가 팀 정보를 바탕으로 가이드를 다시 만들어요."
+									: "팀을 만든 직후라면 AI 개발 가이드 생성이 아직 진행 중일 수 있어요."
 							}
 						/>
 						{regenerateDevGuideMutation.error ? (
@@ -1168,7 +1168,7 @@ function RealGuidePanel({ projectGroup }: { projectGroup: MyProjectGroup }) {
 					}
 					description={getDevGuidePanelDescription(generationStatus)}
 					eyebrow="Guide"
-					title="AI 개발 가이드라인"
+					title="AI 개발 가이드"
 				/>
 				<div className="grid gap-4 p-5">
 					{regenerateDevGuideMutation.error ? (
@@ -1250,14 +1250,14 @@ function getDevGuidePanelDescription(
 	generationStatus: DevGuideGenerationStatus | undefined,
 ) {
 	if (generationStatus === "GENERATING") {
-		return "기존 가이드라인을 표시하는 동안 새 가이드라인을 생성 중입니다.";
+		return "기존 AI 개발 가이드를 보여주는 동안 새 가이드를 만들고 있어요.";
 	}
 
 	if (generationStatus === "FAILED") {
-		return "최근 생성이 실패해 기존 가이드라인을 표시하고 있습니다.";
+		return "최근 생성이 실패해서 기존 AI 개발 가이드를 보여주고 있어요.";
 	}
 
-	return "팀 방향, MVP 우선순위, 결정 포인트를 한곳에 모았습니다.";
+	return "팀 방향, MVP 우선순위, 결정 포인트를 한곳에 모았어요.";
 }
 
 function DevGuideHeaderAction({
@@ -1358,7 +1358,7 @@ function RealDevGuideTechStackPanel({ guide }: { guide: DevGuideContent }) {
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="역할별로 우선 검토할 기술 선택지를 정리했습니다."
+				description="역할별로 먼저 검토할 기술 선택지를 모았어요."
 				eyebrow="Stack"
 				title="기술 스택"
 			/>
@@ -1386,7 +1386,7 @@ function RealDevGuideDecisionPanel({ guide }: { guide: DevGuideContent }) {
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="팀이 초기에 합의해야 할 선택지를 모았습니다."
+				description="팀이 초기에 합의할 선택지를 모았어요."
 				eyebrow="Decision"
 				title="결정 포인트"
 			/>
@@ -1418,7 +1418,7 @@ function RealDevGuideMilestonePanel({ guide }: { guide: DevGuideContent }) {
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="12주 흐름을 주차별 목표와 역할 작업으로 나눴습니다."
+				description="12주 계획을 주차별 목표와 역할 작업으로 나눴어요."
 				eyebrow="Roadmap"
 				title="마일스톤"
 			/>
@@ -1478,23 +1478,22 @@ function RealRulesPanelDisabled() {
 		<AppPanel>
 			<AppPanelHeader
 				action={<Badge variant="neutral">준비 중</Badge>}
-				description="팀 규칙 저장 API가 연결되면 이 탭에서 직접 수정할 수 있습니다."
+				description="팀 규칙 저장 API가 연결되면 이 탭에서 수정할 수 있어요."
 				eyebrow="Rulebook"
 				title="팀 규칙"
 			/>
 			<div className="grid gap-4 p-5">
 				<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-5">
 					<p className="text-sm font-semibold text-brand-ink">
-						아직 서버 기능이 준비되지 않았습니다.
+						아직 서버 기능이 준비되지 않았어요.
 					</p>
 					<p className="mt-2 text-sm leading-6 text-muted-foreground">
-						규칙 조회/수정 API가 생기면 mock 프리뷰와 같은 규칙 편집 경험으로
-						연결합니다.
+						규칙 조회/수정 API가 생기면 이곳에서 바로 편집할 수 있게 연결할게요.
 					</p>
 				</div>
 				<textarea
 					className="min-h-56 rounded-lg border border-input bg-secondary/40 px-4 py-3 font-mono text-sm leading-7 text-muted-foreground"
-					defaultValue={"# 팀 규칙\n- 서버 API 연결 후 편집할 수 있습니다."}
+					defaultValue={"# 팀 규칙\n- 서버 API 연결 후 편집할 수 있어요."}
 					disabled
 				/>
 				<div className="flex justify-end">
@@ -1513,7 +1512,7 @@ function RealChatPanelDisabled() {
 		<AppPanel>
 			<AppPanelHeader
 				action={<Badge variant="neutral">준비 중</Badge>}
-				description="팀 채팅 API가 연결되기 전까지는 입력을 비활성화합니다."
+				description="팀 채팅 API가 연결되면 메시지를 보낼 수 있어요."
 				eyebrow="Messages"
 				title="팀 채팅"
 			/>
@@ -1523,7 +1522,7 @@ function RealChatPanelDisabled() {
 						<div className="max-w-[min(34rem,88%)] rounded-lg border border-border/70 bg-white p-4 shadow-crisp">
 							<p className="font-semibold text-brand-ink">Team-po</p>
 							<p className="mt-2 text-sm leading-6 text-muted-foreground">
-								채팅 기능은 API가 연결되면 활성화됩니다.
+								채팅 기능은 API가 연결되면 사용할 수 있어요.
 							</p>
 						</div>
 					</div>
@@ -1538,7 +1537,7 @@ function RealChatPanelDisabled() {
 							className="h-11 rounded-lg border border-input bg-secondary/40 px-3 text-sm font-normal text-muted-foreground outline-none"
 							disabled
 							id="real-team-message"
-							placeholder="채팅 API 연결 후 입력할 수 있습니다"
+							placeholder="채팅 API 연결 후 입력할 수 있어요"
 						/>
 					</label>
 					<div className="flex items-end">
@@ -1575,7 +1574,7 @@ function RealManagePanel({
 			<AppPanel>
 				<AppPanelHeader
 					action={<Badge variant="neutral">일부 준비 중</Badge>}
-					description="서버에 구현된 멤버 관리자 권한은 바로 조정하고, 아직 없는 팀 상태 편집은 비활성화했습니다."
+					description="멤버 관리자 권한은 바로 조정할 수 있어요. 팀 상태 편집은 준비 중이에요."
 					eyebrow="Manage"
 					title="팀 관리"
 				/>
@@ -1602,15 +1601,15 @@ function RealManagePanel({
 						</label>
 					</div>
 					<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
-						팀 이름과 상태 편집 API는 아직 연결되지 않았습니다. 기능이 생기면 이
-						관리 탭 안에서 활성화합니다.
+						팀 이름과 상태 편집 API는 아직 연결되지 않았어요. 기능이 생기면 이
+						관리 탭에서 활성화할게요.
 					</div>
 				</div>
 			</AppPanel>
 
 			<AppPanel>
 				<AppPanelHeader
-					description="방장은 팀원 관리자 권한을 부여하거나 회수할 수 있습니다."
+					description="방장은 팀원 관리자 권한을 부여하거나 회수할 수 있어요."
 					eyebrow="Members"
 					title="멤버 관리"
 				/>
@@ -1722,8 +1721,8 @@ function RealAdminPermissionStatus({
 					<p className="font-semibold text-brand-ink">관리자 권한 관리</p>
 					<p className="mt-1 text-xs text-muted-foreground">
 						{canManageAdminPermissions
-							? "팀원 카드에서 권한을 조정할 수 있습니다."
-							: "방장 계정에서만 권한을 변경할 수 있습니다."}
+							? "팀원 카드에서 권한을 조정할 수 있어요."
+							: "방장 계정에서만 권한을 변경할 수 있어요."}
 					</p>
 				</div>
 			</div>
@@ -1897,7 +1896,7 @@ function RealProjectChecklistsPanel({
 				title: "",
 			});
 			setFeedback({
-				message: "체크리스트를 추가했습니다.",
+				message: "체크리스트를 추가했어요.",
 				tone: "success",
 			});
 		} catch (error: unknown) {
@@ -1965,7 +1964,7 @@ function RealProjectChecklistsPanel({
 			});
 			handleCancelEdit(checklist.id);
 			setFeedback({
-				message: "체크리스트를 수정했습니다.",
+				message: "체크리스트를 수정했어요.",
 				tone: "success",
 			});
 		} catch (error: unknown) {
@@ -1992,7 +1991,7 @@ function RealProjectChecklistsPanel({
 				title: checklist.title,
 			});
 			setFeedback({
-				message: "체크리스트 상태를 변경했습니다.",
+				message: "체크리스트 상태를 바꿨어요.",
 				tone: "success",
 			});
 		} catch (error: unknown) {
@@ -2011,7 +2010,7 @@ function RealProjectChecklistsPanel({
 				projectGroupId: projectGroup.projectGroupId,
 			});
 			setFeedback({
-				message: "체크리스트를 삭제했습니다.",
+				message: "체크리스트를 삭제했어요.",
 				tone: "success",
 			});
 		} catch (error: unknown) {
@@ -2030,7 +2029,7 @@ function RealProjectChecklistsPanel({
 				projectGroupId: projectGroup.projectGroupId,
 			});
 			setFeedback({
-				message: "AI 조언을 생성했습니다.",
+				message: "AI 조언을 만들었어요.",
 				tone: "success",
 			});
 		} catch (error: unknown) {
@@ -2045,7 +2044,7 @@ function RealProjectChecklistsPanel({
 		<AppPanel>
 			<AppPanelHeader
 				action={<Badge variant="neutral">{checklists.length} tasks</Badge>}
-				description="팀 작업을 등록하고 담당자, 마감일, AI 조언을 관리합니다."
+				description="팀 작업, 담당자, 마감일, AI 조언을 함께 관리해요."
 				eyebrow="Checklist"
 				title="프로젝트 체크리스트"
 			/>
@@ -2158,7 +2157,7 @@ function RealProjectChecklistsPanel({
 				{checklistQuery.isLoading ? (
 					<RealInlineStatus
 						icon={<LoaderCircle className="size-4 animate-spin" />}
-						message="체크리스트를 불러오고 있습니다."
+						message="체크리스트를 불러오고 있어요."
 					/>
 				) : null}
 
@@ -2302,7 +2301,7 @@ function RealProjectChecklistsPanel({
 												</p>
 											</div>
 											<p className="mt-2 text-sm leading-6 text-muted-foreground">
-												{checklist.description ?? "설명이 없습니다."}
+												{checklist.description ?? "설명이 없어요."}
 											</p>
 											<div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
 												<span>
@@ -2425,7 +2424,7 @@ function RealChecklistAdvice({
 			<div className="mt-3 grid gap-3 md:grid-cols-3">
 				<RealAdviceList
 					items={checklist.aiAdvice.recommendedFlow}
-					title="추천 흐름"
+					title="추천 순서"
 				/>
 				<RealAdviceList
 					items={checklist.aiAdvice.considerations}
@@ -2604,7 +2603,7 @@ function RealGithubInstallationPanel({
 				},
 				onSuccess: () => {
 					setFeedback({
-						message: "GitHub 저장소 연결을 저장했습니다.",
+						message: "GitHub 저장소 연결을 저장했어요.",
 						tone: "success",
 					});
 				},
@@ -2620,9 +2619,9 @@ function RealGithubInstallationPanel({
 						{githubStatus?.connected ? "connected" : "not connected"}
 					</Badge>
 				}
-				description="Organization 연결 상태와 저장소 집계 준비 상태를 확인합니다."
+				description="GitHub 조직과 저장소 연결 상태를 확인해요."
 				eyebrow="GitHub App"
-				title="Organization 연동"
+				title="GitHub 조직 연결"
 			/>
 			<div className="grid gap-5 p-5">
 				<RealActionFeedback feedback={completionFeedback ?? feedback} />
@@ -2632,8 +2631,8 @@ function RealGithubInstallationPanel({
 						icon={<LoaderCircle className="size-4 animate-spin" />}
 						message={
 							isCompletingInstallation
-								? "GitHub App 설치를 완료하고 있습니다."
-								: "GitHub 연동 상태를 불러오고 있습니다."
+								? "GitHub App 설치를 마무리하고 있어요."
+								: "GitHub 연결 상태를 불러오고 있어요."
 						}
 					/>
 				) : null}
@@ -2671,8 +2670,8 @@ function RealGithubInstallationPanel({
 						</p>
 						<p className="mt-1 text-sm leading-6 text-muted-foreground">
 							{githubStatus?.connected
-								? "Organization이 팀 스페이스에 연결되어 있습니다."
-								: "호스트가 GitHub 설치 흐름을 시작할 수 있습니다."}
+								? "GitHub 조직이 팀 스페이스에 연결되어 있어요."
+								: "호스트가 GitHub App 설치를 시작할 수 있어요."}
 						</p>
 					</div>
 					<Button
@@ -2698,7 +2697,7 @@ function RealGithubInstallationPanel({
 										연결된 저장소
 									</p>
 									<p className="mt-1 text-sm leading-6 text-muted-foreground">
-										팀 스페이스에 등록된 GitHub 저장소입니다.
+										팀 스페이스에 등록된 GitHub 저장소예요.
 									</p>
 								</div>
 								<Badge
@@ -2714,7 +2713,7 @@ function RealGithubInstallationPanel({
 								{githubRepositoriesQuery.isLoading ? (
 									<RealInlineStatus
 										icon={<LoaderCircle className="size-4 animate-spin" />}
-										message="등록된 저장소를 불러오고 있습니다."
+										message="등록된 저장소를 불러오고 있어요."
 									/>
 								) : null}
 
@@ -2728,7 +2727,7 @@ function RealGithubInstallationPanel({
 								connectedRepositories.length === 0 ? (
 									<div className="rounded-lg border border-dashed border-border bg-white/65 p-4">
 										<p className="text-sm leading-6 text-muted-foreground">
-											아직 팀 스페이스에 등록된 GitHub 저장소가 없습니다.
+											아직 팀 스페이스에 등록된 GitHub 저장소가 없어요.
 										</p>
 									</div>
 								) : null}
@@ -2751,7 +2750,8 @@ function RealGithubInstallationPanel({
 										저장소 설정
 									</p>
 									<p className="mt-1 text-sm leading-6 text-muted-foreground">
-										GitHub App이 접근 가능한 저장소 중 집계할 대상을 선택합니다.
+										GitHub App이 접근할 수 있는 저장소 중 집계할 대상을
+										선택해요.
 									</p>
 								</div>
 								<Badge
@@ -2766,7 +2766,7 @@ function RealGithubInstallationPanel({
 									{availableGithubRepositoriesQuery.isLoading ? (
 										<RealInlineStatus
 											icon={<LoaderCircle className="size-4 animate-spin" />}
-											message="선택 가능한 저장소를 불러오고 있습니다."
+											message="선택 가능한 저장소를 불러오고 있어요."
 										/>
 									) : null}
 
@@ -2782,7 +2782,7 @@ function RealGithubInstallationPanel({
 									availableRepositories.length === 0 ? (
 										<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4">
 											<p className="text-sm leading-6 text-muted-foreground">
-												GitHub App이 접근 가능한 저장소가 없습니다.
+												GitHub App이 접근할 수 있는 저장소가 없어요.
 											</p>
 										</div>
 									) : null}
@@ -2834,7 +2834,7 @@ function RealGithubInstallationPanel({
 							) : (
 								<div className="mt-4 rounded-lg border border-dashed border-border bg-secondary/30 p-4">
 									<p className="text-sm leading-6 text-muted-foreground">
-										호스트만 GitHub 저장소 설정을 변경할 수 있습니다.
+										호스트만 GitHub 저장소 설정을 변경할 수 있어요.
 									</p>
 								</div>
 							)}
@@ -2857,15 +2857,15 @@ function GithubOrganizationPolicyNotice() {
 					<div className="min-w-0">
 						<div className="flex flex-wrap items-center gap-2">
 							<p className="text-sm font-semibold text-brand-ink">
-								저장소 연결 전 TeamPo 접근 권한을 확인하세요
+								저장소 연결 전 TeamPo 접근 권한을 확인해 주세요
 							</p>
 							<Badge variant="warm">permission check</Badge>
 						</div>
 						<p className="mt-2 text-sm leading-6 text-amber-900/80">
 							GitHub App 설치나 선택 저장소 권한이 제한되어 있으면 TeamPo가
-							저장소와 PR 정보를 가져오지 못할 수 있습니다. Organization owner가
+							저장소와 PR 정보를 가져오지 못할 수 있어요. Organization owner가
 							TeamPo GitHub App이 설치되어 있는지, 선택한 저장소와 Pull requests
-							읽기 권한이 열려 있는지 확인하세요.
+							읽기 권한이 열려 있는지 확인해 주세요.
 						</p>
 					</div>
 				</div>
@@ -2999,7 +2999,7 @@ function RealGithubRepositoryContributionCard({
 				<RealInlineStatus
 					className="mt-4"
 					icon={<LoaderCircle className="size-4 animate-spin" />}
-					message="저장소 기여도를 불러오고 있습니다."
+					message="저장소 기여도를 불러오고 있어요."
 				/>
 			) : null}
 
@@ -3052,7 +3052,7 @@ function RealGithubRepositoryContributionCard({
 					) : (
 						<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4">
 							<p className="text-sm leading-6 text-muted-foreground">
-								아직 동기화된 PR 기여도가 없습니다.
+								아직 동기화된 PR 기여도가 없어요.
 							</p>
 						</div>
 					)}
@@ -3321,8 +3321,8 @@ function MockTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 
 				{!isSignedIn ? (
 					<div className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-sm leading-6 text-primary">
-						지금은 샘플 팀 스페이스를 둘러보는 프리뷰입니다. 로그인하면 내 팀
-						기준으로 규칙, 체크리스트, 채팅을 이어서 관리할 수 있습니다.
+						지금은 샘플 팀 스페이스를 둘러보고 있어요. 로그인하면 내 팀 기준으로
+						규칙, 체크리스트, 채팅을 이어서 관리할 수 있어요.
 					</div>
 				) : null}
 
@@ -3401,12 +3401,12 @@ function TeamFocusPanel({
 					<h2 className="mt-3 text-xl font-semibold text-brand-ink">
 						{primaryTask
 							? primaryTask.title
-							: "새 작업을 추가해 다음 액션을 정하세요"}
+							: "새 작업을 추가해 다음 할 일을 정해요"}
 					</h2>
 					<p className="mt-1 text-sm leading-6 text-muted-foreground">
 						{primaryTask
 							? `${primaryTask.assignee} 담당 · ${primaryTask.dueLabel} · ${checklistLabels[primaryTask.status]}`
-							: "체크리스트에서 첫 작업을 만들면 팀 홈 상단에 바로 강조됩니다."}
+							: "체크리스트에서 첫 작업을 만들면 팀 홈 상단에 바로 보여요."}
 					</p>
 				</div>
 
@@ -3543,7 +3543,7 @@ function TeamRail({
 						<span className="font-semibold text-brand-ink">
 							{isGithubLinked ? "완료" : "설정 필요"}
 						</span>
-						상태입니다. 팀 설정과 멤버 관리는 관리 탭으로 이동했습니다.
+						상태예요. 팀 설정과 멤버 관리는 관리 탭에서 확인해요.
 					</div>
 					<div className="grid gap-2">
 						<Button onClick={() => onSelectTab("checklist")} type="button">
@@ -3577,7 +3577,7 @@ function MockManagePanel({
 			<AppPanel>
 				<AppPanelHeader
 					action={<Badge variant="warm">local preview</Badge>}
-					description="팀 설정 화면의 배치를 미리 보는 영역입니다. 서버에 없는 기능은 실서비스에서 비활성화됩니다."
+					description="팀 설정 화면을 미리 확인해요. 아직 연결되지 않은 기능은 준비 중이에요."
 					eyebrow="Manage"
 					title="팀 관리"
 				/>
@@ -3611,14 +3611,14 @@ function MockManagePanel({
 						</label>
 					</div>
 					<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4 text-sm leading-6 text-muted-foreground">
-						팀 운영 상태 변경은 서버 API가 연결되면 활성화됩니다.
+						팀 운영 상태 변경은 서버 API가 연결되면 사용할 수 있어요.
 					</div>
 				</div>
 			</AppPanel>
 
 			<AppPanel>
 				<AppPanelHeader
-					description="현재 데모 멤버 구성을 확인합니다. 초대/내보내기는 아직 비활성화 상태입니다."
+					description="현재 샘플 멤버 구성을 확인해요. 초대와 내보내기는 준비 중이에요."
 					eyebrow="Members"
 					title="멤버 관리"
 				/>
@@ -3661,7 +3661,7 @@ function OverviewPanel({ checklist }: OverviewPanelProps) {
 		<div className="grid gap-5 xl:grid-cols-[1fr_0.86fr]">
 			<AppPanel>
 				<AppPanelHeader
-					description="프로젝트 의도, MVP, 팀원 역할을 한 번에 확인합니다."
+					description="프로젝트 의도, MVP, 팀원 역할을 한 번에 확인해요."
 					eyebrow="Project"
 					title={demoTeamSpace.projectTitle}
 				/>
@@ -3715,7 +3715,7 @@ function OverviewPanel({ checklist }: OverviewPanelProps) {
 
 			<AppPanel>
 				<AppPanelHeader
-					description="오늘 바로 결정하면 좋은 항목입니다."
+					description="오늘 바로 결정하면 좋은 항목이에요."
 					eyebrow="Today"
 					title="오늘의 진행"
 				/>
@@ -3762,7 +3762,7 @@ function GuidePanel() {
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="주제와 MVP를 바탕으로 팀이 먼저 논의할 방향을 정리합니다."
+				description="주제와 MVP를 바탕으로 팀이 먼저 논의할 방향을 정리해요."
 				eyebrow="Guide"
 				title={demoTeamSpace.guideline.title}
 			/>
@@ -3835,7 +3835,7 @@ function RulesPanel({ onRulesChange, rulesMarkdown }: RulesPanelProps) {
 						</Button>
 					)
 				}
-				description="함께 지킬 협업 규칙을 정리하고 필요할 때 수정합니다."
+				description="함께 지킬 협업 규칙을 정리하고 필요할 때 수정해요."
 				eyebrow="Rulebook"
 				title="팀 규칙"
 			/>
@@ -3855,7 +3855,7 @@ function RulesPanel({ onRulesChange, rulesMarkdown }: RulesPanelProps) {
 							value={draftRules}
 						/>
 						<p className="text-sm text-muted-foreground">
-							저장하면 팀 규칙에 바로 반영됩니다.
+							저장하면 팀 규칙에 바로 반영돼요.
 						</p>
 					</div>
 				) : (
@@ -3930,7 +3930,7 @@ function ChecklistPanel({
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="작업을 추가하고 상태, 담당자, 기한을 함께 관리합니다."
+				description="작업, 상태, 담당자, 기한을 함께 관리해요."
 				eyebrow="Tasks"
 				title="체크리스트"
 			/>
@@ -4131,7 +4131,7 @@ function GithubPanel({
 		{
 			description: isProjectGroupGithubLinked ? "기여도 집계 가능" : "연동 전",
 			icon: ShieldCheck,
-			label: "TeamSpace",
+			label: "팀 스페이스",
 			ready: isProjectGroupGithubLinked,
 		},
 	];
@@ -4174,9 +4174,9 @@ function GithubPanel({
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="팀 관리자가 Organization에 TeamPo GitHub App을 설치하고 저장소를 선택하면 기여도 집계가 시작됩니다."
+				description="팀 관리자가 GitHub 조직에 TeamPo App을 설치하고 저장소를 선택하면 기여도 집계가 시작돼요."
 				eyebrow="GitHub App"
-				title="Organization 연동"
+				title="GitHub 조직 연결"
 			/>
 			<div className="grid gap-5 p-5">
 				<div className="grid gap-3 md:grid-cols-4">
@@ -4223,10 +4223,10 @@ function GithubPanel({
 						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 							<div>
 								<p className="text-sm font-semibold text-brand-ink">
-									Organization 준비
+									GitHub 조직 준비
 								</p>
 								<p className="mt-1 text-sm leading-6 text-muted-foreground">
-									TeamSpace에 연결할 GitHub Organization이 필요합니다.
+									팀 스페이스에 연결할 GitHub 조직이 필요해요.
 								</p>
 							</div>
 							<Badge variant={organization ? "brand" : "neutral"}>
@@ -4251,13 +4251,13 @@ function GithubPanel({
 										target="_blank"
 									>
 										<Building2 data-icon="inline-start" />
-										Organization 생성
+										GitHub 조직 만들기
 										<ExternalLink data-icon="inline-end" />
 									</a>
 								</Button>
 								<Button onClick={handleInstallationComplete} type="button">
 									<Github data-icon="inline-start" />
-									GitHub Organization 연결하기
+									GitHub 조직 연결하기
 								</Button>
 							</div>
 						)}
@@ -4270,7 +4270,7 @@ function GithubPanel({
 									TeamPo GitHub App
 								</p>
 								<p className="mt-1 text-sm leading-6 text-muted-foreground">
-									읽기 전용 권한으로 설치하고 필요한 저장소만 선택합니다.
+									읽기 전용 권한으로 설치하고 필요한 저장소만 선택해요.
 								</p>
 							</div>
 							<Badge variant={isGitHubAppInstalled ? "brand" : "neutral"}>
@@ -4328,8 +4328,8 @@ function GithubPanel({
 									저장소 선택
 								</p>
 								<p className="mt-1 text-sm leading-6 text-muted-foreground">
-									설치된 GitHub App이 접근 가능한 저장소 중 팀 활동을 집계할
-									저장소를 선택합니다.
+									설치된 GitHub App이 접근할 수 있는 저장소 중 팀 활동을 집계할
+									저장소를 선택해요.
 								</p>
 							</div>
 							<Badge variant={canSelectRepositories ? "brand" : "neutral"}>
@@ -4351,7 +4351,7 @@ function GithubPanel({
 							<p className="text-xs leading-5 text-muted-foreground">
 								{selectedRepoIds.length > 0
 									? `${selectedRepoIds.length}개 저장소 선택됨`
-									: "최소 1개 저장소를 선택해야 합니다."}
+									: "최소 1개 저장소를 선택해 주세요."}
 							</p>
 							<Button
 								disabled={!canSaveRepositoryConnection}
@@ -4368,11 +4368,10 @@ function GithubPanel({
 						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 							<div>
 								<p className="text-sm font-semibold text-brand-ink">
-									TeamSpace 연동 상태
+									팀 스페이스 연결 상태
 								</p>
 								<p className="mt-1 text-sm leading-6 text-muted-foreground">
-									프로젝트 그룹 기준으로 GitHub Organization 연동 여부를
-									확인합니다.
+									프로젝트 그룹 기준으로 GitHub 조직 연결 여부를 확인해요.
 								</p>
 							</div>
 							<Badge variant={isProjectGroupGithubLinked ? "brand" : "neutral"}>
@@ -4406,7 +4405,7 @@ function GithubPanel({
 							<div className="mt-4 rounded-lg border border-dashed border-border bg-white/65 p-4">
 								<p className="text-sm leading-6 text-muted-foreground">
 									GitHub App 설치와 저장소 선택이 끝나면 이 영역에서 연결된
-									저장소를 확인합니다.
+									저장소를 확인할 수 있어요.
 								</p>
 							</div>
 						)}
@@ -4421,7 +4420,7 @@ function GithubPanel({
 									GitHub 활동 히트맵
 								</p>
 								<p className="mt-1 text-sm text-muted-foreground">
-									기여량이 많을수록 색과 밀도가 진해집니다.
+									기여량이 많을수록 색과 밀도가 진해져요.
 								</p>
 							</div>
 							<Badge variant={isProjectGroupGithubLinked ? "brand" : "neutral"}>
@@ -4450,7 +4449,7 @@ function GithubPanel({
 						<p className="mt-4 text-sm leading-6 text-muted-foreground">
 							{isProjectGroupGithubLinked
 								? demoTeamSpace.githubSummary.weeklySummary
-								: "저장소를 연결하면 커밋, PR, 리뷰, 이슈 기준으로 팀원별 기여 흐름을 집계합니다."}
+								: "저장소를 연결하면 커밋, PR, 리뷰, 이슈 기준으로 팀원별 기여를 집계해요."}
 						</p>
 					</div>
 					<div className="rounded-lg border border-border/70 bg-brand-warm p-5">
@@ -4487,7 +4486,7 @@ function GithubPanel({
 											<p className="mt-2 text-xs leading-5 text-muted-foreground">
 												{isProjectGroupGithubLinked
 													? `커밋 ${contribution.commits} · PR ${contribution.prs} · 리뷰 ${contribution.reviews} · 이슈 ${contribution.issues}`
-													: "저장소 연결 후 기여 수치가 표시됩니다."}
+													: "저장소 연결 후 기여 수치가 표시돼요."}
 											</p>
 										</div>
 									);
@@ -4519,7 +4518,7 @@ function GithubPanel({
 						</div>
 					) : (
 						<p className="mt-4 rounded-lg border border-dashed border-border bg-white/65 p-4 text-sm leading-6 text-muted-foreground">
-							연동된 저장소 활동이 아직 없습니다.
+							연동된 저장소 활동이 아직 없어요.
 						</p>
 					)}
 				</div>
@@ -4611,7 +4610,7 @@ function ChatPanel({ messages, onSend }: ChatPanelProps) {
 	return (
 		<AppPanel>
 			<AppPanelHeader
-				description="팀원이 빠르게 공유할 내용을 남기는 공간입니다."
+				description="팀원이 빠르게 공유할 내용을 남기는 공간이에요."
 				eyebrow="Messages"
 				title="팀 채팅"
 			/>
@@ -4676,7 +4675,7 @@ function ChatPanel({ messages, onSend }: ChatPanelProps) {
 							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
 							id="team-message"
 							onChange={(event) => setDraftMessage(event.target.value)}
-							placeholder="팀에게 공유할 내용을 입력하세요"
+							placeholder="팀에게 공유할 내용 입력"
 							value={draftMessage}
 						/>
 					</label>
@@ -4738,7 +4737,7 @@ function parseRulesMarkdown(markdown: string) {
 		.map((line) => line.replace(/^-\s*/, ""));
 
 	return {
-		items: items.length ? items : ["아직 등록된 규칙이 없습니다."],
+		items: items.length ? items : ["아직 등록된 규칙이 없어요."],
 		title,
 	};
 }

--- a/src/features/team/lib/demo-team-space.ts
+++ b/src/features/team/lib/demo-team-space.ts
@@ -6,7 +6,7 @@ const demoMembers = [
 		id: "member-1",
 		level: 4,
 		name: "조하늘",
-		responsibility: "React 화면 흐름과 상태 관리",
+		responsibility: "React 화면과 상태 관리",
 		role: "FE",
 		temperature: 41.8,
 	},
@@ -35,12 +35,12 @@ export const demoMatchOffer: MatchOffer = {
 	expiresAt: "2026-05-03T11:20:00+09:00",
 	id: "offer-team-po-001",
 	projectDescription:
-		"개발자 사이드 프로젝트를 랜덤 팀으로 시작하고, 팀 결성 이후에는 규칙, 체크리스트, GitHub 요약을 한 공간에서 운영하는 서비스입니다.",
+		"개발자 사이드 프로젝트를 랜덤 팀으로 시작하고, 팀이 만들어진 뒤에는 규칙, 체크리스트, GitHub 요약을 한 공간에서 운영해요.",
 	projectMvp:
-		"회원가입, 매칭 요청, 제안 수락/거절, 팀 스페이스, 협업 규칙 템플릿, 체크리스트를 첫 배포 범위로 둡니다.",
+		"회원가입, 매칭 요청, 제안 수락/거절, 팀 스페이스, 협업 규칙 템플릿, 체크리스트를 첫 배포 범위로 잡아요.",
 	projectTitle: "Team-po 협업 온보딩",
 	recommendedNextStep:
-		"전원이 제안을 수락하면 팀 스페이스가 열리고, 첫 단계로 팀 규칙 템플릿을 함께 확정합니다.",
+		"모두 제안을 수락하면 팀 스페이스가 열려요. 첫 단계로 팀 규칙 템플릿을 함께 확정해요.",
 	status: "offered",
 	teamNamePreview: "Blue Sprint",
 	teammates: demoMembers,
@@ -189,22 +189,22 @@ export const demoTeamSpace: TeamSpace = {
 			},
 		],
 		weeklySummary:
-			"이번 주는 FE 화면 구조와 인증 API 연결이 가장 많이 진행됐습니다. 저장소를 연결하면 커밋, PR, 리뷰, 이슈 기준으로 팀원별 기여 흐름을 자동 집계할 예정입니다.",
+			"이번 주는 FE 화면 구조와 인증 API 연결이 가장 많이 진행됐어요. 저장소를 연결하면 커밋, PR, 리뷰, 이슈 기준으로 팀원별 기여를 자동 집계할 예정이에요.",
 	},
 	guideline: {
 		sections: [
 			{
-				body: "초기 스프린트는 매칭 이후 사용자가 가장 먼저 마주치는 흐름을 안정화합니다. 제안 확인, 수락/거절, 팀 스페이스 진입을 하나의 여정으로 검증하세요.",
+				body: "초기 스프린트는 매칭 이후 사용자가 가장 먼저 마주치는 과정을 안정화해요. 제안 확인, 수락/거절, 팀 스페이스 진입을 하나의 여정으로 검증해 주세요.",
 				id: "guide-1",
 				title: "1. 첫 사용자 여정 고정",
 			},
 			{
-				body: "MVP는 인증, 매칭, 팀 생성, 규칙 템플릿, 체크리스트까지로 제한합니다. GitHub 요약과 채팅은 첫 스프린트에서 사용자가 흐름을 이해할 수 있는 수준으로 연결합니다.",
+				body: "MVP는 인증, 매칭, 팀 생성, 규칙 템플릿, 체크리스트까지로 제한해요. GitHub 요약과 채팅은 첫 스프린트에서 사용자가 전체 과정을 이해할 수 있는 수준으로 연결해요.",
 				id: "guide-2",
 				title: "2. MVP 범위",
 			},
 			{
-				body: "팀 규칙은 누구나 수정할 수 있는 Markdown 문서로 시작하고, 동시 편집 충돌은 마지막 저장자 기준으로 단순 처리하는 정책을 우선 검토합니다.",
+				body: "팀 규칙은 누구나 수정할 수 있는 Markdown 문서로 시작해요. 동시 편집 충돌은 마지막 저장자 기준으로 단순 처리하는 정책을 먼저 검토해요.",
 				id: "guide-3",
 				title: "3. 협업 규칙",
 			},
@@ -226,7 +226,7 @@ export const demoTeamSpace: TeamSpace = {
 			author: "박상혁",
 			id: "message-2",
 			message:
-				"GitHub 연동은 방장이 계정을 연결한 뒤 저장소만 선택하는 흐름이면 충분할 것 같습니다.",
+				"GitHub 연동은 방장이 계정을 연결한 뒤 저장소만 선택하면 충분할 것 같아요.",
 			timeLabel: "10:18",
 		},
 	],
@@ -239,7 +239,7 @@ export const demoTeamSpace: TeamSpace = {
 	name: "Blue Sprint",
 	nextMeetingLabel: "오늘 21:00 첫 규칙 정하기",
 	projectDescription:
-		"랜덤 팀 매칭 이후 팀이 바로 움직일 수 있도록 규칙, 체크리스트, GitHub 활동, 채팅을 한 화면에서 운영합니다.",
+		"랜덤 팀 매칭 이후 바로 움직일 수 있도록 규칙, 체크리스트, GitHub 활동, 채팅을 한 화면에서 운영해요.",
 	projectMvp:
 		"매칭 제안 수락/거절, 팀 스페이스 홈, 규칙 템플릿, 개발 가이드라인, 체크리스트, GitHub 운영 요약",
 	projectTitle: "Team-po 팀 운영 MVP",


### PR DESCRIPTION
Summary
- Rewrite landing, auth, matching, and team workspace copy in concise Korean 해요체.
- Replace internal planning terms with user-action-oriented wording.
- Keep feature-critical labels such as AI 개발 가이드 and AI 조언 where they describe product behavior.
- Document the UX writing approach in DECISIONS.md.

Validation
- pnpm typecheck: pass
- pnpm biome lint .: pass
- pnpm build: pass, with existing Vite chunk size warning

Closes #87