### PR TITLE
fix(ui): preserve JetBrains Mono for English text

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
 	:root {
 		--font-display: "Pretendard Variable", "Pretendard", sans-serif;
 		--font-body: "Pretendard Variable", "Pretendard", sans-serif;
-		--font-mono: "JetBrains Mono", monospace;
+		--font-mono: "JetBrains Mono", "Pretendard Variable", "Pretendard", sans-serif;
 
 		--background: 0 0% 100%;
 		--foreground: 222.2 84% 4.9%;


### PR DESCRIPTION
## Summary
- Restore English-first mono stack by adding JetBrains Mono as primary font for `font-mono`.
- Add Pretendard-based fallback in the same stack for Hangul so Korean text renders correctly.
- Confine this change to the shared CSS token in `src/index.css` only.

## Validation
- `pnpm tsc --noEmit`
- `pnpm biome lint .`
- `pnpm build`

Closes #89
