### PR TITLE
랜딩 CTA와 로그인 흐름 정리

### DIFF
--- a/src/features/auth/components/github-oauth-callback-view.tsx
+++ b/src/features/auth/components/github-oauth-callback-view.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/field";
 import { AuthShell } from "@/features/auth/components/auth-shell";
 import { useGithubOAuthTokenMutation } from "@/features/auth/hooks/use-auth-queries";
+import { consumeStoredAuthRedirectPath } from "@/features/auth/lib/redirect";
 import { getApiErrorMessage } from "@/lib/api/client";
 
 const levelOptions = [1, 2, 3, 4, 5] as const;
@@ -56,7 +57,7 @@ export function GithubOAuthCallbackView() {
 				code,
 				...(selectedLevel ? { level: selectedLevel } : {}),
 			});
-			navigate("/me", { replace: true });
+			navigate(consumeStoredAuthRedirectPath() ?? "/me", { replace: true });
 		},
 		[code, exchangeGithubOAuthCode, navigate],
 	);

--- a/src/features/auth/components/login-view.tsx
+++ b/src/features/auth/components/login-view.tsx
@@ -15,6 +15,10 @@ import { Input } from "@/components/ui/input";
 import { AuthShell } from "@/features/auth/components/auth-shell";
 import { useLoginMutation } from "@/features/auth/hooks/use-auth-queries";
 import {
+	getSafeAuthRedirectPath,
+	storeAuthRedirectPath,
+} from "@/features/auth/lib/redirect";
+import {
 	hasValidationErrors,
 	validateLoginForm,
 } from "@/features/auth/lib/validation";
@@ -24,6 +28,7 @@ import { apiConfig } from "@/lib/api/config";
 export function LoginView() {
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
+	const redirectPath = getSafeAuthRedirectPath(searchParams.get("redirect"));
 	const [form, setForm] = useState({
 		email: searchParams.get("email") ?? "",
 		password: "",
@@ -36,6 +41,11 @@ export function LoginView() {
 	const errors = validateLoginForm(form);
 	const isSubmitDisabled =
 		loginMutation.isPending || hasValidationErrors(errors);
+	const loginActionLabel =
+		redirectPath === "/match" ? "매칭 화면으로 이동" : "내 정보로 이동";
+	const signupPath = redirectPath
+		? `/signup?redirect=${encodeURIComponent(redirectPath)}`
+		: "/signup";
 
 	function markTouched(field: keyof typeof touched) {
 		setTouched((current) => ({
@@ -57,7 +67,7 @@ export function LoginView() {
 		}
 
 		await loginMutation.mutateAsync(form);
-		navigate("/me");
+		navigate(redirectPath ?? "/me");
 	}
 
 	return (
@@ -69,7 +79,9 @@ export function LoginView() {
 			<div className="mb-6 rounded-lg border border-primary/15 bg-primary/5 p-4">
 				<p className="text-sm font-semibold text-primary">로그인 후 할 일</p>
 				<p className="mt-1 text-sm leading-6 text-muted-foreground">
-					내 정보에서 프로필과 현재 팀을 확인해요.
+					{redirectPath === "/match"
+						? "로그인하면 바로 매칭 요청 화면으로 이동해요."
+						: "내 정보에서 프로필과 현재 팀을 확인해요."}
 				</p>
 			</div>
 
@@ -149,7 +161,7 @@ export function LoginView() {
 					) : (
 						<ArrowRight data-icon="inline-start" />
 					)}
-					내 정보로 이동
+					{loginActionLabel}
 				</Button>
 			</form>
 
@@ -161,7 +173,10 @@ export function LoginView() {
 					size="lg"
 					variant="outline"
 				>
-					<a href={apiConfig.githubOAuthAuthorizationUrl}>
+					<a
+						href={apiConfig.githubOAuthAuthorizationUrl}
+						onClick={() => storeAuthRedirectPath(redirectPath)}
+					>
 						<Github data-icon="inline-start" />
 						GitHub로 계속하기
 					</a>
@@ -174,7 +189,7 @@ export function LoginView() {
 				</p>
 				<div className="flex flex-wrap items-center gap-4">
 					<Button asChild className="h-auto px-0" variant="link">
-						<Link to="/signup">회원가입으로 이동</Link>
+						<Link to={signupPath}>회원가입으로 이동</Link>
 					</Button>
 					<Button
 						asChild

--- a/src/features/auth/components/signup-view.tsx
+++ b/src/features/auth/components/signup-view.tsx
@@ -8,7 +8,7 @@ import {
 	ShieldCheck,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -28,6 +28,7 @@ import {
 	useSignupMutation,
 	useValidateSignupAuthNumberMutation,
 } from "@/features/auth/hooks/use-auth-queries";
+import { getSafeAuthRedirectPath } from "@/features/auth/lib/redirect";
 import {
 	hasValidationErrors,
 	validateSignupForm,
@@ -41,6 +42,11 @@ const emailVerificationCooldownSeconds = 60;
 
 export function SignupView() {
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const redirectPath = getSafeAuthRedirectPath(searchParams.get("redirect"));
+	const loginPath = redirectPath
+		? `/login?redirect=${encodeURIComponent(redirectPath)}`
+		: "/login";
 	const [form, setForm] = useState({
 		authNumber: "",
 		email: "",
@@ -146,7 +152,15 @@ export function SignupView() {
 
 		await signupMutation.mutateAsync(form);
 
-		navigate(`/login?email=${encodeURIComponent(form.email.trim())}`);
+		const loginSearchParams = new URLSearchParams({
+			email: form.email.trim(),
+		});
+
+		if (redirectPath) {
+			loginSearchParams.set("redirect", redirectPath);
+		}
+
+		navigate(`/login?${loginSearchParams.toString()}`);
 	}
 
 	async function handleCheckEmail() {
@@ -575,7 +589,7 @@ export function SignupView() {
 					className="mt-2 h-auto justify-start px-0"
 					variant="link"
 				>
-					<Link to="/login">로그인으로 이동</Link>
+					<Link to={loginPath}>로그인으로 이동</Link>
 				</Button>
 			</div>
 		</AuthShell>

--- a/src/features/auth/lib/redirect.ts
+++ b/src/features/auth/lib/redirect.ts
@@ -1,0 +1,38 @@
+const authRedirectStorageKey = "team-po.auth-redirect";
+const allowedAuthRedirectPaths = new Set(["/match", "/me", "/team"]);
+
+export function getSafeAuthRedirectPath(value: string | null) {
+	if (!value) {
+		return null;
+	}
+
+	return allowedAuthRedirectPaths.has(value) ? value : null;
+}
+
+export function storeAuthRedirectPath(value: string | null) {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	const redirectPath = getSafeAuthRedirectPath(value);
+
+	if (!redirectPath) {
+		window.sessionStorage.removeItem(authRedirectStorageKey);
+		return;
+	}
+
+	window.sessionStorage.setItem(authRedirectStorageKey, redirectPath);
+}
+
+export function consumeStoredAuthRedirectPath() {
+	if (typeof window === "undefined") {
+		return null;
+	}
+
+	const redirectPath = getSafeAuthRedirectPath(
+		window.sessionStorage.getItem(authRedirectStorageKey),
+	);
+	window.sessionStorage.removeItem(authRedirectStorageKey);
+
+	return redirectPath;
+}

--- a/src/features/landing/components/cta-section.tsx
+++ b/src/features/landing/components/cta-section.tsx
@@ -4,8 +4,11 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
 import { Surface } from "@/components/ui/surface";
+import { getLandingActionLinks } from "@/features/landing/lib/landing-navigation";
 
 export function CtaSection() {
+	const landingActionLinks = getLandingActionLinks();
+
 	return (
 		<section className="pb-20 pt-10 md:pb-24">
 			<Container>
@@ -23,13 +26,15 @@ export function CtaSection() {
 						</p>
 						<div className="relative flex flex-wrap gap-3">
 							<Button asChild size="lg" className="gap-2">
-								<Link to="/match">
-									매칭 요청하기
+								<Link to={landingActionLinks.match.to}>
+									{landingActionLinks.match.label}
 									<ArrowRight className="size-4" />
 								</Link>
 							</Button>
 							<Button asChild variant="outline" size="lg">
-								<Link to="/team">팀 스페이스 둘러보기</Link>
+								<Link to={landingActionLinks.teamSpace.to}>
+									{landingActionLinks.teamSpace.label}
+								</Link>
 							</Button>
 						</div>
 					</div>

--- a/src/features/landing/components/hero-section.tsx
+++ b/src/features/landing/components/hero-section.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
 import { Surface } from "@/components/ui/surface";
 import { heroStats } from "@/features/landing/constants";
+import { getLandingActionLinks } from "@/features/landing/lib/landing-navigation";
 
 const heroFlowSteps = [
 	{
@@ -44,6 +45,8 @@ function renderHeroStatValue(value: string) {
 }
 
 export function HeroSection() {
+	const landingActionLinks = getLandingActionLinks();
+
 	return (
 		<section className="relative overflow-hidden pb-12 pt-10 md:pb-14 md:pt-12">
 			<div className="ds-grid-overlay absolute inset-0 -z-10 opacity-70" />
@@ -79,10 +82,10 @@ export function HeroSection() {
 							size="lg"
 							className="group relative gap-2 overflow-hidden shadow-lg shadow-primary/25 transition-all hover:-translate-y-0.5 hover:shadow-xl hover:shadow-primary/30 active:translate-y-0"
 						>
-							<Link to="/match">
+							<Link to={landingActionLinks.match.to}>
 								<span className="absolute inset-0 z-0 -translate-x-[150%] skew-x-[-20deg] bg-gradient-to-r from-transparent via-white/20 to-transparent motion-safe:group-hover:animate-[shine_1.5s_ease-in-out_infinite]" />
 								<span className="relative z-10 flex items-center gap-2">
-									매칭 요청하기
+									{landingActionLinks.match.label}
 									<ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
 								</span>
 							</Link>
@@ -93,7 +96,9 @@ export function HeroSection() {
 							size="lg"
 							className="transition-all hover:-translate-y-0.5 hover:bg-white/80"
 						>
-							<Link to="/team">팀 스페이스 둘러보기</Link>
+							<Link to={landingActionLinks.teamSpace.to}>
+								{landingActionLinks.teamSpace.label}
+							</Link>
 						</Button>
 					</div>
 

--- a/src/features/landing/components/system-section.tsx
+++ b/src/features/landing/components/system-section.tsx
@@ -4,18 +4,16 @@ import { Badge } from "@/components/ui/badge";
 import { Container } from "@/components/ui/container";
 import { SectionHeading } from "@/components/ui/section-heading";
 import { Surface } from "@/components/ui/surface";
+import {
+	operatingPrinciples,
+	progressSignals,
+} from "@/features/landing/constants";
 
-const colorTokens = [
-	{ name: "forming", className: "bg-primary" },
-	{ name: "active", className: "bg-accent" },
-	{ name: "shipping", className: "bg-emerald-500" },
-	{ name: "paused", className: "bg-amber-500" },
-];
-
-const principles = [
-	"프로젝트 상태와 다음 할 일을 같이 봐요.",
-	"팀 규칙, 체크리스트, GitHub 활동을 한곳에 모아요.",
-	"주간 리포트와 회고 질문으로 다음 행동을 정해요.",
+const signalToneClasses = [
+	"bg-primary/10 text-primary",
+	"bg-accent/15 text-accent",
+	"bg-emerald-500/10 text-emerald-700",
+	"bg-amber-500/10 text-amber-700",
 ];
 
 export function SystemSection() {
@@ -24,20 +22,27 @@ export function SystemSection() {
 			<Container className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
 				<Surface variant="glass" spacing="spacious" className="space-y-6">
 					<SectionHeading
-						label="운영 기준"
-						title="처음 만난 팀도 같은 기준으로 움직여요"
-						description="상태, 역할, 다음 할 일을 같은 방식으로 확인해요."
+						label="진척 관리"
+						title="팀이 어디까지 왔는지 한눈에 봐요"
+						description="매칭 상태, 체크리스트, GitHub 활동, AI 조언을 모아 다음 할 일을 정해요."
 					/>
 
-					<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-						{colorTokens.map((token) => (
+					<div className="grid gap-3 sm:grid-cols-2">
+						{progressSignals.map((item, index) => (
 							<div
-								key={token.name}
-								className="rounded-xl border border-border/60 bg-white/80 p-3"
+								key={item.signal}
+								className="rounded-xl border border-border/60 bg-white/80 p-4 shadow-sm"
 							>
-								<div className={`h-10 rounded-md ${token.className}`} />
-								<p className="mt-2 text-xs font-semibold text-muted-foreground">
-									{token.name}
+								<p
+									className={`mb-4 w-fit rounded-full px-2.5 py-1 font-mono text-[11px] font-semibold ${signalToneClasses[index]}`}
+								>
+									{item.signal}
+								</p>
+								<h3 className="font-display text-lg leading-tight">
+									{item.title}
+								</h3>
+								<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+									{item.description}
 								</p>
 							</div>
 						))}
@@ -45,11 +50,18 @@ export function SystemSection() {
 				</Surface>
 
 				<Surface spacing="spacious" className="space-y-5">
-					<p className="font-display text-2xl leading-tight">
-						팀 운영은 단순하게
-					</p>
 					<div className="space-y-3">
-						{principles.map((item) => (
+						<Badge variant="warm">확장 예정</Badge>
+						<p className="font-display text-2xl leading-tight">
+							주간 리포트로 이어지는 팀 활동
+						</p>
+						<p className="text-sm leading-relaxed text-muted-foreground">
+							매칭 요청, 할 일, GitHub 기록, AI 조언이 쌓이면 팀의 진행 상황을
+							더 쉽게 돌아볼 수 있어요.
+						</p>
+					</div>
+					<div className="space-y-3">
+						{operatingPrinciples.map((item) => (
 							<div
 								key={item}
 								className="flex items-start gap-3 rounded-lg bg-secondary/40 p-3"
@@ -59,8 +71,14 @@ export function SystemSection() {
 							</div>
 						))}
 					</div>
-					<div className="pt-2">
-						<Badge variant="brand">매칭부터 팀 운영까지</Badge>
+					<div className="rounded-xl border border-primary/15 bg-primary/5 p-4">
+						<p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+							주간 지표
+						</p>
+						<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+							매칭 대기 시간, 체크리스트 완료율, PR/이슈 연결, AI 조언 반영
+							여부를 한 화면에서 볼 수 있게 준비하고 있어요.
+						</p>
 					</div>
 				</Surface>
 			</Container>

--- a/src/features/landing/components/value-section.tsx
+++ b/src/features/landing/components/value-section.tsx
@@ -1,25 +1,25 @@
-import { BrainCircuit, Gauge, GitBranch } from "lucide-react";
+import { GitBranch, Shuffle, SquareKanban } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Container } from "@/components/ui/container";
 import { SectionHeading } from "@/components/ui/section-heading";
 import { Surface } from "@/components/ui/surface";
-import { supportFeatures } from "@/features/landing/constants";
+import { productCapabilities } from "@/features/landing/constants";
 
-const valueIcons = [GitBranch, Gauge, BrainCircuit];
+const valueIcons = [Shuffle, SquareKanban, GitBranch];
 
 export function ValueSection() {
 	return (
 		<section className="py-20 md:py-24">
 			<Container className="space-y-10">
 				<SectionHeading
-					label="팀 운영 루틴"
-					title="매칭 뒤에도 계속 움직이게 해요"
-					description="주간 리포트, 회고 질문, 지연 신호를 모아 다음 할 일을 정하기 쉽게 해요."
+					label="핵심 기능"
+					title="매칭부터 팀 운영까지 이어져요"
+					description="역할을 고르고 제안을 확인한 뒤, 팀 스페이스에서 할 일을 정리해요."
 				/>
 
 				<div className="grid gap-4 md:grid-cols-3">
-					{supportFeatures.map((feature, index) => {
+					{productCapabilities.map((feature, index) => {
 						const Icon = valueIcons[index];
 
 						return (
@@ -28,8 +28,13 @@ export function ValueSection() {
 									<div className="flex size-10 items-center justify-center rounded-xl bg-accent/15 text-accent shadow-sm">
 										<Icon className="size-5" />
 									</div>
-									<Badge variant="brand">추천</Badge>
+									<Badge variant={index < 2 ? "brand" : "warm"}>
+										{feature.status}
+									</Badge>
 								</div>
+								<p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary/75">
+									{feature.detail}
+								</p>
 								<h3 className="font-display text-xl leading-tight">
 									{feature.title}
 								</h3>

--- a/src/features/landing/constants.ts
+++ b/src/features/landing/constants.ts
@@ -62,17 +62,56 @@ export const lifecycleStages = [
 	},
 ] as const;
 
-export const supportFeatures = [
+export const productCapabilities = [
 	{
-		title: "주간 리포트 초안",
-		description: "커밋, PR, 이슈를 모아 이번 주 진행 상황을 보여줘요.",
+		status: "매칭",
+		title: "역할만 골라도 요청할 수 있어요",
+		description:
+			"참여할 역할을 고르고 프로젝트를 제안하면 팀 제안을 확인하고 바로 응답해요.",
+		detail: "요청 · 제안 확인 · 수락/거절",
 	},
 	{
-		title: "회고 질문 추천",
-		description: "팀 대화와 이슈 기록을 바탕으로 다음 회고 질문을 제안해요.",
+		status: "팀 운영",
+		title: "팀이 만들어지면 할 일이 보여요",
+		description:
+			"팀원 역할, 관리자 권한, 체크리스트, 마감일을 한 팀 스페이스에서 정리해요.",
+		detail: "팀원 · 체크리스트 · 마감일",
 	},
 	{
-		title: "지연 신호 확인",
-		description: "일정이 밀릴 때 담당자와 우선순위를 다시 볼 수 있게 알려줘요.",
+		status: "GitHub + AI",
+		title: "개발 기록까지 운영에 연결해요",
+		description:
+			"GitHub 활동, AI 개발 가이드, 체크리스트 조언을 모아 다음 할 일을 정리해요.",
+		detail: "GitHub 활동 · AI 개발 가이드",
 	},
+] as const;
+
+export const progressSignals = [
+	{
+		signal: "매칭",
+		title: "팀 결성 상태",
+		description:
+			"요청이 대기 중인지, 제안 응답이 필요한지, 팀이 만들어졌는지 확인해요.",
+	},
+	{
+		signal: "할 일",
+		title: "체크리스트 진행률",
+		description: "담당자와 마감일이 있는 할 일을 완료율로 보여줘요.",
+	},
+	{
+		signal: "GitHub",
+		title: "개발 활동",
+		description: "PR, 이슈, 리뷰 같은 개발 기록을 팀 운영 지표로 연결해요.",
+	},
+	{
+		signal: "AI",
+		title: "AI 개발 가이드",
+		description: "프로젝트 방향과 체크리스트 조언을 다음 행동으로 정리해요.",
+	},
+] as const;
+
+export const operatingPrinciples = [
+	"매칭에서 받은 역할과 프로젝트 정보가 팀 스페이스로 이어져요.",
+	"체크리스트와 GitHub 활동으로 이번 주 진행 상황을 볼 수 있어요.",
+	"AI 조언은 결정을 대신하지 않고 다음 할 일을 정리하도록 도와요.",
 ] as const;

--- a/src/features/landing/lib/landing-navigation.ts
+++ b/src/features/landing/lib/landing-navigation.ts
@@ -1,0 +1,45 @@
+import { getAuthSession } from "@/lib/api/auth-session";
+import { apiConfig } from "@/lib/api/config";
+
+interface LandingActionLink {
+	label: string;
+	to: string;
+}
+
+interface LandingActionLinks {
+	match: LandingActionLink;
+	teamSpace: LandingActionLink;
+}
+
+export function getLandingActionLinks(): LandingActionLinks {
+	const isSignedIn = Boolean(getAuthSession());
+
+	return {
+		match: {
+			label: "매칭 시작하기",
+			to: isSignedIn ? "/match" : "/login?redirect=/match",
+		},
+		teamSpace: getTeamSpaceLink(isSignedIn),
+	};
+}
+
+function getTeamSpaceLink(isSignedIn: boolean): LandingActionLink {
+	if (isSignedIn) {
+		return {
+			label: "팀 스페이스 보기",
+			to: "/team",
+		};
+	}
+
+	if (apiConfig.useMocks) {
+		return {
+			label: "샘플 팀 스페이스 보기",
+			to: "/team",
+		};
+	}
+
+	return {
+		label: "로그인하고 팀 스페이스 보기",
+		to: "/login?redirect=/team",
+	};
+}


### PR DESCRIPTION
Summary
- 랜딩 CTA 문구와 이동 경로를 로그인 상태와 API 모드에 맞게 정리했습니다.
- 매칭/팀 스페이스 진입 시 로그인 후 원래 목적지로 돌아오도록 redirect 흐름을 보강했습니다.
- 랜딩 UX writing에서 내부 구현 용어를 줄이고 사용자 행동 중심 문구로 다듬었습니다.

Validation
- pnpm typecheck: pass
- pnpm biome lint .: pass
- pnpm build: pass

Closes #91