### PR TITLE
feat(auth): add password reset flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon-light.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
     <title>Team-po</title>
   </head>
   <body>

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -121,6 +121,40 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /users/password-reset:
+    post:
+      tags: [Auth]
+      summary: Request a password reset email
+      description: |
+        Always returns the same success response for valid email-shaped input so
+        callers cannot distinguish missing, GitHub-only, or password-backed
+        accounts from this endpoint.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestPasswordResetRequest'
+      responses:
+        '200':
+          description: Password reset email accepted when the account can use password login
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /users/password-reset/confirm:
+    post:
+      tags: [Auth]
+      summary: Complete password reset with a single-use token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPasswordRequest'
+      responses:
+        '200':
+          description: Password reset completed
+        '400':
+          $ref: '#/components/responses/BadRequest'
   /oauth/github/token:
     post:
       tags: [Auth]
@@ -967,6 +1001,25 @@ components:
         expiresAt:
           type: string
           format: date-time
+    RequestPasswordResetRequest:
+      type: object
+      additionalProperties: false
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+    ResetPasswordRequest:
+      type: object
+      additionalProperties: false
+      required: [token, newPassword]
+      properties:
+        token:
+          type: string
+          minLength: 1
+        newPassword:
+          type: string
+          minLength: 8
     GithubOAuthTokenRequest:
       type: object
       additionalProperties: false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { GithubOAuthCallbackPage } from "@/pages/github-oauth-callback-page";
 import { LandingPage } from "@/pages/landing-page";
 import { LoginPage } from "@/pages/login-page";
 import { MatchPage } from "@/pages/match-page";
+import { PasswordResetPage } from "@/pages/password-reset-page";
 import { TeamPoPresentationEleventhPage } from "@/pages/team-po-presentation-eleventh-page";
 import { TeamPoPresentationFourteenthPage } from "@/pages/team-po-presentation-fourteenth-page";
 import { TeamPoPresentationThirteenthPage } from "@/pages/team-po-presentation-thirteenth-page";
@@ -91,6 +92,7 @@ export function App() {
 				/>
 				<Route path="/login" element={<LoginPage />} />
 				<Route path="/signup" element={<SignupPage />} />
+				<Route path="/password-reset" element={<PasswordResetPage />} />
 				<Route path="/verify-email" element={<EmailVerificationPage />} />
 				<Route
 					path="/oauth/github/callback"

--- a/src/features/auth/components/login-view.tsx
+++ b/src/features/auth/components/login-view.tsx
@@ -46,6 +46,9 @@ export function LoginView() {
 	const signupPath = redirectPath
 		? `/signup?redirect=${encodeURIComponent(redirectPath)}`
 		: "/signup";
+	const passwordResetPath = form.email.trim()
+		? `/password-reset?email=${encodeURIComponent(form.email.trim())}`
+		: "/password-reset";
 
 	function markTouched(field: keyof typeof touched) {
 		setTouched((current) => ({
@@ -119,7 +122,16 @@ export function LoginView() {
 					</Field>
 
 					<Field data-invalid={Boolean(touched.password && errors.password)}>
-						<FieldLabel htmlFor="login-password">비밀번호</FieldLabel>
+						<div className="flex items-center justify-between gap-3">
+							<FieldLabel htmlFor="login-password">비밀번호</FieldLabel>
+							<Button
+								asChild
+								className="h-auto px-0 text-xs text-muted-foreground"
+								variant="link"
+							>
+								<Link to={passwordResetPath}>비밀번호 찾기</Link>
+							</Button>
+						</div>
 						<div className="relative">
 							<KeyRound className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground" />
 							<Input

--- a/src/features/auth/components/password-reset-view.tsx
+++ b/src/features/auth/components/password-reset-view.tsx
@@ -1,0 +1,491 @@
+import {
+	ArrowRight,
+	CheckCircle2,
+	Github,
+	KeyRound,
+	LoaderCircle,
+	Mail,
+	RotateCcw,
+	ShieldCheck,
+} from "lucide-react";
+import { useEffect, useLayoutEffect, useState } from "react";
+import {
+	Link,
+	useLocation,
+	useNavigate,
+	useSearchParams,
+} from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldGroup,
+	FieldLabel,
+	FieldSeparator,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { AuthShell } from "@/features/auth/components/auth-shell";
+import {
+	useRequestPasswordResetMutation,
+	useResetPasswordMutation,
+} from "@/features/auth/hooks/use-auth-queries";
+import {
+	hasValidationErrors,
+	validatePasswordResetForm,
+	validatePasswordResetRequestForm,
+} from "@/features/auth/lib/validation";
+import { getApiErrorMessage } from "@/lib/api/client";
+import { apiConfig } from "@/lib/api/config";
+
+export function PasswordResetView() {
+	useNoReferrerForResetToken();
+
+	const navigate = useNavigate();
+	const location = useLocation();
+	const [searchParams] = useSearchParams();
+	const locationToken = getPasswordResetToken(location);
+	const [token, setToken] = useState(locationToken);
+	const isCompleted = searchParams.get("completed") === "true";
+	const [requestForm, setRequestForm] = useState({
+		email: searchParams.get("email") ?? "",
+	});
+	const [resetForm, setResetForm] = useState({
+		password: "",
+		passwordConfirm: "",
+	});
+	const [requestTouched, setRequestTouched] = useState({
+		email: Boolean(searchParams.get("email")),
+	});
+	const [resetTouched, setResetTouched] = useState({
+		password: false,
+		passwordConfirm: false,
+	});
+	const requestPasswordResetMutation = useRequestPasswordResetMutation();
+	const resetPasswordMutation = useResetPasswordMutation();
+	const requestErrors = validatePasswordResetRequestForm(requestForm);
+	const resetErrors = validatePasswordResetForm(resetForm);
+	const loginPath = requestForm.email.trim()
+		? `/login?email=${encodeURIComponent(requestForm.email.trim())}`
+		: "/login";
+	const isRequestSubmitDisabled =
+		requestPasswordResetMutation.isPending || hasValidationErrors(requestErrors);
+	const isResetSubmitDisabled =
+		resetPasswordMutation.isPending || !token || hasValidationErrors(resetErrors);
+
+	useEffect(() => {
+		if (locationToken) {
+			setToken(locationToken);
+		}
+	}, [locationToken]);
+
+	useRemovePasswordResetTokenFromUrl(Boolean(locationToken), location, navigate);
+
+
+	async function handleRequestSubmit(
+		event: React.FormEvent<HTMLFormElement>,
+	) {
+		event.preventDefault();
+		setRequestTouched({ email: true });
+
+		if (hasValidationErrors(requestErrors)) {
+			return;
+		}
+
+		await requestPasswordResetMutation.mutateAsync({
+			email: requestForm.email,
+		});
+	}
+
+	async function handleResetSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		setResetTouched({
+			password: true,
+			passwordConfirm: true,
+		});
+
+		if (!token || hasValidationErrors(resetErrors)) {
+			return;
+		}
+
+		await resetPasswordMutation.mutateAsync({
+			newPassword: resetForm.password,
+			token,
+		});
+		navigate("/password-reset?completed=true", { replace: true });
+	}
+
+	function handleRequestNewLink() {
+		setToken("");
+		setResetForm({
+			password: "",
+			passwordConfirm: "",
+		});
+		setResetTouched({
+			password: false,
+			passwordConfirm: false,
+		});
+		resetPasswordMutation.reset();
+		requestPasswordResetMutation.reset();
+	}
+
+	if (isCompleted) {
+		return (
+			<AuthShell
+				badge="Reset"
+				description="새 비밀번호 저장을 마쳤어요."
+				title="이제 다시 로그인해요"
+			>
+				<div className="rounded-lg border border-emerald-500/25 bg-emerald-50 p-4">
+					<div className="flex items-start gap-3">
+						<CheckCircle2 className="mt-0.5 size-5 shrink-0 text-emerald-600" />
+						<div>
+							<p className="font-semibold text-emerald-900">
+								비밀번호가 변경되었습니다.
+							</p>
+							<p className="mt-1 text-sm leading-6 text-emerald-800/80">
+								보안을 위해 기존 로그인 세션은 만료됩니다. 새 비밀번호로 다시
+								로그인해 주세요.
+							</p>
+						</div>
+					</div>
+				</div>
+				<Button asChild className="mt-6 w-full" size="lg">
+					<Link to="/login">
+						<ArrowRight data-icon="inline-start" />
+						로그인으로 이동
+					</Link>
+				</Button>
+			</AuthShell>
+		);
+	}
+
+	if (token) {
+		return (
+			<AuthShell
+				badge="Reset"
+				description="메일로 받은 링크가 유효할 때 새 비밀번호를 저장할 수 있어요."
+				title="새 비밀번호 설정"
+			>
+				<div className="mb-6 rounded-lg border border-primary/15 bg-primary/5 p-4">
+					<div className="flex items-start gap-3">
+						<ShieldCheck className="mt-0.5 size-5 shrink-0 text-primary" />
+						<p className="text-sm leading-6 text-muted-foreground">
+							링크는 한 번만 사용할 수 있어요. 저장 후에는 로그인 화면으로
+							이동합니다.
+						</p>
+					</div>
+				</div>
+
+				<form
+					className="flex flex-col gap-6"
+					onSubmit={(event) => void handleResetSubmit(event)}
+				>
+					<FieldGroup>
+						<Field
+							data-invalid={Boolean(
+								resetTouched.password && resetErrors.password,
+							)}
+						>
+							<FieldLabel htmlFor="password-reset-new-password">
+								새 비밀번호
+							</FieldLabel>
+							<div className="relative">
+								<KeyRound className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground" />
+								<Input
+									aria-invalid={Boolean(
+										resetTouched.password && resetErrors.password,
+									)}
+									autoComplete="new-password"
+									className="h-11 bg-white pl-10"
+									id="password-reset-new-password"
+									minLength={8}
+									onBlur={() =>
+										setResetTouched((current) => ({
+											...current,
+											password: true,
+										}))
+									}
+									onChange={(event) => {
+										setResetTouched((current) => ({
+											...current,
+											password: true,
+										}));
+										setResetForm((current) => ({
+											...current,
+											password: event.target.value,
+										}));
+									}}
+									placeholder="8자 이상"
+									required
+									type="password"
+									value={resetForm.password}
+								/>
+							</div>
+							{resetTouched.password && resetErrors.password ? (
+								<FieldError>{resetErrors.password}</FieldError>
+							) : (
+								<FieldDescription>
+									이전에 사용하던 비밀번호와 다른 값을 권장해요.
+								</FieldDescription>
+							)}
+						</Field>
+
+						<Field
+							data-invalid={Boolean(
+								resetTouched.passwordConfirm &&
+									resetErrors.passwordConfirm,
+							)}
+						>
+							<FieldLabel htmlFor="password-reset-password-confirm">
+								새 비밀번호 확인
+							</FieldLabel>
+							<div className="relative">
+								<KeyRound className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground" />
+								<Input
+									aria-invalid={Boolean(
+										resetTouched.passwordConfirm &&
+											resetErrors.passwordConfirm,
+									)}
+									autoComplete="new-password"
+									className="h-11 bg-white pl-10"
+									id="password-reset-password-confirm"
+									minLength={8}
+									onBlur={() =>
+										setResetTouched((current) => ({
+											...current,
+											passwordConfirm: true,
+										}))
+									}
+									onChange={(event) => {
+										setResetTouched((current) => ({
+											...current,
+											passwordConfirm: true,
+										}));
+										setResetForm((current) => ({
+											...current,
+											passwordConfirm: event.target.value,
+										}));
+									}}
+									placeholder="한 번 더 입력"
+									required
+									type="password"
+									value={resetForm.passwordConfirm}
+								/>
+							</div>
+							{resetTouched.passwordConfirm &&
+							resetErrors.passwordConfirm ? (
+								<FieldError>{resetErrors.passwordConfirm}</FieldError>
+							) : null}
+						</Field>
+					</FieldGroup>
+
+					{resetPasswordMutation.error ? (
+						<FieldError>
+							{getApiErrorMessage(resetPasswordMutation.error)}
+						</FieldError>
+					) : null}
+
+					<Button disabled={isResetSubmitDisabled} size="lg" type="submit">
+						{resetPasswordMutation.isPending ? (
+							<LoaderCircle className="animate-spin" data-icon="inline-start" />
+						) : (
+							<RotateCcw data-icon="inline-start" />
+						)}
+						비밀번호 저장
+					</Button>
+				</form>
+
+				<Button
+					asChild
+					className="mt-6 h-auto justify-start px-0 text-muted-foreground"
+					variant="link"
+				>
+					<Link onClick={handleRequestNewLink} to="/password-reset">
+						새 링크 다시 요청하기
+					</Link>
+				</Button>
+			</AuthShell>
+		);
+	}
+
+	return (
+		<AuthShell
+			badge="Reset"
+			description="가입 이메일로 새 비밀번호 설정 링크를 보내드려요."
+			title="비밀번호를 다시 설정해요"
+		>
+			<div className="mb-6 rounded-lg border border-primary/15 bg-primary/5 p-4">
+				<p className="text-sm font-semibold text-primary">
+					메일함을 확인해 주세요
+				</p>
+				<p className="mt-1 text-sm leading-6 text-muted-foreground">
+					가입된 이메일이라면 재설정 링크가 발송됩니다. GitHub로 가입한
+					계정은 아래 GitHub 로그인을 이용해 주세요.
+				</p>
+			</div>
+
+			<form
+				className="flex flex-col gap-6"
+				onSubmit={(event) => void handleRequestSubmit(event)}
+			>
+				<FieldGroup>
+					<Field
+						data-invalid={Boolean(
+							requestTouched.email && requestErrors.email,
+						)}
+					>
+						<FieldLabel htmlFor="password-reset-email">이메일</FieldLabel>
+						<div className="relative">
+							<Mail className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground" />
+							<Input
+								aria-invalid={Boolean(
+									requestTouched.email && requestErrors.email,
+								)}
+								autoComplete="email"
+								className="h-11 bg-white pl-10"
+								id="password-reset-email"
+								onBlur={() => setRequestTouched({ email: true })}
+								onChange={(event) => {
+									setRequestTouched({ email: true });
+									requestPasswordResetMutation.reset();
+									setRequestForm({ email: event.target.value });
+								}}
+								placeholder="you@teampo.dev"
+								required
+								type="email"
+								value={requestForm.email}
+							/>
+						</div>
+						{requestTouched.email && requestErrors.email ? (
+							<FieldError>{requestErrors.email}</FieldError>
+						) : (
+							<FieldDescription>
+								계정 존재 여부와 관계없이 같은 안내가 표시됩니다.
+							</FieldDescription>
+						)}
+					</Field>
+				</FieldGroup>
+
+				{requestPasswordResetMutation.error ? (
+					<FieldError>
+						{getApiErrorMessage(requestPasswordResetMutation.error)}
+					</FieldError>
+				) : requestPasswordResetMutation.isSuccess ? (
+					<div className="rounded-lg border border-emerald-500/25 bg-emerald-50 p-4 text-sm leading-6 text-emerald-800">
+						가입된 이메일이라면 비밀번호 재설정 링크를 보냈어요.
+					</div>
+				) : null}
+
+				<Button disabled={isRequestSubmitDisabled} size="lg" type="submit">
+					{requestPasswordResetMutation.isPending ? (
+						<LoaderCircle className="animate-spin" data-icon="inline-start" />
+					) : (
+						<Mail data-icon="inline-start" />
+					)}
+					재설정 링크 받기
+				</Button>
+			</form>
+
+			<div className="mt-6 flex flex-col gap-4">
+				<FieldSeparator>또는</FieldSeparator>
+				<Button
+					asChild
+					className="border-zinc-950 bg-zinc-950 text-white shadow-soft hover:bg-zinc-800 hover:text-white hover:shadow-panel"
+					size="lg"
+					variant="outline"
+				>
+					<a href={apiConfig.githubOAuthAuthorizationUrl}>
+						<Github data-icon="inline-start" />
+						GitHub로 계속하기
+					</a>
+				</Button>
+			</div>
+
+			<div className="mt-6 rounded-lg border border-border/70 bg-brand-warm p-4 text-sm">
+				<p className="text-muted-foreground">
+					비밀번호가 기억났다면 로그인으로 돌아가도 좋아요.
+				</p>
+				<Button
+					asChild
+					className="mt-2 h-auto justify-start px-0"
+					variant="link"
+				>
+					<Link to={loginPath}>로그인으로 이동</Link>
+				</Button>
+			</div>
+		</AuthShell>
+	);
+}
+
+function useNoReferrerForResetToken() {
+	useEffect(() => {
+		const existingMeta = document.querySelector<HTMLMetaElement>(
+			'meta[name="referrer"]',
+		);
+		const meta = existingMeta ?? document.createElement("meta");
+		const previousContent = existingMeta?.getAttribute("content");
+
+		if (!existingMeta) {
+			meta.setAttribute("name", "referrer");
+			document.head.appendChild(meta);
+		}
+
+		meta.setAttribute("content", "no-referrer");
+
+		return () => {
+			if (!existingMeta) {
+				meta.remove();
+				return;
+			}
+
+			if (previousContent === null || previousContent === undefined) {
+				existingMeta.removeAttribute("content");
+				return;
+			}
+
+			existingMeta.setAttribute("content", previousContent);
+		};
+	}, []);
+}
+
+function useRemovePasswordResetTokenFromUrl(
+	hasToken: boolean,
+	location: ReturnType<typeof useLocation>,
+	navigate: ReturnType<typeof useNavigate>,
+) {
+	useLayoutEffect(() => {
+		if (!hasToken) {
+			return;
+		}
+
+		const cleanPath = createPasswordResetCleanPath(location);
+
+		if (cleanPath !== `${location.pathname}${location.search}${location.hash}`) {
+			navigate(cleanPath, { replace: true });
+		}
+	}, [hasToken, location, navigate]);
+}
+
+function getPasswordResetToken(location: ReturnType<typeof useLocation>) {
+	const hashParams = new URLSearchParams(
+		location.hash.startsWith("#") ? location.hash.slice(1) : location.hash,
+	);
+	const hashToken = hashParams.get("token")?.trim();
+
+	if (hashToken) {
+		return hashToken;
+	}
+
+	const searchParams = new URLSearchParams(location.search);
+	return searchParams.get("token")?.trim() ?? "";
+}
+
+function createPasswordResetCleanPath(location: ReturnType<typeof useLocation>) {
+	const searchParams = new URLSearchParams(location.search);
+	searchParams.delete("token");
+	const search = searchParams.toString();
+
+	return `${location.pathname}${search ? `?${search}` : ""}`;
+}

--- a/src/features/auth/components/password-reset-view.tsx
+++ b/src/features/auth/components/password-reset-view.tsx
@@ -36,6 +36,11 @@ import {
 	validatePasswordResetForm,
 	validatePasswordResetRequestForm,
 } from "@/features/auth/lib/validation";
+import {
+	clearStoredPasswordResetToken,
+	getStoredPasswordResetToken,
+	storePasswordResetToken,
+} from "@/features/auth/lib/password-reset-token";
 import { getApiErrorMessage } from "@/lib/api/client";
 import { apiConfig } from "@/lib/api/config";
 
@@ -46,7 +51,9 @@ export function PasswordResetView() {
 	const location = useLocation();
 	const [searchParams] = useSearchParams();
 	const locationToken = getPasswordResetToken(location);
-	const [token, setToken] = useState(locationToken);
+	const [token, setToken] = useState(
+		() => locationToken || getStoredPasswordResetToken(),
+	);
 	const isCompleted = searchParams.get("completed") === "true";
 	const [requestForm, setRequestForm] = useState({
 		email: searchParams.get("email") ?? "",
@@ -70,22 +77,27 @@ export function PasswordResetView() {
 		? `/login?email=${encodeURIComponent(requestForm.email.trim())}`
 		: "/login";
 	const isRequestSubmitDisabled =
-		requestPasswordResetMutation.isPending || hasValidationErrors(requestErrors);
+		requestPasswordResetMutation.isPending ||
+		hasValidationErrors(requestErrors);
 	const isResetSubmitDisabled =
-		resetPasswordMutation.isPending || !token || hasValidationErrors(resetErrors);
+		resetPasswordMutation.isPending ||
+		!token ||
+		hasValidationErrors(resetErrors);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (locationToken) {
+			storePasswordResetToken(locationToken);
 			setToken(locationToken);
 		}
 	}, [locationToken]);
 
-	useRemovePasswordResetTokenFromUrl(Boolean(locationToken), location, navigate);
+	useRemovePasswordResetTokenFromUrl(
+		Boolean(locationToken),
+		location,
+		navigate,
+	);
 
-
-	async function handleRequestSubmit(
-		event: React.FormEvent<HTMLFormElement>,
-	) {
+	async function handleRequestSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 		setRequestTouched({ email: true });
 
@@ -113,10 +125,12 @@ export function PasswordResetView() {
 			newPassword: resetForm.password,
 			token,
 		});
+		clearStoredPasswordResetToken();
 		navigate("/password-reset?completed=true", { replace: true });
 	}
 
 	function handleRequestNewLink() {
+		clearStoredPasswordResetToken();
 		setToken("");
 		setResetForm({
 			password: "",
@@ -234,8 +248,7 @@ export function PasswordResetView() {
 
 						<Field
 							data-invalid={Boolean(
-								resetTouched.passwordConfirm &&
-									resetErrors.passwordConfirm,
+								resetTouched.passwordConfirm && resetErrors.passwordConfirm,
 							)}
 						>
 							<FieldLabel htmlFor="password-reset-password-confirm">
@@ -245,8 +258,7 @@ export function PasswordResetView() {
 								<KeyRound className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground" />
 								<Input
 									aria-invalid={Boolean(
-										resetTouched.passwordConfirm &&
-											resetErrors.passwordConfirm,
+										resetTouched.passwordConfirm && resetErrors.passwordConfirm,
 									)}
 									autoComplete="new-password"
 									className="h-11 bg-white pl-10"
@@ -274,8 +286,7 @@ export function PasswordResetView() {
 									value={resetForm.passwordConfirm}
 								/>
 							</div>
-							{resetTouched.passwordConfirm &&
-							resetErrors.passwordConfirm ? (
+							{resetTouched.passwordConfirm && resetErrors.passwordConfirm ? (
 								<FieldError>{resetErrors.passwordConfirm}</FieldError>
 							) : null}
 						</Field>
@@ -321,8 +332,8 @@ export function PasswordResetView() {
 					메일함을 확인해 주세요
 				</p>
 				<p className="mt-1 text-sm leading-6 text-muted-foreground">
-					가입된 이메일이라면 재설정 링크가 발송됩니다. GitHub로 가입한
-					계정은 아래 GitHub 로그인을 이용해 주세요.
+					가입된 이메일이라면 재설정 링크가 발송됩니다. GitHub로 가입한 계정은
+					아래 GitHub 로그인을 이용해 주세요.
 				</p>
 			</div>
 
@@ -332,9 +343,7 @@ export function PasswordResetView() {
 			>
 				<FieldGroup>
 					<Field
-						data-invalid={Boolean(
-							requestTouched.email && requestErrors.email,
-						)}
+						data-invalid={Boolean(requestTouched.email && requestErrors.email)}
 					>
 						<FieldLabel htmlFor="password-reset-email">이메일</FieldLabel>
 						<div className="relative">
@@ -462,7 +471,9 @@ function useRemovePasswordResetTokenFromUrl(
 
 		const cleanPath = createPasswordResetCleanPath(location);
 
-		if (cleanPath !== `${location.pathname}${location.search}${location.hash}`) {
+		if (
+			cleanPath !== `${location.pathname}${location.search}${location.hash}`
+		) {
 			navigate(cleanPath, { replace: true });
 		}
 	}, [hasToken, location, navigate]);
@@ -482,7 +493,9 @@ function getPasswordResetToken(location: ReturnType<typeof useLocation>) {
 	return searchParams.get("token")?.trim() ?? "";
 }
 
-function createPasswordResetCleanPath(location: ReturnType<typeof useLocation>) {
+function createPasswordResetCleanPath(
+	location: ReturnType<typeof useLocation>,
+) {
 	const searchParams = new URLSearchParams(location.search);
 	searchParams.delete("token");
 	const search = searchParams.toString();

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -11,6 +11,8 @@ import { projectGroupQueryKeys } from "@/features/project-groups/hooks/use-proje
 import {
 	exchangeGithubOAuthCode,
 	login,
+	requestPasswordReset,
+	resetPassword,
 	sendSignupEmail,
 	startGithubAccountLink,
 	unlinkGithubAccount,
@@ -35,6 +37,8 @@ import type {
 	CreateUserRequest,
 	GithubOAuthTokenRequest,
 	LoginRequest,
+	RequestPasswordResetRequest,
+	ResetPasswordRequest,
 	SendSignupEmailRequest,
 	ValidateSignupAuthNumberRequest,
 } from "@/lib/types/auth";
@@ -150,6 +154,19 @@ export function useValidateSignupAuthNumberMutation() {
 	return useMutation({
 		mutationFn: (payload: ValidateSignupAuthNumberRequest) =>
 			validateSignupAuthNumber(payload),
+	});
+}
+
+export function useRequestPasswordResetMutation() {
+	return useMutation({
+		mutationFn: (payload: RequestPasswordResetRequest) =>
+			requestPasswordReset(payload),
+	});
+}
+
+export function useResetPasswordMutation() {
+	return useMutation({
+		mutationFn: (payload: ResetPasswordRequest) => resetPassword(payload),
 	});
 }
 

--- a/src/features/auth/hooks/use-auth-queries.ts
+++ b/src/features/auth/hooks/use-auth-queries.ts
@@ -165,8 +165,14 @@ export function useRequestPasswordResetMutation() {
 }
 
 export function useResetPasswordMutation() {
+	const queryClient = useQueryClient();
+
 	return useMutation({
 		mutationFn: (payload: ResetPasswordRequest) => resetPassword(payload),
+		onSuccess: () => {
+			clearAuthSession();
+			clearAuthScopedQueryData(queryClient);
+		},
 	});
 }
 

--- a/src/features/auth/lib/password-reset-token.ts
+++ b/src/features/auth/lib/password-reset-token.ts
@@ -1,0 +1,34 @@
+const passwordResetTokenStorageKey = "team-po.password-reset-token";
+
+export function getStoredPasswordResetToken() {
+	if (typeof window === "undefined") {
+		return "";
+	}
+
+	return (
+		window.sessionStorage.getItem(passwordResetTokenStorageKey)?.trim() ?? ""
+	);
+}
+
+export function storePasswordResetToken(token: string) {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	const normalizedToken = token.trim();
+
+	if (!normalizedToken) {
+		clearStoredPasswordResetToken();
+		return;
+	}
+
+	window.sessionStorage.setItem(passwordResetTokenStorageKey, normalizedToken);
+}
+
+export function clearStoredPasswordResetToken() {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	window.sessionStorage.removeItem(passwordResetTokenStorageKey);
+}

--- a/src/features/auth/lib/validation.ts
+++ b/src/features/auth/lib/validation.ts
@@ -17,6 +17,15 @@ export interface VerifyEmailFormValues {
 	email: string;
 }
 
+export interface PasswordResetRequestFormValues {
+	email: string;
+}
+
+export interface PasswordResetFormValues {
+	password: string;
+	passwordConfirm: string;
+}
+
 export interface ProfileEditFormValues {
 	description: string;
 	level: number;
@@ -64,6 +73,26 @@ export function validateVerifyEmailForm(
 	return {
 		authNumber: getAuthNumberError(values.authNumber),
 		email: getEmailError(values.email),
+	};
+}
+
+export function validatePasswordResetRequestForm(
+	values: PasswordResetRequestFormValues,
+): FormErrors<PasswordResetRequestFormValues> {
+	return {
+		email: getEmailError(values.email),
+	};
+}
+
+export function validatePasswordResetForm(
+	values: PasswordResetFormValues,
+): FormErrors<PasswordResetFormValues> {
+	return {
+		password: getPasswordError(values.password),
+		passwordConfirm: getPasswordConfirmError(
+			values.password,
+			values.passwordConfirm,
+		),
 	};
 }
 

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -6,6 +6,8 @@ import type {
 	GithubOAuthTokenResponse,
 	LoginRequest,
 	LoginResponse,
+	RequestPasswordResetRequest,
+	ResetPasswordRequest,
 	SendSignupEmailRequest,
 	ValidateSignupAuthNumberRequest,
 } from "@/lib/types/auth";
@@ -60,6 +62,25 @@ export function validateSignupAuthNumber(
 		json: {
 			authNumber: payload.authNumber,
 			email: payload.email.trim(),
+		},
+		method: "POST",
+		skipAuth: true,
+	});
+}
+
+export function requestPasswordReset(payload: RequestPasswordResetRequest) {
+	return apiRequest<void>("/users/password-reset", {
+		json: { email: payload.email.trim() },
+		method: "POST",
+		skipAuth: true,
+	});
+}
+
+export function resetPassword(payload: ResetPasswordRequest) {
+	return apiRequest<void>("/users/password-reset/confirm", {
+		json: {
+			newPassword: payload.newPassword,
+			token: payload.token.trim(),
 		},
 		method: "POST",
 		skipAuth: true,

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -10,6 +10,8 @@ import type {
 	CreateUserRequest,
 	GithubOAuthTokenRequest,
 	LoginRequest,
+	RequestPasswordResetRequest,
+	ResetPasswordRequest,
 	SendSignupEmailRequest,
 	ValidateSignupAuthNumberRequest,
 } from "@/lib/types/auth";
@@ -46,6 +48,9 @@ import type {
 let currentUser: UserProfile | null = createPreviewUser();
 let currentUserId = 1;
 let currentPassword = previewAuthSeed.password;
+const mockUserPasswords = new Map<string, string>([
+	[previewAuthSeed.email, previewAuthSeed.password],
+]);
 let matchStatus: MatchStatus | null = null;
 let activeProjectRequestRole: MatchRole | null = null;
 let activeMatchMembers: MatchMemberResponse["members"] = [];
@@ -70,6 +75,10 @@ let githubRepositoryContributions = new Map<
 >();
 let deleteEmailAuthSentUserId: number | null = null;
 let deleteEmailVerifiedUserId: number | null = null;
+const mockPasswordResetToken = "mock-password-reset-token";
+const passwordResetTokens = new Map<string, string>([
+	[mockPasswordResetToken, previewAuthSeed.email],
+]);
 const verifiedSignupEmails = new Set<string>([previewAuthSeed.email]);
 const pendingGithubInstallationStateStorageKey =
 	"team-po.mock.github-installation-state";
@@ -108,7 +117,8 @@ function syncSessionFromRequest(request: Request) {
 	if (requestUserId === 1) {
 		currentUser = createPreviewUser();
 		currentUserId = 1;
-		currentPassword = previewAuthSeed.password;
+		currentPassword =
+			mockUserPasswords.get(previewAuthSeed.email) ?? previewAuthSeed.password;
 		resetDeleteEmailState();
 		resetMatchState();
 		activeProjectGroup = createMockProjectGroup();
@@ -935,6 +945,7 @@ function completeMatchIfEveryoneAccepted() {
 export const handlers = [
 	http.post(getPath("/users/sign-in"), async ({ request }) => {
 		const body = (await request.json()) as LoginRequest;
+		const email = normalizeEmail(body.email);
 
 		await delay(400);
 
@@ -954,13 +965,10 @@ export const handlers = [
 			);
 		}
 
-		if (
-			normalizeEmail(body.email) === previewAuthSeed.email &&
-			body.password === previewAuthSeed.password
-		) {
+		if (email === previewAuthSeed.email && body.password === mockUserPasswords.get(email)) {
 			currentUserId = 1;
 			currentUser = createPreviewUser();
-			currentPassword = previewAuthSeed.password;
+			currentPassword = mockUserPasswords.get(email) ?? previewAuthSeed.password;
 			resetDeleteEmailState();
 			resetMatchState();
 			activeProjectGroup = createMockProjectGroup();
@@ -978,7 +986,7 @@ export const handlers = [
 		}
 
 		if (
-			normalizeEmail(body.email) !== currentUser.email ||
+			email !== currentUser.email ||
 			body.password !== currentPassword
 		) {
 			return buildErrorResponse(
@@ -1125,6 +1133,68 @@ export const handlers = [
 			accessToken: createMockJwt(currentUserId, currentUser?.email ?? ""),
 			expiresAt: "2026-04-20T13:00:00.000Z",
 		});
+	}),
+
+	http.post(getPath("/users/password-reset"), async ({ request }) => {
+		const body = (await request.json()) as RequestPasswordResetRequest;
+		const email = normalizeEmail(body.email);
+
+		await delay(350);
+
+		if (!isValidEmail(email)) {
+			return buildErrorResponse(
+				400,
+				"입력한 정보를 다시 확인해 주세요.",
+				"INVALID_INPUT_FIELD",
+				{
+					email: "올바른 이메일 형식이 아니에요.",
+				},
+			);
+		}
+
+		if (
+			email === previewAuthSeed.email ||
+			(currentUser &&
+				email === currentUser.email &&
+				currentUser.isGithubLogin === false)
+		) {
+			passwordResetTokens.set(mockPasswordResetToken, email);
+		}
+
+		return new HttpResponse(null, { status: 200 });
+	}),
+
+	http.post(getPath("/users/password-reset/confirm"), async ({ request }) => {
+		const body = (await request.json()) as ResetPasswordRequest;
+		const email = passwordResetTokens.get(body.token);
+
+		await delay(350);
+
+		if (body.newPassword.length < 8) {
+			return buildErrorResponse(
+				400,
+				"입력한 정보를 다시 확인해 주세요.",
+				"INVALID_INPUT_FIELD",
+				{
+					newPassword: "비밀번호는 8자 이상이어야 해요.",
+				},
+			);
+		}
+
+		if (!email) {
+			return buildErrorResponse(
+				400,
+				"비밀번호 재설정 링크가 만료되었거나 올바르지 않습니다.",
+				"INVALID_PASSWORD_RESET_TOKEN",
+			);
+		}
+
+		passwordResetTokens.delete(body.token);
+		mockUserPasswords.set(email, body.newPassword);
+		if (currentUser?.email === email) {
+			currentPassword = body.newPassword;
+		}
+		return new HttpResponse(null, { status: 200 });
 	}),
 
 	http.get(getPath("/users/check-email"), ({ request }) => {
@@ -1292,6 +1362,7 @@ export const handlers = [
 			temperature: 50,
 		});
 		currentPassword = body.password;
+		mockUserPasswords.set(currentUser.email, body.password);
 		resetDeleteEmailState();
 		resetMatchState();
 		activeProjectGroup = null;
@@ -1402,6 +1473,9 @@ export const handlers = [
 		}
 
 		currentPassword = body.afterPassword;
+		if (currentUser) {
+			mockUserPasswords.set(currentUser.email, body.afterPassword);
+		}
 		return new HttpResponse(null, { status: 200 });
 	}),
 

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -21,6 +21,15 @@ export interface ValidateSignupAuthNumberRequest {
 	email: string;
 }
 
+export interface RequestPasswordResetRequest {
+	email: string;
+}
+
+export interface ResetPasswordRequest {
+	newPassword: string;
+	token: string;
+}
+
 export interface SessionPayload {
 	accessToken: string;
 	expiresAt: string;

--- a/src/pages/password-reset-page.tsx
+++ b/src/pages/password-reset-page.tsx
@@ -1,0 +1,5 @@
+import { PasswordResetView } from "@/features/auth/components/password-reset-view";
+
+export function PasswordResetPage() {
+	return <PasswordResetView />;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"headers": [
+		{
+			"source": "/(.*)",
+			"headers": [
+				{
+					"key": "Referrer-Policy",
+					"value": "no-referrer"
+				}
+			]
+		}
+	],
 	"rewrites": [
 		{
 			"source": "/(.*)",


### PR DESCRIPTION
## Summary

- Add `/password-reset` request and confirmation UI for email password resets.
- Add login page password reset entry point and prefilled email handoff.
- Wire password reset API types, request functions, mutation hooks, OpenAPI contract, and MSW handlers.
- Handle reset tokens through URL fragment/query compatibility, immediately clean token URLs, and add Referrer-Policy protection.
- Update mock auth password state so reset and password edit flows invalidate the old password in preview mode.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm biome lint .`
- [x] `pnpm build`

Closes #95