### PR TITLE
fix(team): stack GitHub repository settings

### DIFF
--- a/src/features/team/components/real-github-installation-panel.tsx
+++ b/src/features/team/components/real-github-installation-panel.tsx
@@ -282,7 +282,7 @@ export function RealGithubInstallationPanel({
 				</div>
 
 				{isGithubConnected ? (
-					<div className="grid gap-4 2xl:grid-cols-[minmax(0,1.18fr)_minmax(22rem,0.82fr)]">
+					<div className="grid gap-4">
 						<div className="min-w-0 rounded-lg border border-border/70 bg-brand-warm p-5">
 							<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 								<div>


### PR DESCRIPTION
Summary
- Keep the GitHub repository settings panel below connected repositories at every viewport size.
- Remove the wide-screen two-column layout that made the GitHub integration screen feel cramped.

Validation
- pnpm tsc --noEmit
- pnpm biome lint .
- pnpm build
- Browser check: at 1397px viewport, settingsBelowConnected=true and sameColumn=true

Closes #103