### PR TITLE
[codex] implement team-space server APIs

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -689,6 +689,53 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /team-space/{projectGroupId}/dev-guide/history:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get AI development guide version history
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: AI development guide version history
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevGuideHistoryListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /team-space/{projectGroupId}/dev-guide/history/{devGuideId}:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get AI development guide version content
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/DevGuideId'
+      responses:
+        '200':
+          description: AI development guide version content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevGuideHistoryContentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /team-space/{projectGroupId}/dev-guide/regenerate:
     post:
       tags: [TeamSpace]
@@ -722,6 +769,28 @@ paths:
           $ref: '#/components/responses/Conflict'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /team-space/{projectGroupId}/dev-guide/{devGuideId}/confirm:
+    post:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Confirm an AI development guide version
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/DevGuideId'
+      responses:
+        '200':
+          description: AI development guide version confirmed
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /team-space/{projectGroupId}/github/status:
@@ -905,6 +974,30 @@ paths:
           $ref: '#/components/responses/NotFound'
         '502':
           $ref: '#/components/responses/BadGateway'
+  /team-space/{projectGroupId}/github/users/{targetUserId}/weekly-summaries:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get weekly GitHub activity summaries for a team member
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+        - $ref: '#/components/parameters/TargetUserId'
+      responses:
+        '200':
+          description: Weekly GitHub summaries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GithubWeeklySummaryListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   securitySchemes:
     bearerAuth:
@@ -929,6 +1022,13 @@ components:
     ChecklistId:
       in: path
       name: checklistId
+      required: true
+      schema:
+        type: integer
+        format: int64
+    DevGuideId:
+      in: path
+      name: devGuideId
       required: true
       schema:
         type: integer
@@ -1589,6 +1689,75 @@ components:
         contributionScore:
           type: integer
           format: int64
+    GithubWeeklySummaryListResponse:
+      type: object
+      additionalProperties: false
+      required: [summaries]
+      properties:
+        summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/GithubWeeklySummary'
+    GithubWeeklySummary:
+      type: object
+      additionalProperties: false
+      required:
+        - weeklyGithubSummaryId
+        - periodStart
+        - periodEnd
+        - sourcePrCount
+        - sourceIssueCount
+        - summary
+      properties:
+        weeklyGithubSummaryId:
+          type: integer
+          format: int64
+        periodStart:
+          type: string
+          format: date-time
+        periodEnd:
+          type: string
+          format: date-time
+        sourcePrCount:
+          type: integer
+          format: int64
+        sourceIssueCount:
+          type: integer
+          format: int64
+        summary:
+          $ref: '#/components/schemas/GithubWeeklySummaryContent'
+    GithubWeeklySummaryContent:
+      type: object
+      additionalProperties: false
+      required:
+        - summary
+        - mainActivities
+        - pullRequestHighlights
+        - issueHighlights
+        - followUpSuggestions
+      properties:
+        summary:
+          type: string
+        mainActivities:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+        pullRequestHighlights:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+        issueHighlights:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+        followUpSuggestions:
+          type: array
+          maxItems: 3
+          items:
+            type: string
     DevGuideGenerationStatus:
       type: string
       enum: [GENERATING, COMPLETED, FAILED]
@@ -1654,6 +1823,36 @@ components:
           type:
             - integer
             - 'null'
+    DevGuideHistory:
+      type: object
+      additionalProperties: false
+      required: [devGuideId, versionNo, generationType, confirmed, createdAt]
+      properties:
+        devGuideId:
+          type: integer
+          format: int64
+        versionNo:
+          type: integer
+        generationType:
+          $ref: '#/components/schemas/DevGuideGenerationType'
+        confirmed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+    DevGuideHistoryListResponse:
+      type: object
+      additionalProperties: false
+      required: [histories]
+      properties:
+        histories:
+          type: array
+          items:
+            $ref: '#/components/schemas/DevGuideHistory'
+    DevGuideHistoryContentResponse:
+      allOf:
+        - $ref: '#/components/schemas/DevGuideHistory'
+        - $ref: '#/components/schemas/DevGuideContent'
     DevGuideContent:
       type: object
       additionalProperties: false

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1850,9 +1850,58 @@ components:
           items:
             $ref: '#/components/schemas/DevGuideHistory'
     DevGuideHistoryContentResponse:
-      allOf:
-        - $ref: '#/components/schemas/DevGuideHistory'
-        - $ref: '#/components/schemas/DevGuideContent'
+      type: object
+      additionalProperties: false
+      required:
+        - devGuideId
+        - versionNo
+        - generationType
+        - confirmed
+        - createdAt
+        - overview
+        - techStack
+        - mvpPriorities
+        - decisionPoints
+        - milestones
+      properties:
+        devGuideId:
+          type: integer
+          format: int64
+        versionNo:
+          type: integer
+        generationType:
+          $ref: '#/components/schemas/DevGuideGenerationType'
+        confirmed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        overview:
+          type: string
+        techStack:
+          type: array
+          minItems: 5
+          maxItems: 7
+          items:
+            $ref: '#/components/schemas/DevGuideTechStackItem'
+        mvpPriorities:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            $ref: '#/components/schemas/DevGuideMvpPriority'
+        decisionPoints:
+          type: array
+          minItems: 3
+          maxItems: 5
+          items:
+            $ref: '#/components/schemas/DevGuideDecisionPoint'
+        milestones:
+          type: array
+          minItems: 12
+          maxItems: 12
+          items:
+            $ref: '#/components/schemas/DevGuideMilestone'
     DevGuideContent:
       type: object
       additionalProperties: false

--- a/src/features/team/components/real-github-installation-panel.tsx
+++ b/src/features/team/components/real-github-installation-panel.tsx
@@ -444,6 +444,7 @@ export function RealGithubInstallationPanel({
 				) : null}
 
 				<RealGithubWeeklySummariesPanel
+					isGithubConnected={isGithubConnected}
 					members={projectGroup.members}
 					projectGroupId={projectGroup.projectGroupId}
 				/>
@@ -453,9 +454,11 @@ export function RealGithubInstallationPanel({
 }
 
 function RealGithubWeeklySummariesPanel({
+	isGithubConnected,
 	members,
 	projectGroupId,
 }: {
+	isGithubConnected: boolean;
 	members: ProjectGroupMember[];
 	projectGroupId: number;
 }) {
@@ -465,10 +468,17 @@ function RealGithubWeeklySummariesPanel({
 				<div>
 					<p className="text-sm font-semibold text-brand-ink">팀원 주간 요약</p>
 					<p className="mt-1 text-sm leading-6 text-muted-foreground">
-						GitHub PR과 이슈를 바탕으로 팀원별 최근 활동을 확인해요.
+						{isGithubConnected
+							? "GitHub PR과 이슈를 바탕으로 팀원별 최근 활동을 확인해요."
+							: "GitHub 연결 전에는 서버에 저장된 최근 요약을 먼저 확인해요."}
 					</p>
 				</div>
-				<Badge variant="neutral">{members.length}명</Badge>
+				<div className="flex flex-wrap gap-2">
+					<Badge variant={isGithubConnected ? "brand" : "neutral"}>
+						{isGithubConnected ? "연결된 요약" : "저장된 요약"}
+					</Badge>
+					<Badge variant="neutral">{members.length}명</Badge>
+				</div>
 			</div>
 
 			<div className="mt-4 grid gap-3 lg:grid-cols-2">
@@ -572,7 +582,7 @@ function RealGithubWeeklySummaryBody({
 				</p>
 			</div>
 
-			<div className="grid grid-cols-2 gap-2">
+			<div className="grid gap-2 sm:grid-cols-2">
 				<RealGithubContributionStat
 					icon={GitPullRequest}
 					label="원천 PR"
@@ -978,7 +988,7 @@ function RealGithubContributionStat({
 		<div className="min-w-0 rounded-md border border-border/70 bg-secondary/25 p-3">
 			<div className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
 				<Icon className="size-3.5 shrink-0" />
-				<p className="truncate text-[11px] font-semibold">{label}</p>
+				<p className="min-w-0 text-[11px] font-semibold leading-4">{label}</p>
 			</div>
 			<p className="mt-2 truncate font-mono text-sm font-semibold text-brand-ink">
 				{contributionNumberFormatter.format(value)}

--- a/src/features/team/components/real-github-installation-panel.tsx
+++ b/src/features/team/components/real-github-installation-panel.tsx
@@ -9,6 +9,7 @@ import {
 	Save,
 	Sparkles,
 	Trophy,
+	UserRound,
 	type LucideIcon,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -28,16 +29,22 @@ import {
 	useGithubInstallationStatusQuery,
 	useGithubRepositoriesQuery,
 	useGithubRepositoryContributionsQuery,
+	useGithubWeeklySummariesQuery,
 	useSetGithubRepositoriesMutation,
 	useSyncGithubPullRequestContributionsMutation,
 } from "@/features/team/hooks/use-team-space-queries";
 import { getApiErrorMessage } from "@/lib/api/client";
-import type { MyProjectGroup } from "@/lib/types/project-group";
+import type {
+	MyProjectGroup,
+	ProjectGroupMember,
+} from "@/lib/types/project-group";
 import type {
 	GithubRepository,
 	GithubRepositoryContributor,
+	GithubWeeklySummary,
 } from "@/lib/types/team-space";
 import { cn } from "@/lib/utils";
+import { formatDateTime } from "@/lib/utils/date";
 
 const contributionNumberFormatter = new Intl.NumberFormat("ko-KR");
 
@@ -435,8 +442,187 @@ export function RealGithubInstallationPanel({
 						</div>
 					</div>
 				) : null}
+
+				<RealGithubWeeklySummariesPanel
+					members={projectGroup.members}
+					projectGroupId={projectGroup.projectGroupId}
+				/>
 			</div>
 		</AppPanel>
+	);
+}
+
+function RealGithubWeeklySummariesPanel({
+	members,
+	projectGroupId,
+}: {
+	members: ProjectGroupMember[];
+	projectGroupId: number;
+}) {
+	return (
+		<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<p className="text-sm font-semibold text-brand-ink">팀원 주간 요약</p>
+					<p className="mt-1 text-sm leading-6 text-muted-foreground">
+						GitHub PR과 이슈를 바탕으로 팀원별 최근 활동을 확인해요.
+					</p>
+				</div>
+				<Badge variant="neutral">{members.length}명</Badge>
+			</div>
+
+			<div className="mt-4 grid gap-3 lg:grid-cols-2">
+				{members.map((member) => (
+					<RealGithubWeeklySummaryCard
+						key={member.userId}
+						member={member}
+						projectGroupId={projectGroupId}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function RealGithubWeeklySummaryCard({
+	member,
+	projectGroupId,
+}: {
+	member: ProjectGroupMember;
+	projectGroupId: number;
+}) {
+	const weeklySummariesQuery = useGithubWeeklySummariesQuery(
+		projectGroupId,
+		member.userId,
+	);
+	const latestSummary = weeklySummariesQuery.data?.summaries[0] ?? null;
+
+	return (
+		<div className="min-w-0 rounded-lg border border-border/70 bg-brand-warm p-4">
+			<div className="flex min-w-0 items-start gap-3">
+				<div className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+					<UserRound className="size-4" />
+				</div>
+				<div className="min-w-0 flex-1">
+					<div className="flex flex-wrap items-start justify-between gap-2">
+						<div className="min-w-0">
+							<p className="truncate font-semibold text-brand-ink">
+								{member.nickname}
+							</p>
+							<p className="mt-1 text-xs text-muted-foreground">
+								{member.memberRole}
+							</p>
+						</div>
+						{latestSummary ? (
+							<Badge variant="brand">
+								PR{" "}
+								{contributionNumberFormatter.format(
+									latestSummary.sourcePrCount,
+								)}
+							</Badge>
+						) : (
+							<Badge variant="neutral">요약 대기</Badge>
+						)}
+					</div>
+
+					{weeklySummariesQuery.isLoading ? (
+						<RealInlineStatus
+							className="mt-4 bg-white/55"
+							icon={<LoaderCircle className="size-4 animate-spin" />}
+							message="주간 요약을 불러오고 있어요."
+						/>
+					) : null}
+
+					{weeklySummariesQuery.error ? (
+						<RealInlineStatus
+							className="mt-4 bg-white/55"
+							message={getApiErrorMessage(weeklySummariesQuery.error)}
+						/>
+					) : null}
+
+					{latestSummary ? (
+						<RealGithubWeeklySummaryBody summary={latestSummary} />
+					) : null}
+
+					{weeklySummariesQuery.isSuccess && !latestSummary ? (
+						<p className="mt-4 rounded-md border border-dashed border-border bg-white/55 p-3 text-sm leading-6 text-muted-foreground">
+							아직 생성된 주간 요약이 없어요.
+						</p>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function RealGithubWeeklySummaryBody({
+	summary,
+}: {
+	summary: GithubWeeklySummary;
+}) {
+	return (
+		<div className="mt-4 grid gap-3">
+			<div className="rounded-md border border-primary/15 bg-white/75 p-3">
+				<p className="text-xs font-semibold text-primary">
+					{formatDateTime(summary.periodStart)} -{" "}
+					{formatDateTime(summary.periodEnd)}
+				</p>
+				<p className="mt-2 text-sm leading-6 text-brand-ink">
+					{summary.summary.summary}
+				</p>
+			</div>
+
+			<div className="grid grid-cols-2 gap-2">
+				<RealGithubContributionStat
+					icon={GitPullRequest}
+					label="원천 PR"
+					value={summary.sourcePrCount}
+				/>
+				<RealGithubContributionStat
+					icon={ListChecks}
+					label="원천 이슈"
+					value={summary.sourceIssueCount}
+				/>
+			</div>
+
+			<RealGithubWeeklySummaryList
+				items={summary.summary.mainActivities}
+				title="주요 활동"
+			/>
+			<RealGithubWeeklySummaryList
+				items={summary.summary.followUpSuggestions}
+				title="다음 액션"
+			/>
+		</div>
+	);
+}
+
+function RealGithubWeeklySummaryList({
+	items,
+	title,
+}: {
+	items: string[];
+	title: string;
+}) {
+	if (items.length === 0) {
+		return null;
+	}
+
+	return (
+		<div>
+			<p className="text-xs font-semibold text-muted-foreground">{title}</p>
+			<ul className="mt-2 grid gap-1.5">
+				{items.slice(0, 3).map((item) => (
+					<li
+						className="flex gap-2 text-sm leading-6 text-brand-ink"
+						key={item}
+					>
+						<Sparkles className="mt-1 size-3.5 shrink-0 text-primary/70" />
+						<span>{item}</span>
+					</li>
+				))}
+			</ul>
+		</div>
 	);
 }
 

--- a/src/features/team/components/real-team-guide-panel.tsx
+++ b/src/features/team/components/real-team-guide-panel.tsx
@@ -262,13 +262,6 @@ export function RealGuidePanel({
 				</div>
 			</AppPanel>
 
-			<div className="grid gap-5 lg:grid-cols-[0.95fr_1.05fr]">
-				<RealDevGuideTechStackPanel guide={guide} />
-				<RealDevGuideDecisionPanel guide={guide} />
-			</div>
-
-			<RealDevGuideMilestonePanel guide={guide} />
-
 			<RealDevGuideHistoryPanel
 				confirmError={confirmDevGuideMutation.error}
 				histories={histories}
@@ -282,6 +275,13 @@ export function RealGuidePanel({
 				selectedHistoryContentError={historyContentQuery.error}
 				selectedHistoryContentLoading={historyContentQuery.isLoading}
 			/>
+
+			<div className="grid gap-5 lg:grid-cols-[0.95fr_1.05fr]">
+				<RealDevGuideTechStackPanel guide={guide} />
+				<RealDevGuideDecisionPanel guide={guide} />
+			</div>
+
+			<RealDevGuideMilestonePanel guide={guide} />
 		</div>
 	);
 }

--- a/src/features/team/components/real-team-guide-panel.tsx
+++ b/src/features/team/components/real-team-guide-panel.tsx
@@ -1,10 +1,20 @@
-import { CheckCircle2, LoaderCircle, RefreshCw } from "lucide-react";
+import {
+	Check,
+	CheckCircle2,
+	History,
+	LoaderCircle,
+	RefreshCw,
+} from "lucide-react";
+import { useState } from "react";
 
 import { AppPanel, AppPanelHeader } from "@/components/app-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RealInlineStatus } from "@/features/team/components/real-team-shared";
 import {
+	useConfirmDevGuideMutation,
+	useDevGuideHistoriesQuery,
+	useDevGuideHistoryContentQuery,
 	useDevGuideQuery,
 	useRegenerateDevGuideMutation,
 } from "@/features/team/hooks/use-team-space-queries";
@@ -13,14 +23,19 @@ import type { MyProjectGroup } from "@/lib/types/project-group";
 import type {
 	DevGuideContent,
 	DevGuideGenerationStatus,
+	DevGuideHistory,
 	DevGuideQueryResponse,
 } from "@/lib/types/team-space";
+import { formatDateTime } from "@/lib/utils/date";
 
 export function RealGuidePanel({
 	projectGroup,
 }: {
 	projectGroup: MyProjectGroup;
 }) {
+	const [selectedHistoryId, setSelectedHistoryId] = useState<number | null>(
+		null,
+	);
 	const devGuideQuery = useDevGuideQuery(projectGroup.projectGroupId);
 	const regenerateDevGuideMutation = useRegenerateDevGuideMutation();
 	const guideResponse = devGuideQuery.data;
@@ -28,9 +43,31 @@ export function RealGuidePanel({
 	const generationStatus = guideResponse?.generationStatus;
 	const remainingRegenerationCount =
 		guideResponse?.remainingRegenerationCount ?? null;
+	const historiesQuery = useDevGuideHistoriesQuery(
+		projectGroup.projectGroupId,
+		Boolean(guideResponse) && generationStatus !== "GENERATING",
+	);
+	const histories = historiesQuery.data?.histories ?? [];
+	const selectedHistory =
+		histories.find((history) => history.devGuideId === selectedHistoryId) ??
+		histories[0] ??
+		null;
+	const historyContentQuery = useDevGuideHistoryContentQuery(
+		projectGroup.projectGroupId,
+		selectedHistory?.devGuideId,
+		Boolean(selectedHistory),
+	);
+	const confirmDevGuideMutation = useConfirmDevGuideMutation();
 
 	const handleRegenerateDevGuide = () => {
 		regenerateDevGuideMutation.mutate({
+			projectGroupId: projectGroup.projectGroupId,
+		});
+	};
+
+	const handleConfirmDevGuide = (devGuideId: number) => {
+		confirmDevGuideMutation.mutate({
+			devGuideId,
 			projectGroupId: projectGroup.projectGroupId,
 		});
 	};
@@ -231,6 +268,20 @@ export function RealGuidePanel({
 			</div>
 
 			<RealDevGuideMilestonePanel guide={guide} />
+
+			<RealDevGuideHistoryPanel
+				confirmError={confirmDevGuideMutation.error}
+				histories={histories}
+				historiesError={historiesQuery.error}
+				isConfirming={confirmDevGuideMutation.isPending}
+				isLoading={historiesQuery.isLoading}
+				onConfirm={handleConfirmDevGuide}
+				onSelectHistory={setSelectedHistoryId}
+				selectedHistory={selectedHistory}
+				selectedHistoryContent={historyContentQuery.data ?? null}
+				selectedHistoryContentError={historyContentQuery.error}
+				selectedHistoryContentLoading={historyContentQuery.isLoading}
+			/>
 		</div>
 	);
 }
@@ -468,6 +519,217 @@ function RealDevGuideMilestonePanel({ guide }: { guide: DevGuideContent }) {
 			</div>
 		</AppPanel>
 	);
+}
+
+function RealDevGuideHistoryPanel({
+	confirmError,
+	histories,
+	historiesError,
+	isConfirming,
+	isLoading,
+	onConfirm,
+	onSelectHistory,
+	selectedHistory,
+	selectedHistoryContent,
+	selectedHistoryContentError,
+	selectedHistoryContentLoading,
+}: {
+	confirmError: unknown;
+	histories: DevGuideHistory[];
+	historiesError: unknown;
+	isConfirming: boolean;
+	isLoading: boolean;
+	onConfirm: (devGuideId: number) => void;
+	onSelectHistory: (devGuideId: number) => void;
+	selectedHistory: DevGuideHistory | null;
+	selectedHistoryContent: (DevGuideContent & DevGuideHistory) | null;
+	selectedHistoryContentError: unknown;
+	selectedHistoryContentLoading: boolean;
+}) {
+	const canConfirmSelected = selectedHistory
+		? !selectedHistory.confirmed
+		: false;
+
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				action={<Badge variant="neutral">버전 {histories.length}개</Badge>}
+				description="서버에 저장된 개발 가이드 버전을 비교하고 팀 기준 버전으로 확정해요."
+				eyebrow="History"
+				title="가이드 버전 기록"
+			/>
+			<div className="grid gap-5 p-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+				<div className="grid content-start gap-3">
+					{isLoading ? (
+						<RealInlineStatus
+							icon={<LoaderCircle className="size-4 animate-spin" />}
+							message="가이드 버전 기록을 불러오고 있어요."
+						/>
+					) : null}
+
+					{historiesError ? (
+						<RealInlineStatus
+							message={`버전 기록 조회 실패: ${getApiErrorMessage(
+								historiesError,
+							)}`}
+						/>
+					) : null}
+
+					{!isLoading && !historiesError && histories.length === 0 ? (
+						<RealInlineStatus message="아직 저장된 가이드 버전이 없어요." />
+					) : null}
+
+					{histories.map((history) => (
+						<button
+							className={`rounded-lg border p-4 text-left shadow-crisp transition-colors ${
+								selectedHistory?.devGuideId === history.devGuideId
+									? "border-primary/30 bg-primary/5"
+									: "border-border/70 bg-white hover:border-primary/30"
+							}`}
+							key={history.devGuideId}
+							onClick={() => onSelectHistory(history.devGuideId)}
+							type="button"
+						>
+							<span className="flex flex-wrap items-start justify-between gap-3">
+								<span className="min-w-0">
+									<span className="flex items-center gap-2 font-semibold text-brand-ink">
+										<History className="size-4 shrink-0 text-primary" />v
+										{history.versionNo}
+									</span>
+									<span className="mt-1 block text-xs text-muted-foreground">
+										{formatDateTime(history.createdAt)}
+									</span>
+								</span>
+								<span className="flex flex-wrap gap-2">
+									<Badge variant="neutral">
+										{getDevGuideGenerationTypeLabel(history.generationType)}
+									</Badge>
+									{history.confirmed ? (
+										<Badge variant="brand">확정됨</Badge>
+									) : null}
+								</span>
+							</span>
+						</button>
+					))}
+				</div>
+
+				<div className="min-w-0 rounded-lg border border-border/70 bg-brand-warm p-4">
+					<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+						<div className="min-w-0">
+							<p className="text-sm font-semibold text-brand-ink">
+								{selectedHistory
+									? `v${selectedHistory.versionNo} 본문`
+									: "선택된 버전 없음"}
+							</p>
+							<p className="mt-1 text-xs text-muted-foreground">
+								{selectedHistory
+									? formatDateTime(selectedHistory.createdAt)
+									: "기록을 선택하면 본문 요약이 표시돼요."}
+							</p>
+						</div>
+						<Button
+							disabled={!selectedHistory || !canConfirmSelected || isConfirming}
+							onClick={() =>
+								selectedHistory
+									? onConfirm(selectedHistory.devGuideId)
+									: undefined
+							}
+							size="sm"
+							type="button"
+							variant="outline"
+						>
+							{isConfirming ? (
+								<LoaderCircle
+									className="animate-spin"
+									data-icon="inline-start"
+								/>
+							) : (
+								<Check data-icon="inline-start" />
+							)}
+							확정
+						</Button>
+					</div>
+
+					{confirmError ? (
+						<RealInlineStatus
+							className="mt-4"
+							message={`가이드 확정 실패: ${getApiErrorMessage(confirmError)}`}
+						/>
+					) : null}
+
+					{selectedHistoryContentLoading ? (
+						<RealInlineStatus
+							className="mt-4"
+							icon={<LoaderCircle className="size-4 animate-spin" />}
+							message="선택한 버전의 본문을 불러오고 있어요."
+						/>
+					) : null}
+
+					{selectedHistoryContentError ? (
+						<RealInlineStatus
+							className="mt-4"
+							message={`버전 본문 조회 실패: ${getApiErrorMessage(
+								selectedHistoryContentError,
+							)}`}
+						/>
+					) : null}
+
+					{selectedHistoryContent ? (
+						<div className="mt-4 grid gap-4">
+							<p className="text-sm leading-7 text-brand-ink">
+								{selectedHistoryContent.overview}
+							</p>
+							<div className="grid gap-2 sm:grid-cols-3">
+								<RealDevGuideHistoryMetric
+									label="MVP"
+									value={`${selectedHistoryContent.mvpPriorities.length}개`}
+								/>
+								<RealDevGuideHistoryMetric
+									label="결정"
+									value={`${selectedHistoryContent.decisionPoints.length}개`}
+								/>
+								<RealDevGuideHistoryMetric
+									label="마일스톤"
+									value={`${selectedHistoryContent.milestones.length}주`}
+								/>
+							</div>
+						</div>
+					) : null}
+				</div>
+			</div>
+		</AppPanel>
+	);
+}
+
+function RealDevGuideHistoryMetric({
+	label,
+	value,
+}: {
+	label: string;
+	value: string;
+}) {
+	return (
+		<div className="rounded-md border border-border/70 bg-white px-3 py-2">
+			<p className="text-[11px] font-semibold text-muted-foreground">{label}</p>
+			<p className="mt-1 font-mono text-sm font-semibold text-brand-ink">
+				{value}
+			</p>
+		</div>
+	);
+}
+
+function getDevGuideGenerationTypeLabel(
+	type: DevGuideHistory["generationType"],
+) {
+	if (type === "MANUAL") {
+		return "수동";
+	}
+
+	if (type === "RECOVERY") {
+		return "복구";
+	}
+
+	return "초기";
 }
 
 function RealDevGuideRoleTask({

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -150,6 +150,11 @@ export function useRegenerateDevGuideMutation() {
 						response.remainingRegenerationCount ?? null,
 				},
 			);
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.devGuideHistories(
+					variables.projectGroupId,
+				),
+			});
 		},
 	});
 }

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -2,18 +2,23 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { ApiError } from "@/lib/api/client";
 import {
+	confirmDevGuide,
 	completeGithubAppInstallation,
 	createGithubAppInstallationUrl,
 	getAvailableGithubRepositories,
 	getDevGuide,
+	getDevGuideHistories,
+	getDevGuideHistoryContent,
 	getGithubInstallationStatus,
 	getGithubRepositories,
 	getGithubRepositoryContributions,
+	getGithubWeeklySummaries,
 	regenerateDevGuide,
 	setGithubRepositories,
 	syncGithubPullRequestContributions,
 } from "@/lib/api/team-space";
 import type {
+	ConfirmDevGuideRequest,
 	DevGuideQueryResponse,
 	GithubAppInstallationCompleteRequest,
 	GithubRepositoryContributionRequest,
@@ -25,6 +30,10 @@ export const teamSpaceQueryKeys = {
 	all: ["team-space"] as const,
 	devGuide: (projectGroupId: number) =>
 		["team-space", projectGroupId, "dev-guide"] as const,
+	devGuideHistories: (projectGroupId: number) =>
+		["team-space", projectGroupId, "dev-guide", "history"] as const,
+	devGuideHistoryContent: (projectGroupId: number, devGuideId: number) =>
+		["team-space", projectGroupId, "dev-guide", "history", devGuideId] as const,
 	disabled: ["team-space", "disabled"] as const,
 	githubAvailableRepositories: (projectGroupId: number) =>
 		["team-space", projectGroupId, "github", "available-repositories"] as const,
@@ -42,6 +51,15 @@ export const teamSpaceQueryKeys = {
 			githubRepositoryId,
 			"contributions",
 		] as const,
+	githubWeeklySummaries: (projectGroupId: number, targetUserId: number) =>
+		[
+			"team-space",
+			projectGroupId,
+			"github",
+			"users",
+			targetUserId,
+			"weekly-summaries",
+		] as const,
 	githubStatus: (projectGroupId: number) =>
 		["team-space", projectGroupId, "github", "status"] as const,
 };
@@ -58,6 +76,14 @@ function requireProjectGroupId(projectGroupId: number | undefined) {
 	}
 
 	return projectGroupId;
+}
+
+function requireNumericId(value: number | undefined, label: string) {
+	if (typeof value !== "number") {
+		throw new Error(`${label} is required.`);
+	}
+
+	return value;
 }
 
 export function useGithubInstallationStatusQuery(
@@ -124,6 +150,71 @@ export function useRegenerateDevGuideMutation() {
 						response.remainingRegenerationCount ?? null,
 				},
 			);
+		},
+	});
+}
+
+export function useDevGuideHistoriesQuery(
+	projectGroupId: number | undefined,
+	enabled = true,
+) {
+	return useQuery({
+		enabled: enabled && typeof projectGroupId === "number",
+		queryFn: () => getDevGuideHistories(requireProjectGroupId(projectGroupId)),
+		queryKey:
+			typeof projectGroupId === "number"
+				? teamSpaceQueryKeys.devGuideHistories(projectGroupId)
+				: teamSpaceQueryKeys.disabled,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: devGuideStaleTimeMs,
+	});
+}
+
+export function useDevGuideHistoryContentQuery(
+	projectGroupId: number | undefined,
+	devGuideId: number | undefined,
+	enabled = true,
+) {
+	const hasIds =
+		typeof projectGroupId === "number" && typeof devGuideId === "number";
+
+	return useQuery({
+		enabled: enabled && hasIds,
+		queryFn: () =>
+			getDevGuideHistoryContent({
+				devGuideId: requireNumericId(devGuideId, "Dev guide id"),
+				projectGroupId: requireProjectGroupId(projectGroupId),
+			}),
+		queryKey: hasIds
+			? teamSpaceQueryKeys.devGuideHistoryContent(projectGroupId, devGuideId)
+			: teamSpaceQueryKeys.disabled,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: devGuideStaleTimeMs,
+	});
+}
+
+export function useConfirmDevGuideMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: ConfirmDevGuideRequest) => confirmDevGuide(payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.devGuide(variables.projectGroupId),
+			});
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.devGuideHistories(
+					variables.projectGroupId,
+				),
+			});
+			queryClient.invalidateQueries({
+				queryKey: teamSpaceQueryKeys.devGuideHistoryContent(
+					variables.projectGroupId,
+					variables.devGuideId,
+				),
+			});
 		},
 	});
 }
@@ -260,5 +351,29 @@ export function useSyncGithubPullRequestContributionsMutation() {
 				),
 			});
 		},
+	});
+}
+
+export function useGithubWeeklySummariesQuery(
+	projectGroupId: number | undefined,
+	targetUserId: number | undefined,
+	enabled = true,
+) {
+	const hasIds =
+		typeof projectGroupId === "number" && typeof targetUserId === "number";
+
+	return useQuery({
+		enabled: enabled && hasIds,
+		queryFn: () =>
+			getGithubWeeklySummaries({
+				projectGroupId: requireProjectGroupId(projectGroupId),
+				targetUserId: requireNumericId(targetUserId, "Target user id"),
+			}),
+		queryKey: hasIds
+			? teamSpaceQueryKeys.githubWeeklySummaries(projectGroupId, targetUserId)
+			: teamSpaceQueryKeys.disabled,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: githubContributionStaleTimeMs,
 	});
 }

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -39,11 +39,13 @@ import type { MyProjectGroup } from "@/lib/types/project-group";
 import type {
 	DevGuideContent,
 	DevGuideGenerationStatus,
+	DevGuideHistoryContentResponse,
 	DevGuideQueryResponse,
 	GithubAppInstallationCompleteRequest,
 	GithubInstallationStatus,
 	GithubRepository,
 	GithubRepositoryContributionResponse,
+	GithubWeeklySummaryListResponse,
 	RegenerateDevGuideResponse,
 } from "@/lib/types/team-space";
 import type {
@@ -72,6 +74,8 @@ let activeDevGuideGenerationStatus: DevGuideGenerationStatus | null =
 let remainingDevGuideRegenerationCount: number | null = activeDevGuide
 	? 3
 	: null;
+let activeDevGuideHistories = createMockDevGuideHistories(activeDevGuide);
+let nextDevGuideId = 902;
 let nextProjectChecklistId = 103;
 let githubInstallationStatus: GithubInstallationStatus =
 	createDisconnectedGithubStatus();
@@ -272,6 +276,8 @@ function resetTeamSpaceApiState() {
 	activeDevGuide = createMockDevGuide(activeProjectGroup);
 	activeDevGuideGenerationStatus = activeDevGuide ? "COMPLETED" : null;
 	remainingDevGuideRegenerationCount = activeDevGuide ? 3 : null;
+	activeDevGuideHistories = createMockDevGuideHistories(activeDevGuide);
+	nextDevGuideId = 902;
 	nextProjectChecklistId = 103;
 	githubInstallationStatus = createDisconnectedGithubStatus();
 	clearPendingGithubInstallationState();
@@ -308,6 +314,106 @@ function createRegeneratedMockDevGuide(feedback: string | undefined) {
 			? `${guide.overview} 최근 재생성 요청에서 전달한 피드백도 함께 반영했습니다: ${feedback}`
 			: `${guide.overview} 최근 팀 정보를 기준으로 가이드라인을 다시 생성했습니다.`,
 	} satisfies DevGuideContent;
+}
+
+function createMockDevGuideHistories(
+	guide: DevGuideContent | null,
+): DevGuideHistoryContentResponse[] {
+	if (!guide) {
+		return [];
+	}
+
+	return [
+		{
+			...guide,
+			confirmed: true,
+			createdAt: "2026-05-24T09:00:00Z",
+			devGuideId: 901,
+			generationType: "INITIAL",
+			versionNo: 2,
+		},
+		{
+			...guide,
+			confirmed: false,
+			createdAt: "2026-05-20T09:00:00Z",
+			devGuideId: 900,
+			generationType: "INITIAL",
+			overview: `${guide.overview} 초기 버전은 체크리스트 운영보다 팀 규칙 정리에 더 무게를 두었습니다.`,
+			versionNo: 1,
+		},
+	];
+}
+
+function addMockDevGuideHistory({
+	content,
+	generationType,
+}: {
+	content: DevGuideContent;
+	generationType: DevGuideHistoryContentResponse["generationType"];
+}) {
+	const nextVersionNo =
+		Math.max(
+			0,
+			...activeDevGuideHistories.map((history) => history.versionNo),
+		) + 1;
+
+	activeDevGuideHistories = [
+		{
+			...content,
+			confirmed: false,
+			createdAt: new Date().toISOString(),
+			devGuideId: nextDevGuideId,
+			generationType,
+			versionNo: nextVersionNo,
+		},
+		...activeDevGuideHistories,
+	];
+	nextDevGuideId += 1;
+}
+
+function createMockGithubWeeklySummaries(
+	targetUserId: number,
+): GithubWeeklySummaryListResponse {
+	const member = activeProjectGroup?.members.find(
+		(candidate) => candidate.userId === targetUserId,
+	);
+
+	if (!member) {
+		return { summaries: [] };
+	}
+
+	const roleLabel = member.memberRole.toLowerCase();
+
+	return {
+		summaries: [
+			{
+				periodEnd: "2026-06-07T14:59:59Z",
+				periodStart: "2026-06-01T15:00:00Z",
+				sourceIssueCount: 3,
+				sourcePrCount: 4,
+				summary: {
+					followUpSuggestions: [
+						"리뷰 대기 PR의 merge 기준을 팀 체크리스트에 남겨요.",
+						"다음 주에는 변경 파일이 큰 PR을 더 작게 나눠요.",
+					],
+					issueHighlights: [
+						"매칭 플로우 예외 케이스를 이슈로 정리했어요.",
+						"팀 스페이스 진입 조건을 재확인했어요.",
+					],
+					mainActivities: [
+						`${member.nickname}님은 ${roleLabel} 작업 흐름을 안정화했어요.`,
+						"팀 스페이스 API 계약과 화면 상태를 함께 점검했어요.",
+					],
+					pullRequestHighlights: [
+						"GitHub 연동 상태 카드의 실패/로딩 표시를 다듬었어요.",
+						"체크리스트 API 응답과 mock 데이터를 맞췄어요.",
+					],
+					summary: `${member.nickname}님은 이번 주 팀 운영 기능의 연결성과 검증 흐름을 개선했습니다.`,
+				},
+				weeklyGithubSummaryId: targetUserId * 1000 + 1,
+			},
+		],
+	};
 }
 
 async function readOptionalJsonBody<T>(request: Request) {
@@ -2002,6 +2108,77 @@ export const handlers = [
 		},
 	),
 
+	http.get(
+		getPath("/team-space/:projectGroupId/dev-guide/history"),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			if (activeDevGuideGenerationStatus === "GENERATING") {
+				return buildErrorResponse(
+					409,
+					"개발 가이드라인이 생성 중입니다.",
+					"DEV_GUIDE_GENERATING",
+				);
+			}
+
+			return HttpResponse.json({
+				histories: activeDevGuideHistories.map(
+					({
+						confirmed,
+						createdAt,
+						devGuideId,
+						generationType,
+						versionNo,
+					}) => ({
+						confirmed,
+						createdAt,
+						devGuideId,
+						generationType,
+						versionNo,
+					}),
+				),
+			});
+		},
+	),
+
+	http.get(
+		getPath("/team-space/:projectGroupId/dev-guide/history/:devGuideId"),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const devGuideId = Number(params.devGuideId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			const history = activeDevGuideHistories.find(
+				(candidate) => candidate.devGuideId === devGuideId,
+			);
+
+			if (!history) {
+				return buildErrorResponse(
+					404,
+					"개발 가이드라인이 존재하지 않습니다.",
+					"DEV_GUIDE_NOT_FOUND",
+				);
+			}
+
+			return HttpResponse.json(history);
+		},
+	),
+
 	http.post(
 		getPath("/team-space/:projectGroupId/dev-guide/regenerate"),
 		async ({ params, request }) => {
@@ -2070,12 +2247,66 @@ export const handlers = [
 				remainingDevGuideRegenerationCount =
 					remainingDevGuideRegenerationCount ?? 3;
 			}
+			addMockDevGuideHistory({
+				content: activeDevGuide,
+				generationType,
+			});
 
 			return HttpResponse.json({
 				content: activeDevGuide,
 				generationType,
 				remainingRegenerationCount: remainingDevGuideRegenerationCount,
 			} satisfies RegenerateDevGuideResponse);
+		},
+	),
+
+	http.post(
+		getPath("/team-space/:projectGroupId/dev-guide/:devGuideId/confirm"),
+		async ({ params, request }) => {
+			await delay(350);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const devGuideId = Number(params.devGuideId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			if (activeDevGuideGenerationStatus === "GENERATING") {
+				return buildErrorResponse(
+					409,
+					"개발 가이드라인이 생성 중입니다.",
+					"DEV_GUIDE_GENERATING",
+				);
+			}
+
+			const history = activeDevGuideHistories.find(
+				(candidate) => candidate.devGuideId === devGuideId,
+			);
+
+			if (!history) {
+				return buildErrorResponse(
+					404,
+					"개발 가이드라인이 존재하지 않습니다.",
+					"DEV_GUIDE_NOT_FOUND",
+				);
+			}
+
+			activeDevGuideHistories = activeDevGuideHistories.map((candidate) => ({
+				...candidate,
+				confirmed: candidate.devGuideId === devGuideId,
+			}));
+			activeDevGuide = {
+				decisionPoints: history.decisionPoints,
+				milestones: history.milestones,
+				mvpPriorities: history.mvpPriorities,
+				overview: history.overview,
+				techStack: history.techStack,
+			};
+
+			return new HttpResponse(null, { status: 200 });
 		},
 	),
 
@@ -2372,6 +2603,38 @@ export const handlers = [
 			);
 
 			return new HttpResponse(null, { status: 200 });
+		},
+	),
+
+	http.get(
+		getPath(
+			"/team-space/:projectGroupId/github/users/:targetUserId/weekly-summaries",
+		),
+		async ({ params, request }) => {
+			await delay(300);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const targetUserId = Number(params.targetUserId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			const targetMember = activeProjectGroup?.members.find(
+				(member) => member.userId === targetUserId,
+			);
+
+			if (!targetMember) {
+				return buildErrorResponse(
+					404,
+					"팀 멤버를 찾을 수 없습니다.",
+					"PROJECT_GROUP_MEMBER_NOT_FOUND",
+				);
+			}
+
+			return HttpResponse.json(createMockGithubWeeklySummaries(targetUserId));
 		},
 	),
 ];

--- a/src/lib/api/team-space.contract.ts
+++ b/src/lib/api/team-space.contract.ts
@@ -1,0 +1,33 @@
+import {
+	confirmDevGuide,
+	getDevGuideHistories,
+	getDevGuideHistoryContent,
+	getGithubWeeklySummaries,
+} from "@/lib/api/team-space";
+import type {
+	ConfirmDevGuideRequest,
+	DevGuideHistoryContentResponse,
+	DevGuideHistoryListResponse,
+	GithubWeeklySummaryListResponse,
+	GithubWeeklySummaryRequest,
+} from "@/lib/types/team-space";
+
+type TeamSpaceServerOnlyApiContract = {
+	confirmDevGuide: (payload: ConfirmDevGuideRequest) => Promise<void>;
+	getDevGuideHistories: (
+		projectGroupId: number,
+	) => Promise<DevGuideHistoryListResponse>;
+	getDevGuideHistoryContent: (
+		payload: ConfirmDevGuideRequest,
+	) => Promise<DevGuideHistoryContentResponse>;
+	getGithubWeeklySummaries: (
+		payload: GithubWeeklySummaryRequest,
+	) => Promise<GithubWeeklySummaryListResponse>;
+};
+
+export const teamSpaceServerOnlyApiContract = {
+	confirmDevGuide,
+	getDevGuideHistories,
+	getDevGuideHistoryContent,
+	getGithubWeeklySummaries,
+} satisfies TeamSpaceServerOnlyApiContract;

--- a/src/lib/api/team-space.ts
+++ b/src/lib/api/team-space.ts
@@ -1,5 +1,8 @@
 import { apiRequest } from "@/lib/api/client";
 import type {
+	ConfirmDevGuideRequest,
+	DevGuideHistoryContentResponse,
+	DevGuideHistoryListResponse,
 	DevGuideQueryResponse,
 	GithubAppInstallationCompleteRequest,
 	GithubAppInstallationUrl,
@@ -7,6 +10,8 @@ import type {
 	GithubRepositoryContributionRequest,
 	GithubRepositoryContributionResponse,
 	GithubRepositoryListResponse,
+	GithubWeeklySummaryListResponse,
+	GithubWeeklySummaryRequest,
 	RegenerateDevGuideRequest,
 	RegenerateDevGuideResponse,
 	SetGithubRepositoriesRequest,
@@ -28,6 +33,33 @@ export function regenerateDevGuide({
 		`/team-space/${projectGroupId}/dev-guide/regenerate`,
 		{
 			json: trimmedFeedback ? { feedback: trimmedFeedback } : undefined,
+			method: "POST",
+		},
+	);
+}
+
+export function getDevGuideHistories(projectGroupId: number) {
+	return apiRequest<DevGuideHistoryListResponse>(
+		`/team-space/${projectGroupId}/dev-guide/history`,
+	);
+}
+
+export function getDevGuideHistoryContent({
+	devGuideId,
+	projectGroupId,
+}: ConfirmDevGuideRequest) {
+	return apiRequest<DevGuideHistoryContentResponse>(
+		`/team-space/${projectGroupId}/dev-guide/history/${devGuideId}`,
+	);
+}
+
+export function confirmDevGuide({
+	devGuideId,
+	projectGroupId,
+}: ConfirmDevGuideRequest) {
+	return apiRequest<void>(
+		`/team-space/${projectGroupId}/dev-guide/${devGuideId}/confirm`,
+		{
 			method: "POST",
 		},
 	);
@@ -109,5 +141,14 @@ export function syncGithubPullRequestContributions({
 		{
 			method: "POST",
 		},
+	);
+}
+
+export function getGithubWeeklySummaries({
+	projectGroupId,
+	targetUserId,
+}: GithubWeeklySummaryRequest) {
+	return apiRequest<GithubWeeklySummaryListResponse>(
+		`/team-space/${projectGroupId}/github/users/${targetUserId}/weekly-summaries`,
 	);
 }

--- a/src/lib/types/team-space.ts
+++ b/src/lib/types/team-space.ts
@@ -112,3 +112,48 @@ export interface RegenerateDevGuideResponse {
 	generationType: DevGuideGenerationType;
 	remainingRegenerationCount?: number | null;
 }
+
+export interface ConfirmDevGuideRequest {
+	devGuideId: number;
+	projectGroupId: number;
+}
+
+export interface DevGuideHistory {
+	confirmed: boolean;
+	createdAt: string;
+	devGuideId: number;
+	generationType: DevGuideGenerationType;
+	versionNo: number;
+}
+
+export interface DevGuideHistoryListResponse {
+	histories: DevGuideHistory[];
+}
+
+export type DevGuideHistoryContentResponse = DevGuideContent & DevGuideHistory;
+
+export interface GithubWeeklySummaryRequest {
+	projectGroupId: number;
+	targetUserId: number;
+}
+
+export interface GithubWeeklySummaryContent {
+	followUpSuggestions: string[];
+	issueHighlights: string[];
+	mainActivities: string[];
+	pullRequestHighlights: string[];
+	summary: string;
+}
+
+export interface GithubWeeklySummary {
+	periodEnd: string;
+	periodStart: string;
+	sourceIssueCount: number;
+	sourcePrCount: number;
+	summary: GithubWeeklySummaryContent;
+	weeklyGithubSummaryId: number;
+}
+
+export interface GithubWeeklySummaryListResponse {
+	summaries: GithubWeeklySummary[];
+}


### PR DESCRIPTION
## Summary

- Add client contracts, types, and API calls for server-only Team Space endpoints.
- Surface dev guide history/detail/confirm flows in the team guide UI.
- Surface GitHub weekly summary data in the GitHub integration UI.
- Extend API mocks and OpenAPI docs so local development covers the new flows.
- Apply design review polish: clearer GitHub weekly-summary context, no mobile metric-label truncation, and earlier access to guide version history.

## Why

The server already exposed Team Space dev-guide history/confirmation and GitHub weekly summary endpoints, but the client did not yet consume them. This brings the client API surface back in sync with the server and keeps the newly exposed UI readable across desktop and mobile layouts.

## Validation

- `./node_modules/.bin/tsc -p tsconfig.app.json --noEmit`
- `./node_modules/.bin/biome lint .`
- `./node_modules/.bin/tsc -b`
- `./node_modules/.bin/vite build`
- Browser verification on `http://127.0.0.1:5173/team` for guide history, confirm action, and GitHub weekly summary UI.
- Design quality review across desktop `1440x900` and mobile `390x844` after polish changes.