### PR TITLE
Fix chat message alignment and autocomplete

### DIFF
--- a/src/features/team/components/mock-team-space-view.tsx
+++ b/src/features/team/components/mock-team-space-view.tsx
@@ -1459,7 +1459,7 @@ function ChatPanel({ messages, onSend }: ChatPanelProps) {
 								className={cn(
 									"max-w-[min(34rem,88%)] rounded-lg border p-4 shadow-crisp",
 									message.author === "나"
-										? "border-primary/20 bg-primary text-primary-foreground"
+										? "border-blue-600 bg-blue-600 text-white"
 										: "border-border/70 bg-white text-brand-ink",
 								)}
 							>
@@ -1469,7 +1469,7 @@ function ChatPanel({ messages, onSend }: ChatPanelProps) {
 										className={cn(
 											"font-mono text-xs",
 											message.author === "나"
-												? "text-primary-foreground/75"
+												? "text-blue-100"
 												: "text-muted-foreground",
 										)}
 									>
@@ -1480,7 +1480,7 @@ function ChatPanel({ messages, onSend }: ChatPanelProps) {
 									className={cn(
 										"mt-2 text-sm leading-6",
 										message.author === "나"
-											? "text-primary-foreground/90"
+											? "text-blue-50"
 											: "text-muted-foreground",
 									)}
 								>
@@ -1491,6 +1491,7 @@ function ChatPanel({ messages, onSend }: ChatPanelProps) {
 					))}
 				</div>
 				<form
+					autoComplete="off"
 					className="grid shrink-0 gap-3 rounded-lg border border-border/70 bg-white p-4 shadow-crisp md:grid-cols-[1fr_auto]"
 					onSubmit={handleSubmit}
 				>
@@ -1500,6 +1501,7 @@ function ChatPanel({ messages, onSend }: ChatPanelProps) {
 					>
 						메시지
 						<input
+							autoComplete="off"
 							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
 							id="team-message"
 							onChange={(event) => setDraftMessage(event.target.value)}

--- a/src/features/team/components/real-team-chat-panel.tsx
+++ b/src/features/team/components/real-team-chat-panel.tsx
@@ -126,6 +126,7 @@ export function RealTeamChatPanel({ projectGroup }: RealTeamChatPanelProps) {
 					/>
 				) : null}
 				<form
+					autoComplete="off"
 					className="grid shrink-0 gap-3 rounded-lg border border-border/70 bg-white p-4 shadow-crisp md:grid-cols-[1fr_auto]"
 					onSubmit={handleSubmit}
 				>
@@ -135,6 +136,7 @@ export function RealTeamChatPanel({ projectGroup }: RealTeamChatPanelProps) {
 					>
 						메시지
 						<input
+							autoComplete="off"
 							className="h-11 rounded-lg border border-input bg-white px-3 text-sm font-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-secondary/60 disabled:text-muted-foreground"
 							disabled={!isConnected}
 							id="real-team-message"
@@ -202,7 +204,7 @@ function ChatBubble({ message }: { message: ChatMessage }) {
 				className={cn(
 					"max-w-[min(34rem,88%)] rounded-lg border p-4 shadow-crisp",
 					message.mine
-						? "border-primary/20 bg-primary text-primary-foreground"
+						? "border-blue-600 bg-blue-600 text-white"
 						: "border-border/70 bg-white text-brand-ink",
 				)}
 			>
@@ -212,7 +214,7 @@ function ChatBubble({ message }: { message: ChatMessage }) {
 						className={cn(
 							"font-mono text-xs",
 							message.mine
-								? "text-primary-foreground/75"
+								? "text-blue-100"
 								: "text-muted-foreground",
 						)}
 					>
@@ -222,9 +224,7 @@ function ChatBubble({ message }: { message: ChatMessage }) {
 				<p
 					className={cn(
 						"mt-2 whitespace-pre-wrap break-words text-sm leading-6",
-						message.mine
-							? "text-primary-foreground/90"
-							: "text-muted-foreground",
+						message.mine ? "text-blue-50" : "text-muted-foreground",
 					)}
 				>
 					{message.content}


### PR DESCRIPTION
Summary
- Render my chat messages as right-aligned blue bubbles in real and mock team chat views.
- Disable browser autocomplete on team chat message inputs.

Validation
- pnpm tsc --noEmit: pass
- pnpm biome lint .: pass
- pnpm build: pass

Closes #112