### PR TITLE
feat(team): connect team rule api

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Team-po Server API
-  version: 0.5.0
+  version: 0.6.0
   summary: Client-facing contract mirrored from the current Spring controllers.
 servers:
   - url: /api
@@ -863,6 +863,55 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /team-space/{projectGroupId}/team-rule:
+    get:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Get team rule for a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      responses:
+        '200':
+          description: Team rule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamRuleResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags: [TeamSpace]
+      security:
+        - bearerAuth: []
+      summary: Update team rule for a team space
+      parameters:
+        - $ref: '#/components/parameters/ProjectGroupId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTeamRuleRequest'
+      responses:
+        '200':
+          description: Team rule updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamRuleResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /team-space/{projectGroupId}/github/status:
     get:
       tags: [TeamSpace]
@@ -1714,6 +1763,45 @@ components:
         updatedAt:
           type: string
           format: date-time
+    TeamRuleResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - projectGroupId
+        - content
+        - version
+        - updatedAt
+        - updatedByNickname
+      properties:
+        id:
+          type: integer
+          format: int64
+        projectGroupId:
+          type: integer
+          format: int64
+        content:
+          type: string
+        version:
+          type: integer
+          format: int64
+        updatedAt:
+          type: string
+          format: date-time
+        updatedByNickname:
+          type: string
+    UpdateTeamRuleRequest:
+      type: object
+      additionalProperties: false
+      required: [content, version]
+      properties:
+        content:
+          type: string
+          minLength: 1
+          maxLength: 10000
+        version:
+          type: integer
+          format: int64
     GithubInstallationStatus:
       type: object
       additionalProperties: false

--- a/src/features/team/components/real-team-rules-panel.tsx
+++ b/src/features/team/components/real-team-rules-panel.tsx
@@ -1,0 +1,332 @@
+import { LoaderCircle, RefreshCw, RotateCcw, Save } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+
+import { AppPanel, AppPanelHeader } from "@/components/app-shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	type ActionFeedback,
+	RealActionFeedback,
+	RealInlineStatus,
+} from "@/features/team/components/real-team-shared";
+import {
+	useTeamRuleQuery,
+	useUpdateTeamRuleMutation,
+} from "@/features/team/hooks/use-team-space-queries";
+import { ApiError, getApiErrorMessage } from "@/lib/api/client";
+import type { MyProjectGroup } from "@/lib/types/project-group";
+import type { TeamRuleResponse } from "@/lib/types/team-space";
+import { cn } from "@/lib/utils";
+import { formatDateTime } from "@/lib/utils/date";
+
+const maxTeamRuleContentLength = 10_000;
+
+export function RealTeamRulesPanel({
+	projectGroup,
+}: {
+	projectGroup: MyProjectGroup;
+}) {
+	const teamRuleQuery = useTeamRuleQuery(projectGroup.projectGroupId);
+	const updateTeamRuleMutation = useUpdateTeamRuleMutation();
+	const teamRule = teamRuleQuery.data ?? null;
+	const [draftContent, setDraftContent] = useState("");
+	const [syncedRuleKey, setSyncedRuleKey] = useState<string | null>(null);
+	const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+	const teamRuleKey = teamRule ? getTeamRuleKey(teamRule) : null;
+	const isBlank = draftContent.trim().length === 0;
+	const isTooLong = draftContent.length > maxTeamRuleContentLength;
+	const isDirty = Boolean(teamRule && draftContent !== teamRule.content);
+	const canSave =
+		Boolean(teamRule) &&
+		isDirty &&
+		!isBlank &&
+		!isTooLong &&
+		!updateTeamRuleMutation.isPending;
+
+	useEffect(() => {
+		if (!teamRule || !teamRuleKey || teamRuleKey === syncedRuleKey) {
+			return;
+		}
+
+		setDraftContent(teamRule.content);
+		setSyncedRuleKey(teamRuleKey);
+	}, [teamRule, teamRuleKey, syncedRuleKey]);
+
+	async function handleRefresh() {
+		setFeedback(null);
+		const result = await teamRuleQuery.refetch();
+
+		if (result.data) {
+			setDraftContent(result.data.content);
+			setSyncedRuleKey(getTeamRuleKey(result.data));
+		}
+	}
+
+	function handleResetDraft() {
+		if (!teamRule) {
+			return;
+		}
+
+		setDraftContent(teamRule.content);
+		setFeedback(null);
+	}
+
+	async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+
+		if (!teamRule) {
+			return;
+		}
+
+		if (isBlank) {
+			setFeedback({
+				message: "팀 룰 내용을 입력해 주세요.",
+				tone: "error",
+			});
+			return;
+		}
+
+		if (isTooLong) {
+			setFeedback({
+				message: "팀 룰 내용은 10000자 이하로 입력해 주세요.",
+				tone: "error",
+			});
+			return;
+		}
+
+		setFeedback(null);
+
+		try {
+			await updateTeamRuleMutation.mutateAsync({
+				content: draftContent,
+				projectGroupId: projectGroup.projectGroupId,
+				version: teamRule.version,
+			});
+			setFeedback({
+				message: "팀 룰을 저장했어요.",
+				tone: "success",
+			});
+		} catch (error: unknown) {
+			setFeedback({
+				message: getTeamRuleSaveErrorMessage(error),
+				tone: "error",
+			});
+		}
+	}
+
+	if (teamRuleQuery.isLoading) {
+		return (
+			<AppPanel>
+				<AppPanelHeader
+					action={<Badge variant="neutral">조회 중</Badge>}
+					description="팀이 함께 지킬 협업 규칙을 불러오고 있어요."
+					eyebrow="Rulebook"
+					title="팀 룰"
+				/>
+				<div className="p-5">
+					<RealInlineStatus
+						icon={
+							<LoaderCircle className="size-4 shrink-0 animate-spin text-primary" />
+						}
+						message="팀 룰을 불러오고 있어요."
+					/>
+				</div>
+			</AppPanel>
+		);
+	}
+
+	if (teamRuleQuery.error) {
+		return (
+			<AppPanel>
+				<AppPanelHeader
+					action={<Badge variant="neutral">오류</Badge>}
+					description="팀 룰을 불러오지 못했어요."
+					eyebrow="Rulebook"
+					title="팀 룰"
+				/>
+				<div className="grid gap-4 p-5">
+					<RealInlineStatus
+						className="border-red-500/20 bg-red-50 text-red-700"
+						message={`팀 룰 조회 실패: ${getApiErrorMessage(teamRuleQuery.error)}`}
+					/>
+					<div>
+						<Button
+							disabled={teamRuleQuery.isFetching}
+							onClick={() => void handleRefresh()}
+							type="button"
+							variant="outline"
+						>
+							{teamRuleQuery.isFetching ? (
+								<LoaderCircle
+									className="animate-spin"
+									data-icon="inline-start"
+								/>
+							) : (
+								<RefreshCw data-icon="inline-start" />
+							)}
+							다시 불러오기
+						</Button>
+					</div>
+				</div>
+			</AppPanel>
+		);
+	}
+
+	if (!teamRule) {
+		return null;
+	}
+
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				action={
+					<Badge variant={isDirty ? "warm" : "brand"}>
+						{getTeamRuleStatusLabel({
+							isDirty,
+							isFetching: teamRuleQuery.isFetching,
+							isSaving: updateTeamRuleMutation.isPending,
+						})}
+					</Badge>
+				}
+				description="브랜치, 커밋, 리뷰, 공유 방식을 Markdown으로 정리해요."
+				eyebrow="Rulebook"
+				title="팀 룰"
+			/>
+			<form className="grid gap-4 p-5" onSubmit={handleSubmit}>
+				<RealActionFeedback feedback={feedback} />
+				<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_17rem]">
+					<div className="min-w-0">
+						<div className="flex flex-wrap items-end justify-between gap-2">
+							<label
+								className="text-sm font-semibold text-brand-ink"
+								htmlFor="team-rule-content"
+							>
+								Markdown
+							</label>
+							<span
+								className={cn(
+									"font-mono text-xs",
+									isTooLong ? "text-red-700" : "text-muted-foreground",
+								)}
+							>
+								{draftContent.length.toLocaleString()} /{" "}
+								{maxTeamRuleContentLength.toLocaleString()}
+							</span>
+						</div>
+						<textarea
+							className="mt-2 min-h-[28rem] w-full resize-y rounded-lg border border-input bg-white px-4 py-3 font-mono text-sm leading-7 text-brand-ink outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-70"
+							disabled={updateTeamRuleMutation.isPending}
+							id="team-rule-content"
+							onChange={(event) => {
+								setDraftContent(event.target.value);
+								setFeedback(null);
+							}}
+							spellCheck={false}
+							value={draftContent}
+						/>
+						{isBlank || isTooLong ? (
+							<p className="mt-2 text-sm leading-6 text-red-700">
+								{isBlank
+									? "팀 룰 내용을 입력해 주세요."
+									: "팀 룰 내용은 10000자 이하로 입력해 주세요."}
+							</p>
+						) : null}
+					</div>
+
+					<aside className="grid content-start gap-3 rounded-lg border border-border/70 bg-secondary/35 p-4">
+						<RuleMetadataItem
+							label="마지막 수정"
+							value={formatDateTime(teamRule.updatedAt)}
+						/>
+						<RuleMetadataItem
+							label="수정자"
+							value={teamRule.updatedByNickname}
+						/>
+						<RuleMetadataItem label="버전" value={`#${teamRule.version}`} />
+					</aside>
+				</div>
+
+				<div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+					<Button
+						disabled={
+							teamRuleQuery.isFetching || updateTeamRuleMutation.isPending
+						}
+						onClick={() => void handleRefresh()}
+						type="button"
+						variant="outline"
+					>
+						{teamRuleQuery.isFetching ? (
+							<LoaderCircle className="animate-spin" data-icon="inline-start" />
+						) : (
+							<RefreshCw data-icon="inline-start" />
+						)}
+						다시 불러오기
+					</Button>
+					<Button
+						disabled={!isDirty || updateTeamRuleMutation.isPending}
+						onClick={handleResetDraft}
+						type="button"
+						variant="outline"
+					>
+						<RotateCcw data-icon="inline-start" />
+						되돌리기
+					</Button>
+					<Button disabled={!canSave} type="submit">
+						{updateTeamRuleMutation.isPending ? (
+							<LoaderCircle className="animate-spin" data-icon="inline-start" />
+						) : (
+							<Save data-icon="inline-start" />
+						)}
+						저장
+					</Button>
+				</div>
+			</form>
+		</AppPanel>
+	);
+}
+
+function RuleMetadataItem({ label, value }: { label: string; value: string }) {
+	return (
+		<div>
+			<p className="text-xs font-semibold text-muted-foreground">{label}</p>
+			<p className="mt-1 break-words text-sm font-semibold text-brand-ink">
+				{value}
+			</p>
+		</div>
+	);
+}
+
+function getTeamRuleStatusLabel({
+	isDirty,
+	isFetching,
+	isSaving,
+}: {
+	isDirty: boolean;
+	isFetching: boolean;
+	isSaving: boolean;
+}) {
+	if (isSaving) {
+		return "저장 중";
+	}
+
+	if (isFetching) {
+		return "조회 중";
+	}
+
+	return isDirty ? "변경 있음" : "동기화";
+}
+
+function getTeamRuleKey(teamRule: TeamRuleResponse) {
+	return `${teamRule.projectGroupId}:${teamRule.id}:${teamRule.version}`;
+}
+
+function getTeamRuleSaveErrorMessage(error: unknown) {
+	if (
+		error instanceof ApiError &&
+		error.code === "PROJECT_TEAM_RULE_UPDATE_CONFLICT"
+	) {
+		return `${error.message} 다시 불러온 뒤 저장해 주세요.`;
+	}
+
+	return getApiErrorMessage(error);
+}

--- a/src/features/team/components/team-space-view.tsx
+++ b/src/features/team/components/team-space-view.tsx
@@ -3,7 +3,6 @@ import {
 	CheckCircle2,
 	GitPullRequest,
 	LoaderCircle,
-	Save,
 	Settings2,
 	Sparkles,
 } from "lucide-react";
@@ -34,6 +33,7 @@ import { RealGuidePanel } from "@/features/team/components/real-team-guide-panel
 import { RealManagePanel } from "@/features/team/components/real-team-manage-panel";
 import { RealOverviewPanel } from "@/features/team/components/real-team-overview-panel";
 import { RealProjectChecklistsPanel } from "@/features/team/components/real-project-checklists-panel";
+import { RealTeamRulesPanel } from "@/features/team/components/real-team-rules-panel";
 import {
 	type ActionFeedback,
 	RealInlineStatus,
@@ -408,7 +408,6 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 									githubStatusQuery.isLoading || githubStatusQuery.isError,
 								)
 							}
-							isDisabled={isRealTeamTabDisabled}
 							onSelectTab={setSelectedTab}
 							selectedTab={selectedTab}
 						/>
@@ -423,7 +422,9 @@ function RealTeamSpaceView({ isSignedIn }: { isSignedIn: boolean }) {
 							{selectedTab === "guide" ? (
 								<RealGuidePanel projectGroup={projectGroup} />
 							) : null}
-							{selectedTab === "rules" ? <RealRulesPanelDisabled /> : null}
+							{selectedTab === "rules" ? (
+								<RealTeamRulesPanel projectGroup={projectGroup} />
+							) : null}
 							{selectedTab === "checklist" ? (
 								<RealProjectChecklistsPanel projectGroup={projectGroup} />
 							) : null}
@@ -759,40 +760,6 @@ function RealTeamFocusPanel({
 	);
 }
 
-function RealRulesPanelDisabled() {
-	return (
-		<AppPanel>
-			<AppPanelHeader
-				action={<Badge variant="neutral">준비 중</Badge>}
-				description="팀 규칙 저장 API가 연결되면 이 탭에서 수정할 수 있어요."
-				eyebrow="Rulebook"
-				title="팀 규칙"
-			/>
-			<div className="grid gap-4 p-5">
-				<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-5">
-					<p className="text-sm font-semibold text-brand-ink">
-						아직 서버 기능이 준비되지 않았어요.
-					</p>
-					<p className="mt-2 text-sm leading-6 text-muted-foreground">
-						규칙 조회/수정 API가 생기면 이곳에서 바로 편집할 수 있게 연결할게요.
-					</p>
-				</div>
-				<textarea
-					className="min-h-56 rounded-lg border border-input bg-secondary/40 px-4 py-3 font-mono text-sm leading-7 text-muted-foreground"
-					defaultValue={"# 팀 규칙\n- 서버 API 연결 후 편집할 수 있어요."}
-					disabled
-				/>
-				<div className="flex justify-end">
-					<Button disabled type="button">
-						<Save data-icon="inline-start" />
-						저장 준비 중
-					</Button>
-				</div>
-			</div>
-		</AppPanel>
-	);
-}
-
 function getRealTeamTabBadge(
 	tabId: TeamTab,
 	checklists: ProjectChecklist[],
@@ -814,7 +781,7 @@ function getRealTeamTabBadge(
 	}
 
 	if (tabId === "rules") {
-		return "준비";
+		return null;
 	}
 
 	if (tabId === "github") {
@@ -829,8 +796,4 @@ function getRealTeamTabBadge(
 	}
 
 	return null;
-}
-
-function isRealTeamTabDisabled(tabId: TeamTab) {
-	return tabId === "rules";
 }

--- a/src/features/team/hooks/use-team-space-queries.ts
+++ b/src/features/team/hooks/use-team-space-queries.ts
@@ -13,9 +13,11 @@ import {
 	getGithubRepositories,
 	getGithubRepositoryContributions,
 	getGithubWeeklySummaries,
+	getTeamRule,
 	regenerateDevGuide,
 	setGithubRepositories,
 	syncGithubPullRequestContributions,
+	updateTeamRule,
 } from "@/lib/api/team-space";
 import type {
 	ConfirmDevGuideRequest,
@@ -24,6 +26,8 @@ import type {
 	GithubRepositoryContributionRequest,
 	RegenerateDevGuideRequest,
 	SetGithubRepositoriesRequest,
+	TeamRuleResponse,
+	UpdateTeamRuleRequest,
 } from "@/lib/types/team-space";
 
 export const teamSpaceQueryKeys = {
@@ -62,12 +66,15 @@ export const teamSpaceQueryKeys = {
 		] as const,
 	githubStatus: (projectGroupId: number) =>
 		["team-space", projectGroupId, "github", "status"] as const,
+	teamRule: (projectGroupId: number) =>
+		["team-space", projectGroupId, "team-rule"] as const,
 };
 
 const githubStatusStaleTimeMs = 15_000;
 const githubRepositoryStaleTimeMs = 15_000;
 const githubContributionStaleTimeMs = 15_000;
 const devGuideStaleTimeMs = 60_000;
+const teamRuleStaleTimeMs = 30_000;
 const pendingDevGuideRefetchIntervalMs = 5_000;
 
 function requireProjectGroupId(projectGroupId: number | undefined) {
@@ -338,6 +345,37 @@ export function useSetGithubRepositoriesMutation() {
 					variables.projectGroupId,
 				),
 			});
+		},
+	});
+}
+
+export function useTeamRuleQuery(
+	projectGroupId: number | undefined,
+	enabled = true,
+) {
+	return useQuery({
+		enabled: enabled && typeof projectGroupId === "number",
+		queryFn: () => getTeamRule(requireProjectGroupId(projectGroupId)),
+		queryKey:
+			typeof projectGroupId === "number"
+				? teamSpaceQueryKeys.teamRule(projectGroupId)
+				: teamSpaceQueryKeys.disabled,
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: teamRuleStaleTimeMs,
+	});
+}
+
+export function useUpdateTeamRuleMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (payload: UpdateTeamRuleRequest) => updateTeamRule(payload),
+		onSuccess: (response, variables) => {
+			queryClient.setQueryData<TeamRuleResponse>(
+				teamSpaceQueryKeys.teamRule(variables.projectGroupId),
+				response,
+			);
 		},
 	});
 }

--- a/src/lib/api/mocks/handlers.ts
+++ b/src/lib/api/mocks/handlers.ts
@@ -48,12 +48,59 @@ import type {
 	GithubRepositoryContributionResponse,
 	GithubWeeklySummaryListResponse,
 	RegenerateDevGuideResponse,
+	TeamRuleResponse,
+	UpdateTeamRuleRequest,
 } from "@/lib/types/team-space";
 import type {
 	EditPasswordRequest,
 	UpdateCurrentUserRequest,
 	UserProfile,
 } from "@/lib/types/user";
+
+const defaultMockTeamRuleContent = `# 팀 룰
+
+## 1. 기본 원칙
+
+- 막힌 내용은 혼자 오래 끌지 않고 팀 채널에 공유한다.
+- 중요한 결정은 구두로만 남기지 않고 GitHub Issue, PR, 회의록 중 하나에 기록한다.
+- 일정이 늦어질 것 같으면 마감 직전이 아니라 가능한 빨리 공유한다.
+
+## 2. GitHub 작업 규칙
+
+- 모든 작업은 Issue를 먼저 만들고 시작한다.
+- 브랜치는 Issue 번호를 포함해 만든다. 예: \`feat/12-login-api\`, \`fix/25-token-refresh\`
+- \`main\` 브랜치에는 직접 커밋하지 않는다.
+- 하나의 PR은 하나의 목적만 가진다.
+- PR 본문에는 변경 내용, 테스트 결과, 리뷰어가 확인해야 할 점을 적는다.
+
+## 3. 커밋 규칙
+
+- 커밋 메시지는 변경 의도를 알 수 있게 작성한다.
+- 추천 형식:
+  - \`feat: 새로운 기능 추가\`
+  - \`fix: 버그 수정\`
+  - \`refactor: 동작 변경 없는 구조 개선\`
+  - \`test: 테스트 추가 또는 수정\`
+  - \`docs: 문서 수정\`
+
+## 4. PR 리뷰 규칙
+
+- 리뷰어는 가능한 24시간 안에 확인한다.
+- approve 없이 merge하지 않는다.
+
+## 5. 코드 작성 규칙
+
+- 임시 로그, 불필요한 주석, 사용하지 않는 코드는 남기지 않는다.
+- 비밀번호, 토큰, API Key 같은 민감 정보는 코드와 로그에 남기지 않는다.
+- 예외 상황은 무시하지 않고 명확히 처리한다.
+- API 응답 형식과 에러 코드는 기존 방식과 맞춘다.
+
+## 6. 테스트 규칙
+
+- 주요 서비스 로직은 단위 테스트를 작성한다.
+- 권한 실패, 잘못된 입력, 존재하지 않는 데이터도 테스트한다.
+- 버그를 수정할 때는 같은 문제가 다시 생기지 않도록 테스트를 추가한다.
+- 테스트를 실행하지 못했다면 PR에 이유를 적는다.`;
 
 let currentUser: UserProfile | null = createPreviewUser();
 let currentUserId = 1;
@@ -66,6 +113,8 @@ let activeProjectRequestRole: MatchRole | null = null;
 let activeMatchMembers: MatchMemberResponse["members"] = [];
 let activeMatchProject: MatchProjectResponse | null = null;
 let activeProjectGroup: MyProjectGroup | null = createMockProjectGroup();
+let activeTeamRule: TeamRuleResponse | null =
+	createMockTeamRule(activeProjectGroup);
 let projectGroupFinishAgreementUserIds = new Set<number>();
 let activeProjectChecklists: ProjectChecklist[] = createMockProjectChecklists();
 let activeChatMessages: ChatMessage[] = createMockChatMessages();
@@ -272,6 +321,7 @@ function resetMatchState() {
 
 function resetTeamSpaceApiState() {
 	projectGroupFinishAgreementUserIds = new Set();
+	activeTeamRule = createMockTeamRule(activeProjectGroup);
 	activeProjectChecklists = activeProjectGroup
 		? createMockProjectChecklists()
 		: [];
@@ -425,6 +475,17 @@ async function readOptionalJsonBody<T>(request: Request) {
 	} catch {
 		return null;
 	}
+}
+
+function isTeamRuleUpdateBody(
+	value: unknown,
+): value is Pick<UpdateTeamRuleRequest, "content" | "version"> {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+
+	const { content, version } = value as Partial<UpdateTeamRuleRequest>;
+	return typeof content === "string" && typeof version === "number";
 }
 
 function parseGithubRepositoryIds(value: unknown): number[] | null {
@@ -759,6 +820,28 @@ function createMockProjectGroup(): MyProjectGroup {
 		projectMvp: "매칭 요청, 수락/거절, 팀 스페이스 홈, 첫 체크리스트 운영",
 		projectName: "Blue Sprint",
 		projectTitle: "Team-po 팀 운영 MVP",
+	};
+}
+
+function createMockTeamRule(
+	projectGroup: MyProjectGroup | null,
+): TeamRuleResponse | null {
+	if (!projectGroup) {
+		return null;
+	}
+
+	const currentMember = projectGroup.members.find(
+		(member) => member.userId === currentUserId,
+	);
+
+	return {
+		content: defaultMockTeamRuleContent,
+		id: 700,
+		projectGroupId: projectGroup.projectGroupId,
+		updatedAt: "2026-06-10T10:00:00Z",
+		updatedByNickname:
+			currentMember?.nickname ?? currentUser?.nickname ?? "preview",
+		version: 0,
 	};
 }
 
@@ -2186,6 +2269,115 @@ export const handlers = [
 				lastReadMessageId: body.lastReadMessageId,
 				updatedAt: new Date().toISOString(),
 			});
+		},
+	),
+
+	http.get(
+		getPath("/team-space/:projectGroupId/team-rule"),
+		async ({ params, request }) => {
+			await delay(250);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			activeTeamRule = activeTeamRule ?? createMockTeamRule(activeProjectGroup);
+
+			if (!activeTeamRule) {
+				return buildErrorResponse(
+					404,
+					"소속된 팀 스페이스를 찾을 수 없습니다.",
+					"PROJECT_GROUP_NOT_FOUND",
+				);
+			}
+
+			return HttpResponse.json(activeTeamRule);
+		},
+	),
+
+	http.put(
+		getPath("/team-space/:projectGroupId/team-rule"),
+		async ({ params, request }) => {
+			const body = await readOptionalJsonBody(request);
+
+			await delay(350);
+			syncSessionFromRequest(request);
+
+			const projectGroupId = Number(params.projectGroupId);
+			const accessError = assertProjectGroupAccess(projectGroupId);
+
+			if (accessError) {
+				return accessError;
+			}
+
+			if (!isTeamRuleUpdateBody(body)) {
+				return buildErrorResponse(
+					400,
+					"입력값이 올바르지 않습니다.",
+					"INVALID_INPUT_FIELD",
+				);
+			}
+
+			if (!body.content.trim()) {
+				return buildErrorResponse(
+					400,
+					"팀 룰 내용은 필수입니다.",
+					"PROJECT_TEAM_RULE_CONTENT_REQUIRED",
+				);
+			}
+
+			if (body.content.length > 10_000) {
+				return buildErrorResponse(
+					400,
+					"입력값이 올바르지 않습니다.",
+					"INVALID_INPUT_FIELD",
+					{ content: "팀 룰 내용은 10000자 이하여야 합니다." },
+				);
+			}
+
+			if (body.content.includes("[server-error]")) {
+				return buildErrorResponse(
+					500,
+					"팀 룰 저장 중 서버 오류가 발생했습니다.",
+					"MATCH_DATA_ERROR",
+				);
+			}
+
+			activeTeamRule = activeTeamRule ?? createMockTeamRule(activeProjectGroup);
+
+			if (!activeTeamRule) {
+				return buildErrorResponse(
+					404,
+					"소속된 팀 스페이스를 찾을 수 없습니다.",
+					"PROJECT_GROUP_NOT_FOUND",
+				);
+			}
+
+			if (activeTeamRule.version !== body.version) {
+				return buildErrorResponse(
+					409,
+					"팀 룰이 다른 사용자에 의해 먼저 수정되었습니다.",
+					"PROJECT_TEAM_RULE_UPDATE_CONFLICT",
+				);
+			}
+
+			const currentMember = activeProjectGroup?.members.find(
+				(member) => member.userId === currentUserId,
+			);
+			activeTeamRule = {
+				...activeTeamRule,
+				content: body.content,
+				updatedAt: new Date().toISOString(),
+				updatedByNickname:
+					currentMember?.nickname ?? currentUser?.nickname ?? "preview",
+				version: activeTeamRule.version + 1,
+			};
+
+			return HttpResponse.json(activeTeamRule);
 		},
 	),
 

--- a/src/lib/api/team-space.ts
+++ b/src/lib/api/team-space.ts
@@ -15,6 +15,8 @@ import type {
 	RegenerateDevGuideRequest,
 	RegenerateDevGuideResponse,
 	SetGithubRepositoriesRequest,
+	TeamRuleResponse,
+	UpdateTeamRuleRequest,
 } from "@/lib/types/team-space";
 
 export function getDevGuide(projectGroupId: number) {
@@ -121,6 +123,29 @@ export function setGithubRepositories({
 		},
 		method: "PUT",
 	});
+}
+
+export function getTeamRule(projectGroupId: number) {
+	return apiRequest<TeamRuleResponse>(
+		`/team-space/${projectGroupId}/team-rule`,
+	);
+}
+
+export function updateTeamRule({
+	content,
+	projectGroupId,
+	version,
+}: UpdateTeamRuleRequest) {
+	return apiRequest<TeamRuleResponse>(
+		`/team-space/${projectGroupId}/team-rule`,
+		{
+			json: {
+				content,
+				version,
+			},
+			method: "PUT",
+		},
+	);
 }
 
 export function getGithubRepositoryContributions({

--- a/src/lib/types/team-space.ts
+++ b/src/lib/types/team-space.ts
@@ -30,6 +30,21 @@ export interface SetGithubRepositoriesRequest {
 	projectGroupId: number;
 }
 
+export interface TeamRuleResponse {
+	content: string;
+	id: number;
+	projectGroupId: number;
+	updatedAt: string;
+	updatedByNickname: string;
+	version: number;
+}
+
+export interface UpdateTeamRuleRequest {
+	content: string;
+	projectGroupId: number;
+	version: number;
+}
+
 export interface GithubRepositoryContributionRequest {
 	githubRepositoryId: number;
 	projectGroupId: number;


### PR DESCRIPTION
## Summary
- 팀 룰 API 계약을 OpenAPI와 클라이언트 타입/요청 함수에 반영했습니다.
- 실제 팀 스페이스 규칙 탭을 조회/수정 가능한 Markdown 편집 화면으로 연결했습니다.
- MSW mock에 팀 룰 조회, 저장, 검증 실패, 충돌, 서버 오류 케이스를 추가했습니다.

## Validation
- [x] pnpm tsc --noEmit
- [x] pnpm biome lint .
- [x] pnpm build

Closes #118