### PR TITLE
Split GitHub team panel into subtabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,13 @@ const TeamSpacePage = lazy(() =>
 		default: TeamSpacePage,
 	})),
 );
+const GithubSubtabsPreviewPage = lazy(() =>
+	import("@/pages/github-subtabs-preview-page").then(
+		({ GithubSubtabsPreviewPage }) => ({
+			default: GithubSubtabsPreviewPage,
+		}),
+	),
+);
 const PrVideoPage = lazy(() =>
 	import("@/pages/pr-video-page").then(({ PrVideoPage }) => ({
 		default: PrVideoPage,
@@ -231,6 +238,10 @@ export function App() {
 					<Route path="/me" element={<ProfilePage />} />
 					<Route path="/match" element={<MatchPage />} />
 					<Route path="/team" element={<TeamSpacePage />} />
+					<Route
+						path="/team/github-preview"
+						element={<GithubSubtabsPreviewPage />}
+					/>
 					<Route path="/pr-video" element={<PrVideoPage />} />
 					<Route path="*" element={<Navigate replace to="/" />} />
 				</Routes>

--- a/src/features/team/components/github-subtabs-preview-panel.tsx
+++ b/src/features/team/components/github-subtabs-preview-panel.tsx
@@ -1,0 +1,877 @@
+import {
+	ExternalLink,
+	FileDiff,
+	GitPullRequest,
+	Github,
+	ListChecks,
+	Save,
+	Sparkles,
+	Trophy,
+	UserRound,
+	type LucideIcon,
+} from "lucide-react";
+import { type ReactNode, useState } from "react";
+
+import { AppPanel, AppPanelHeader } from "@/components/app-shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	createGithubSubtabPreviewContribution,
+	githubSubtabPreviewAvailableRepositories,
+	githubSubtabPreviewConnectedRepositories,
+	githubSubtabPreviewProjectGroup,
+	githubSubtabPreviewWeeklySummaries,
+} from "@/features/team/lib/github-subtab-preview";
+import type { ProjectGroupMember } from "@/lib/types/project-group";
+import type {
+	GithubRepository,
+	GithubRepositoryContributionResponse,
+	GithubRepositoryContributor,
+	GithubWeeklySummary,
+} from "@/lib/types/team-space";
+import { cn } from "@/lib/utils";
+import { formatDateTime } from "@/lib/utils/date";
+
+const contributionNumberFormatter = new Intl.NumberFormat("ko-KR");
+
+type GithubPreviewSubtabId = "contributions" | "weekly-summary" | "integration";
+
+const githubPreviewSubtabs: {
+	icon: LucideIcon;
+	id: GithubPreviewSubtabId;
+	label: string;
+}[] = [
+	{ icon: GitPullRequest, id: "contributions", label: "기여도" },
+	{ icon: Sparkles, id: "weekly-summary", label: "주간 요약" },
+	{ icon: Github, id: "integration", label: "연동" },
+];
+
+export function GithubSubtabsPreviewPanel() {
+	const [selectedSubtab, setSelectedSubtab] =
+		useState<GithubPreviewSubtabId>("contributions");
+
+	return (
+		<AppPanel>
+			<AppPanelHeader
+				action={<Badge variant="brand">preview</Badge>}
+				description="기여도, 주간 요약, 연동 설정을 분리해 확인해요."
+				eyebrow="GitHub App"
+				title="GitHub 운영"
+			/>
+			<div className="grid gap-5 p-5">
+				<GithubPreviewSubtabList
+					onSelectSubtab={setSelectedSubtab}
+					selectedSubtab={selectedSubtab}
+				/>
+
+				{selectedSubtab === "contributions" ? (
+					<GithubPreviewContributionsPanel
+						onOpenIntegration={() => setSelectedSubtab("integration")}
+					/>
+				) : null}
+
+				{selectedSubtab === "weekly-summary" ? (
+					<GithubPreviewWeeklySummariesPanel />
+				) : null}
+
+				{selectedSubtab === "integration" ? (
+					<GithubPreviewIntegrationPanel />
+				) : null}
+			</div>
+		</AppPanel>
+	);
+}
+
+function GithubPreviewSubtabList({
+	onSelectSubtab,
+	selectedSubtab,
+}: {
+	onSelectSubtab: (subtab: GithubPreviewSubtabId) => void;
+	selectedSubtab: GithubPreviewSubtabId;
+}) {
+	return (
+		<div
+			aria-label="GitHub 세부 보기"
+			className="grid gap-1 rounded-lg border border-border/70 bg-secondary/50 p-1 sm:grid-cols-3"
+			role="tablist"
+		>
+			{githubPreviewSubtabs.map(({ icon: Icon, id, label }) => {
+				const selected = selectedSubtab === id;
+
+				return (
+					<button
+						aria-selected={selected}
+						className={cn(
+							"flex h-11 min-w-0 items-center justify-center gap-2 rounded-md px-3 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+							selected
+								? "border border-primary/20 bg-white text-brand-ink shadow-crisp"
+								: "text-muted-foreground hover:bg-white/65 hover:text-brand-ink",
+						)}
+						key={id}
+						onClick={() => onSelectSubtab(id)}
+						role="tab"
+						type="button"
+					>
+						<Icon
+							className={cn(
+								"size-4 shrink-0",
+								selected ? "text-primary" : "text-muted-foreground",
+							)}
+						/>
+						<span className="truncate">{label}</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+function GithubPreviewContributionsPanel({
+	onOpenIntegration,
+}: {
+	onOpenIntegration: () => void;
+}) {
+	if (githubSubtabPreviewConnectedRepositories.length === 0) {
+		return (
+			<GithubPreviewEmptyState
+				action={
+					<Button onClick={onOpenIntegration} type="button" variant="outline">
+						<Github data-icon="inline-start" />
+						연동 설정
+					</Button>
+				}
+				description="연동 탭에서 GitHub App 설치와 저장소 선택을 마치면 저장소별 기여도가 표시돼요."
+				icon={GitPullRequest}
+				title="기여도를 보려면 GitHub 연동이 필요해요."
+			/>
+		);
+	}
+
+	return (
+		<div className="min-w-0 rounded-lg border border-border/70 bg-brand-warm p-5">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<p className="text-sm font-semibold text-brand-ink">연결된 저장소</p>
+					<p className="mt-1 text-sm leading-6 text-muted-foreground">
+						팀 스페이스에 등록된 GitHub 저장소예요.
+					</p>
+				</div>
+				<Badge variant="brand">
+					{githubSubtabPreviewConnectedRepositories.length}개
+				</Badge>
+			</div>
+
+			<div className="mt-4 grid min-w-0 gap-3">
+				{githubSubtabPreviewConnectedRepositories.map((repository) => (
+					<GithubPreviewRepositoryContributionCard
+						key={repository.githubRepositoryId}
+						repository={repository}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function GithubPreviewWeeklySummariesPanel() {
+	return (
+		<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<p className="text-sm font-semibold text-brand-ink">팀원 주간 요약</p>
+					<p className="mt-1 text-sm leading-6 text-muted-foreground">
+						GitHub PR과 이슈를 바탕으로 팀원별 최근 활동을 확인해요.
+					</p>
+				</div>
+				<div className="flex flex-wrap gap-2">
+					<Badge variant="brand">연결된 요약</Badge>
+					<Badge variant="neutral">
+						{githubSubtabPreviewProjectGroup.members.length}명
+					</Badge>
+				</div>
+			</div>
+
+			<div className="mt-4 grid gap-3 lg:grid-cols-2">
+				{githubSubtabPreviewProjectGroup.members.map((member) => (
+					<GithubPreviewWeeklySummaryCard key={member.userId} member={member} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+function GithubPreviewIntegrationPanel() {
+	const connectedRepositoryIds = new Set(
+		githubSubtabPreviewConnectedRepositories.map(
+			(repository) => repository.githubRepositoryId,
+		),
+	);
+
+	return (
+		<div className="grid gap-4">
+			<div className="grid gap-3 md:grid-cols-3">
+				<GithubPreviewStatusCard
+					label="Organization"
+					ready={true}
+					value="team-po-labs"
+				/>
+				<GithubPreviewStatusCard
+					label="Repositories"
+					ready={true}
+					value={`${githubSubtabPreviewConnectedRepositories.length}개`}
+				/>
+				<GithubPreviewStatusCard label="Permission" ready={true} value="HOST" />
+			</div>
+
+			<div className="flex flex-col gap-3 rounded-lg border border-border/70 bg-white p-4 shadow-crisp sm:flex-row sm:items-center sm:justify-between">
+				<div className="min-w-0">
+					<p className="text-sm font-semibold text-brand-ink">
+						TeamPo GitHub App
+					</p>
+					<p className="mt-1 text-sm leading-6 text-muted-foreground">
+						GitHub 조직이 팀 스페이스에 연결되어 있어요.
+					</p>
+				</div>
+				<Button disabled type="button">
+					<Github data-icon="inline-start" />
+					설치 URL 발급
+				</Button>
+			</div>
+
+			<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+					<div>
+						<p className="text-sm font-semibold text-brand-ink">저장소 설정</p>
+						<p className="mt-1 text-sm leading-6 text-muted-foreground">
+							GitHub App이 접근할 수 있는 저장소 중 집계할 대상을 선택해요.
+						</p>
+					</div>
+					<Badge className="whitespace-nowrap" variant="brand">
+						preview
+					</Badge>
+				</div>
+
+				<div className="mt-4 grid gap-3">
+					{githubSubtabPreviewAvailableRepositories.map((repository) => (
+						<GithubPreviewRepositoryOption
+							key={repository.githubRepositoryId}
+							repository={repository}
+							selected={connectedRepositoryIds.has(
+								repository.githubRepositoryId,
+							)}
+						/>
+					))}
+
+					<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+						<p className="text-xs leading-5 text-muted-foreground">
+							{githubSubtabPreviewConnectedRepositories.length}개 저장소 선택됨
+						</p>
+						<Button disabled type="button">
+							<Save data-icon="inline-start" />
+							저장소 설정 저장
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function GithubPreviewEmptyState({
+	action,
+	description,
+	icon: Icon,
+	title,
+}: {
+	action?: ReactNode;
+	description: string;
+	icon: LucideIcon;
+	title: string;
+}) {
+	return (
+		<div className="rounded-lg border border-dashed border-border bg-white p-6 text-center shadow-crisp">
+			<div className="mx-auto grid size-12 place-items-center rounded-lg bg-primary/10 text-primary">
+				<Icon className="size-5" />
+			</div>
+			<p className="mt-4 text-sm font-semibold text-brand-ink">{title}</p>
+			<p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+				{description}
+			</p>
+			{action ? <div className="mt-4 flex justify-center">{action}</div> : null}
+		</div>
+	);
+}
+
+function GithubPreviewWeeklySummaryCard({
+	member,
+}: {
+	member: ProjectGroupMember;
+}) {
+	const summary = githubSubtabPreviewWeeklySummaries[member.userId] ?? null;
+
+	return (
+		<div className="min-w-0 rounded-lg border border-border/70 bg-brand-warm p-4">
+			<div className="flex min-w-0 items-start gap-3">
+				<div className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+					<UserRound className="size-4" />
+				</div>
+				<div className="min-w-0 flex-1">
+					<div className="flex flex-wrap items-start justify-between gap-2">
+						<div className="min-w-0">
+							<p className="truncate font-semibold text-brand-ink">
+								{member.nickname}
+							</p>
+							<p className="mt-1 text-xs text-muted-foreground">
+								{member.memberRole}
+							</p>
+						</div>
+						{summary ? (
+							<Badge variant="brand">
+								PR {contributionNumberFormatter.format(summary.sourcePrCount)}
+							</Badge>
+						) : (
+							<Badge variant="neutral">요약 대기</Badge>
+						)}
+					</div>
+
+					{summary ? (
+						<GithubPreviewWeeklySummaryBody summary={summary} />
+					) : (
+						<p className="mt-4 rounded-md border border-dashed border-border bg-white/55 p-3 text-sm leading-6 text-muted-foreground">
+							아직 생성된 주간 요약이 없어요.
+						</p>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function GithubPreviewWeeklySummaryBody({
+	summary,
+}: {
+	summary: GithubWeeklySummary;
+}) {
+	return (
+		<div className="mt-4 grid gap-3">
+			<div className="rounded-md border border-primary/15 bg-white/75 p-3">
+				<p className="text-xs font-semibold text-primary">
+					{formatDateTime(summary.periodStart)} -{" "}
+					{formatDateTime(summary.periodEnd)}
+				</p>
+				<p className="mt-2 text-sm leading-6 text-brand-ink">
+					{summary.summary.summary}
+				</p>
+			</div>
+
+			<div className="grid gap-2 sm:grid-cols-2">
+				<GithubPreviewContributionStat
+					icon={GitPullRequest}
+					label="원천 PR"
+					value={summary.sourcePrCount}
+				/>
+				<GithubPreviewContributionStat
+					icon={ListChecks}
+					label="원천 이슈"
+					value={summary.sourceIssueCount}
+				/>
+			</div>
+
+			<GithubPreviewSummaryList
+				items={summary.summary.mainActivities}
+				title="주요 활동"
+			/>
+			<GithubPreviewSummaryList
+				items={summary.summary.followUpSuggestions}
+				title="다음 액션"
+			/>
+		</div>
+	);
+}
+
+function GithubPreviewSummaryList({
+	items,
+	title,
+}: {
+	items: string[];
+	title: string;
+}) {
+	if (items.length === 0) {
+		return null;
+	}
+
+	return (
+		<div>
+			<p className="text-xs font-semibold text-muted-foreground">{title}</p>
+			<ul className="mt-2 grid gap-1.5">
+				{items.slice(0, 3).map((item) => (
+					<li
+						className="flex gap-2 text-sm leading-6 text-brand-ink"
+						key={item}
+					>
+						<Sparkles className="mt-1 size-3.5 shrink-0 text-primary/70" />
+						<span>{item}</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+function GithubPreviewStatusCard({
+	label,
+	ready,
+	value,
+}: {
+	label: string;
+	ready: boolean;
+	value: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"rounded-lg border p-4 shadow-crisp",
+				ready ? "border-primary/20 bg-primary/5" : "border-border/70 bg-white",
+			)}
+		>
+			<div className="flex items-center justify-between gap-3">
+				<p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+					{label}
+				</p>
+				<Badge variant={ready ? "brand" : "neutral"}>
+					{ready ? "ready" : "pending"}
+				</Badge>
+			</div>
+			<p className="mt-3 truncate text-sm font-semibold text-brand-ink">
+				{value}
+			</p>
+		</div>
+	);
+}
+
+function GithubPreviewRepositoryContributionCard({
+	repository,
+}: {
+	repository: GithubRepository;
+}) {
+	const contribution = createGithubSubtabPreviewContribution(repository);
+	const sortedContributors = [...contribution.contributors].sort(
+		(left, right) => right.contributionScore - left.contributionScore,
+	);
+	const totals = calculateGithubContributionTotals(contribution);
+
+	return (
+		<div className="min-w-0 overflow-hidden rounded-lg border border-primary/15 bg-white p-4 shadow-crisp">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<a
+					className="min-w-0"
+					href={`https://github.com/${repository.fullName}`}
+					rel="noreferrer"
+					target="_blank"
+				>
+					<span className="flex min-w-0 items-center gap-2">
+						<span className="truncate font-mono text-sm font-semibold text-primary">
+							{repository.fullName}
+						</span>
+						<ExternalLink className="size-4 shrink-0 text-primary" />
+					</span>
+					<span className="mt-1 block text-xs text-muted-foreground">
+						{repository.repoName}
+					</span>
+				</a>
+				<Button
+					className="shrink-0"
+					disabled
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					PR 동기화
+				</Button>
+			</div>
+
+			<div className="mt-4 grid gap-4">
+				<GithubPreviewContributionOverview
+					topContributor={sortedContributors[0] ?? null}
+					totals={totals}
+				/>
+
+				<div className="grid grid-cols-3 gap-2">
+					<GithubPreviewContributionStat
+						icon={GitPullRequest}
+						label="PR"
+						value={totals.mergedPrCount}
+					/>
+					<GithubPreviewContributionStat
+						icon={ListChecks}
+						label="이슈"
+						value={totals.linkedIssueCount}
+					/>
+					<GithubPreviewContributionStat
+						icon={FileDiff}
+						label="파일"
+						value={totals.changedFiles}
+					/>
+				</div>
+
+				<div className="grid gap-2">
+					{sortedContributors.map((contributor, index) => (
+						<GithubPreviewContributorRow
+							contributor={contributor}
+							key={`${contributor.userId}-${contributor.githubUserId}`}
+							maxContributionScore={totals.highestContributionScore}
+							rank={index + 1}
+						/>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function calculateGithubContributionTotals(
+	contribution: GithubRepositoryContributionResponse,
+) {
+	return contribution.contributors.reduce(
+		(totals, contributor) => ({
+			changedFiles: totals.changedFiles + contributor.changedFiles,
+			highestContributionScore: Math.max(
+				totals.highestContributionScore,
+				contributor.contributionScore,
+			),
+			contributionScore:
+				totals.contributionScore + contributor.contributionScore,
+			linkedIssueCount: totals.linkedIssueCount + contributor.linkedIssueCount,
+			mergedPrCount: totals.mergedPrCount + contributor.mergedPrCount,
+		}),
+		{
+			changedFiles: 0,
+			highestContributionScore: 0,
+			contributionScore: 0,
+			linkedIssueCount: 0,
+			mergedPrCount: 0,
+		},
+	);
+}
+
+function calculateContributionSharePercent({
+	contributionScore,
+	maxContributionScore,
+}: {
+	contributionScore: number;
+	maxContributionScore: number;
+}) {
+	if (maxContributionScore <= 0 || contributionScore <= 0) {
+		return 0;
+	}
+
+	return Math.round((contributionScore / maxContributionScore) * 100);
+}
+
+function getContributionShareClass(sharePercent: number) {
+	if (sharePercent >= 92) {
+		return "w-full";
+	}
+
+	if (sharePercent >= 78) {
+		return "w-5/6";
+	}
+
+	if (sharePercent >= 62) {
+		return "w-2/3";
+	}
+
+	if (sharePercent >= 46) {
+		return "w-1/2";
+	}
+
+	if (sharePercent >= 30) {
+		return "w-1/3";
+	}
+
+	if (sharePercent > 0) {
+		return "w-1/5";
+	}
+
+	return "w-0";
+}
+
+function getRepositoryScoreFillClass(contributionScore: number) {
+	if (contributionScore >= 100) {
+		return "w-full";
+	}
+
+	if (contributionScore >= 80) {
+		return "w-5/6";
+	}
+
+	if (contributionScore >= 60) {
+		return "w-2/3";
+	}
+
+	if (contributionScore >= 35) {
+		return "w-1/2";
+	}
+
+	if (contributionScore > 0) {
+		return "w-1/3";
+	}
+
+	return "w-0";
+}
+
+function GithubPreviewContributionOverview({
+	topContributor,
+	totals,
+}: {
+	topContributor: GithubRepositoryContributor | null;
+	totals: ReturnType<typeof calculateGithubContributionTotals>;
+}) {
+	const scoreFillClass = getRepositoryScoreFillClass(totals.contributionScore);
+
+	return (
+		<div className="relative overflow-hidden rounded-lg border border-primary/20 bg-[linear-gradient(135deg,hsl(var(--primary)/0.13),hsl(var(--accent)/0.07)_48%,rgb(255_255_255)_100%)] p-4 shadow-[inset_0_1px_0_rgb(255_255_255_/_0.82),0_14px_30px_rgb(37_99_235_/_0.08)]">
+			<div className="relative">
+				<div className="min-w-0">
+					<p className="flex items-center gap-1.5 text-xs font-semibold text-primary">
+						<Sparkles
+							aria-hidden="true"
+							className="size-3.5 shrink-0 text-primary/60"
+						/>
+						기여도 점수
+					</p>
+					<div className="mt-2 flex flex-wrap items-end gap-x-3 gap-y-1">
+						<p className="font-mono text-3xl font-semibold leading-none text-brand-ink">
+							{contributionNumberFormatter.format(totals.contributionScore)}
+						</p>
+						<p className="text-xs leading-5 text-muted-foreground">
+							PR {contributionNumberFormatter.format(totals.mergedPrCount)} ·
+							이슈 {contributionNumberFormatter.format(totals.linkedIssueCount)}
+						</p>
+					</div>
+				</div>
+
+				<div
+					aria-hidden="true"
+					className="mt-4 h-1.5 overflow-hidden rounded-full bg-white/85 ring-1 ring-primary/10"
+				>
+					<div
+						className={cn(
+							"h-full rounded-full bg-gradient-to-r from-primary to-accent",
+							scoreFillClass,
+						)}
+					/>
+				</div>
+
+				<div className="mt-4 rounded-md border border-white/80 bg-white/75 px-3 py-2 shadow-sm">
+					{topContributor ? (
+						<div className="flex min-w-0 items-center gap-2">
+							<Trophy className="size-4 shrink-0 text-primary" />
+							<p className="min-w-0 truncate text-xs font-semibold text-brand-ink">
+								@{topContributor.githubUsername}
+							</p>
+							<span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+								선두 ·{" "}
+								{contributionNumberFormatter.format(
+									topContributor.contributionScore,
+								)}
+								점
+							</span>
+						</div>
+					) : (
+						<p className="text-xs leading-5 text-muted-foreground">
+							동기화 후 팀원별 PR 기여도가 여기에 표시돼요.
+						</p>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function GithubPreviewContributionStat({
+	icon: Icon,
+	label,
+	value,
+}: {
+	icon: LucideIcon;
+	label: string;
+	value: number;
+}) {
+	return (
+		<div className="min-w-0 rounded-md border border-border/70 bg-secondary/25 p-3">
+			<div className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
+				<Icon className="size-3.5 shrink-0" />
+				<p className="min-w-0 text-[11px] font-semibold leading-4">{label}</p>
+			</div>
+			<p className="mt-2 truncate font-mono text-sm font-semibold text-brand-ink">
+				{contributionNumberFormatter.format(value)}
+			</p>
+		</div>
+	);
+}
+
+function GithubPreviewContributorRow({
+	contributor,
+	maxContributionScore,
+	rank,
+}: {
+	contributor: GithubRepositoryContributor;
+	maxContributionScore: number;
+	rank: number;
+}) {
+	const sharePercent = calculateContributionSharePercent({
+		contributionScore: contributor.contributionScore,
+		maxContributionScore,
+	});
+	const shareClass = getContributionShareClass(sharePercent);
+
+	return (
+		<div className="rounded-lg border border-border/70 bg-white p-3 shadow-sm">
+			<div className="flex min-w-0 gap-3">
+				<div
+					className={cn(
+						"flex size-8 shrink-0 items-center justify-center rounded-lg border font-mono text-xs font-semibold",
+						rank === 1
+							? "border-primary/25 bg-primary/10 text-primary"
+							: "border-border/70 bg-secondary text-muted-foreground",
+					)}
+				>
+					{rank === 1 ? <Trophy className="size-4" /> : rank}
+				</div>
+				<div className="min-w-0 flex-1">
+					<div className="flex min-w-0 flex-col gap-2 min-[440px]:flex-row min-[440px]:items-start min-[440px]:justify-between">
+						<div className="min-w-0">
+							<p className="truncate text-sm font-semibold text-brand-ink">
+								@{contributor.githubUsername}
+							</p>
+							<p className="mt-1 text-xs text-muted-foreground">
+								PR{" "}
+								{contributionNumberFormatter.format(contributor.mergedPrCount)}{" "}
+								· 이슈{" "}
+								{contributionNumberFormatter.format(
+									contributor.linkedIssueCount,
+								)}
+							</p>
+						</div>
+						<Badge
+							className="w-fit whitespace-nowrap"
+							variant={rank === 1 ? "brand" : "neutral"}
+						>
+							{contributionNumberFormatter.format(
+								contributor.contributionScore,
+							)}
+							점
+						</Badge>
+					</div>
+
+					<div
+						aria-label={`기여도 선두 대비 ${sharePercent}%`}
+						aria-valuemax={100}
+						aria-valuemin={0}
+						aria-valuenow={sharePercent}
+						className="mt-3 h-2 overflow-hidden rounded-full bg-secondary"
+						role="progressbar"
+					>
+						<div
+							className={cn(
+								"h-full rounded-full bg-gradient-to-r from-primary to-accent",
+								shareClass,
+							)}
+						/>
+					</div>
+
+					<dl className="mt-3 grid grid-cols-2 gap-2 min-[520px]:grid-cols-4">
+						<GithubPreviewContributorMetric
+							label="추가"
+							tone="positive"
+							value={`+${contributionNumberFormatter.format(
+								contributor.additions,
+							)}`}
+						/>
+						<GithubPreviewContributorMetric
+							label="삭제"
+							tone="negative"
+							value={`-${contributionNumberFormatter.format(
+								contributor.deletions,
+							)}`}
+						/>
+						<GithubPreviewContributorMetric
+							label="파일"
+							value={contributionNumberFormatter.format(
+								contributor.changedFiles,
+							)}
+						/>
+						<GithubPreviewContributorMetric
+							label="비중"
+							value={`${sharePercent}%`}
+						/>
+					</dl>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function GithubPreviewContributorMetric({
+	label,
+	tone = "neutral",
+	value,
+}: {
+	label: string;
+	tone?: "negative" | "neutral" | "positive";
+	value: string;
+}) {
+	const toneClass = {
+		negative: "text-destructive",
+		neutral: "text-brand-ink",
+		positive: "text-chart-3",
+	}[tone];
+
+	return (
+		<div className="min-w-0 rounded-md bg-secondary/50 px-2.5 py-2">
+			<dt className="text-[11px] font-medium text-muted-foreground">{label}</dt>
+			<dd className={cn("mt-0.5 truncate font-mono text-xs", toneClass)}>
+				{value}
+			</dd>
+		</div>
+	);
+}
+
+function GithubPreviewRepositoryOption({
+	repository,
+	selected,
+}: {
+	repository: GithubRepository;
+	selected: boolean;
+}) {
+	return (
+		<label
+			className={cn(
+				"flex cursor-not-allowed items-start gap-3 rounded-lg border p-4 opacity-80 shadow-crisp",
+				selected
+					? "border-primary/30 bg-primary/5"
+					: "border-border/70 bg-white",
+			)}
+		>
+			<input
+				checked={selected}
+				className="mt-1 size-4 rounded border-border text-primary"
+				disabled
+				readOnly
+				type="checkbox"
+			/>
+			<span className="min-w-0 flex-1">
+				<span className="block truncate text-sm font-semibold text-brand-ink">
+					{repository.fullName}
+				</span>
+				<span className="mt-1 block text-xs text-muted-foreground">
+					{repository.repoName}
+				</span>
+			</span>
+			<Badge className="shrink-0" variant={selected ? "brand" : "neutral"}>
+				{selected ? "selected" : "available"}
+			</Badge>
+		</label>
+	);
+}

--- a/src/features/team/components/real-github-installation-panel.tsx
+++ b/src/features/team/components/real-github-installation-panel.tsx
@@ -12,7 +12,7 @@ import {
 	UserRound,
 	type LucideIcon,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
 import { AppPanel, AppPanelHeader } from "@/components/app-shell";
 import { Badge } from "@/components/ui/badge";
@@ -48,6 +48,18 @@ import { formatDateTime } from "@/lib/utils/date";
 
 const contributionNumberFormatter = new Intl.NumberFormat("ko-KR");
 
+type GithubSubtabId = "contributions" | "weekly-summary" | "integration";
+
+const githubSubtabs: {
+	icon: LucideIcon;
+	id: GithubSubtabId;
+	label: string;
+}[] = [
+	{ icon: GitPullRequest, id: "contributions", label: "기여도" },
+	{ icon: Sparkles, id: "weekly-summary", label: "주간 요약" },
+	{ icon: Github, id: "integration", label: "연동" },
+];
+
 function areNumberSelectionsEqual(left: number[], right: number[]) {
 	if (left.length !== right.length) {
 		return false;
@@ -81,16 +93,22 @@ export function RealGithubInstallationPanel({
 	);
 	const createInstallUrlMutation = useCreateGithubAppInstallationUrlMutation();
 	const setGithubRepositoriesMutation = useSetGithubRepositoriesMutation();
+	const [selectedGithubSubtab, setSelectedGithubSubtab] =
+		useState<GithubSubtabId>("contributions");
 	const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
 	const githubStatus = githubStatusQuery.data;
 	const isGithubConnected = githubStatus?.connected === true;
+	const shouldLoadGithubRepositories =
+		isGithubConnected && selectedGithubSubtab !== "weekly-summary";
 	const githubRepositoriesQuery = useGithubRepositoriesQuery(
 		projectGroup.projectGroupId,
-		isGithubConnected,
+		shouldLoadGithubRepositories,
 	);
 	const availableGithubRepositoriesQuery = useAvailableGithubRepositoriesQuery(
 		projectGroup.projectGroupId,
-		isGithubConnected && canManageGithubInstallation,
+		isGithubConnected &&
+			canManageGithubInstallation &&
+			selectedGithubSubtab === "integration",
 	);
 	const connectedRepositories =
 		githubRepositoriesQuery.data?.repositories ?? [];
@@ -151,6 +169,7 @@ export function RealGithubInstallationPanel({
 		canChangeGithubRepositories &&
 		hasRepositorySelectionChanged;
 	const showGithubPolicyNotice =
+		selectedGithubSubtab === "integration" &&
 		githubStatusQuery.isSuccess &&
 		canManageGithubInstallation &&
 		!hasGithubRepositorySelection;
@@ -211,6 +230,11 @@ export function RealGithubInstallationPanel({
 		);
 	}
 
+	function handleGithubSubtabSelect(subtab: GithubSubtabId) {
+		setSelectedGithubSubtab(subtab);
+		setFeedback(null);
+	}
+
 	return (
 		<AppPanel>
 			<AppPanelHeader
@@ -219,9 +243,9 @@ export function RealGithubInstallationPanel({
 						{githubStatus?.connected ? "connected" : "not connected"}
 					</Badge>
 				}
-				description="GitHub 조직과 저장소 연결 상태를 확인해요."
+				description="기여도, 주간 요약, 연동 설정을 분리해 확인해요."
 				eyebrow="GitHub App"
-				title="GitHub 조직 연결"
+				title="GitHub 운영"
 			/>
 			<div className="grid gap-5 p-5">
 				<RealActionFeedback feedback={completionFeedback ?? feedback} />
@@ -243,53 +267,13 @@ export function RealGithubInstallationPanel({
 					/>
 				) : null}
 
-				<div className="grid gap-3 md:grid-cols-3">
-					<RealGithubStatusCard
-						label="Organization"
-						ready={githubStatus?.connected === true}
-						value={githubStatus?.organizationLogin ?? "연결 전"}
-					/>
-					<RealGithubStatusCard
-						label="Repositories"
-						ready={hasGithubRepositorySelection}
-						value={`${githubStatus?.repositoryCount ?? 0}개`}
-					/>
-					<RealGithubStatusCard
-						label="Permission"
-						ready={canManageGithubInstallation}
-						value={canManageGithubInstallation ? "HOST" : "READ ONLY"}
-					/>
-				</div>
+				<RealGithubSubtabList
+					onSelectSubtab={handleGithubSubtabSelect}
+					selectedSubtab={selectedGithubSubtab}
+				/>
 
-				{showGithubPolicyNotice ? <GithubOrganizationPolicyNotice /> : null}
-
-				<div className="flex flex-col gap-3 rounded-lg border border-border/70 bg-white p-4 shadow-crisp sm:flex-row sm:items-center sm:justify-between">
-					<div className="min-w-0">
-						<p className="text-sm font-semibold text-brand-ink">
-							TeamPo GitHub App
-						</p>
-						<p className="mt-1 text-sm leading-6 text-muted-foreground">
-							{githubStatus?.connected
-								? "GitHub 조직이 팀 스페이스에 연결되어 있어요."
-								: "호스트가 GitHub App 설치를 시작할 수 있어요."}
-						</p>
-					</div>
-					<Button
-						disabled={!canCreateInstallUrl}
-						onClick={handleCreateInstallUrl}
-						type="button"
-					>
-						{createInstallUrlMutation.isPending ? (
-							<LoaderCircle className="animate-spin" data-icon="inline-start" />
-						) : (
-							<Github data-icon="inline-start" />
-						)}
-						설치 URL 발급
-					</Button>
-				</div>
-
-				{isGithubConnected ? (
-					<div className="grid gap-4">
+				{selectedGithubSubtab === "contributions" ? (
+					isGithubConnected ? (
 						<div className="min-w-0 rounded-lg border border-border/70 bg-brand-warm p-5">
 							<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 								<div>
@@ -342,114 +326,255 @@ export function RealGithubInstallationPanel({
 								))}
 							</div>
 						</div>
-
-						<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
-							<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-								<div>
-									<p className="text-sm font-semibold text-brand-ink">
-										저장소 설정
-									</p>
-									<p className="mt-1 text-sm leading-6 text-muted-foreground">
-										GitHub App이 접근할 수 있는 저장소 중 집계할 대상을
-										선택해요.
-									</p>
-								</div>
-								<Badge
-									className="whitespace-nowrap"
-									variant={canManageGithubInstallation ? "brand" : "neutral"}
+					) : (
+						<RealGithubSubtabEmptyState
+							action={
+								<Button
+									onClick={() => handleGithubSubtabSelect("integration")}
+									type="button"
+									variant="outline"
 								>
-									{canManageGithubInstallation ? "editable" : "read only"}
-								</Badge>
-							</div>
-
-							{canManageGithubInstallation ? (
-								<div className="mt-4 grid gap-3">
-									{availableGithubRepositoriesQuery.isLoading ? (
-										<RealInlineStatus
-											icon={<LoaderCircle className="size-4 animate-spin" />}
-											message="선택 가능한 저장소를 불러오고 있어요."
-										/>
-									) : null}
-
-									{availableGithubRepositoriesQuery.error ? (
-										<RealInlineStatus
-											message={getApiErrorMessage(
-												availableGithubRepositoriesQuery.error,
-											)}
-										/>
-									) : null}
-
-									{availableGithubRepositoriesQuery.isSuccess &&
-									availableRepositories.length === 0 ? (
-										<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4">
-											<p className="text-sm leading-6 text-muted-foreground">
-												GitHub App이 접근할 수 있는 저장소가 없어요.
-											</p>
-										</div>
-									) : null}
-
-									{configurableRepositories.map((repository) => {
-										const selected = selectedGithubRepositoryIdSet.has(
-											repository.githubRepositoryId,
-										);
-										const available = availableGithubRepositoryIdSet.has(
-											repository.githubRepositoryId,
-										);
-
-										return (
-											<RealGithubRepositoryOption
-												disabled={
-													!canChangeGithubRepositories ||
-													(!available && !selected)
-												}
-												key={repository.githubRepositoryId}
-												onToggle={handleGithubRepositoryToggle}
-												repository={repository}
-												selected={selected}
-												unavailable={!available}
-											/>
-										);
-									})}
-
-									<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-										<p className="text-xs leading-5 text-muted-foreground">
-											{selectedGithubRepositoryIds.length}개 저장소 선택됨
-										</p>
-										<Button
-											disabled={!canSaveGithubRepositories}
-											onClick={handleSaveGithubRepositories}
-											type="button"
-										>
-											{setGithubRepositoriesMutation.isPending ? (
-												<LoaderCircle
-													className="animate-spin"
-													data-icon="inline-start"
-												/>
-											) : (
-												<Save data-icon="inline-start" />
-											)}
-											저장소 설정 저장
-										</Button>
-									</div>
-								</div>
-							) : (
-								<div className="mt-4 rounded-lg border border-dashed border-border bg-secondary/30 p-4">
-									<p className="text-sm leading-6 text-muted-foreground">
-										호스트만 GitHub 저장소 설정을 변경할 수 있어요.
-									</p>
-								</div>
-							)}
-						</div>
-					</div>
+									<Github data-icon="inline-start" />
+									연동 설정
+								</Button>
+							}
+							description="연동 탭에서 GitHub App 설치와 저장소 선택을 마치면 저장소별 기여도가 표시돼요."
+							icon={GitPullRequest}
+							title="기여도를 보려면 GitHub 연동이 필요해요."
+						/>
+					)
 				) : null}
 
-				<RealGithubWeeklySummariesPanel
-					isGithubConnected={isGithubConnected}
-					members={projectGroup.members}
-					projectGroupId={projectGroup.projectGroupId}
-				/>
+				{selectedGithubSubtab === "weekly-summary" ? (
+					<RealGithubWeeklySummariesPanel
+						isGithubConnected={isGithubConnected}
+						members={projectGroup.members}
+						projectGroupId={projectGroup.projectGroupId}
+					/>
+				) : null}
+
+				{selectedGithubSubtab === "integration" ? (
+					<div className="grid gap-4">
+						<div className="grid gap-3 md:grid-cols-3">
+							<RealGithubStatusCard
+								label="Organization"
+								ready={githubStatus?.connected === true}
+								value={githubStatus?.organizationLogin ?? "연결 전"}
+							/>
+							<RealGithubStatusCard
+								label="Repositories"
+								ready={hasGithubRepositorySelection}
+								value={`${githubStatus?.repositoryCount ?? 0}개`}
+							/>
+							<RealGithubStatusCard
+								label="Permission"
+								ready={canManageGithubInstallation}
+								value={canManageGithubInstallation ? "HOST" : "READ ONLY"}
+							/>
+						</div>
+
+						{showGithubPolicyNotice ? <GithubOrganizationPolicyNotice /> : null}
+
+						<div className="flex flex-col gap-3 rounded-lg border border-border/70 bg-white p-4 shadow-crisp sm:flex-row sm:items-center sm:justify-between">
+							<div className="min-w-0">
+								<p className="text-sm font-semibold text-brand-ink">
+									TeamPo GitHub App
+								</p>
+								<p className="mt-1 text-sm leading-6 text-muted-foreground">
+									{githubStatus?.connected
+										? "GitHub 조직이 팀 스페이스에 연결되어 있어요."
+										: "호스트가 GitHub App 설치를 시작할 수 있어요."}
+								</p>
+							</div>
+							<Button
+								disabled={!canCreateInstallUrl}
+								onClick={handleCreateInstallUrl}
+								type="button"
+							>
+								{createInstallUrlMutation.isPending ? (
+									<LoaderCircle
+										className="animate-spin"
+										data-icon="inline-start"
+									/>
+								) : (
+									<Github data-icon="inline-start" />
+								)}
+								설치 URL 발급
+							</Button>
+						</div>
+
+						{isGithubConnected ? (
+							<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+								<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+									<div>
+										<p className="text-sm font-semibold text-brand-ink">
+											저장소 설정
+										</p>
+										<p className="mt-1 text-sm leading-6 text-muted-foreground">
+											GitHub App이 접근할 수 있는 저장소 중 집계할 대상을
+											선택해요.
+										</p>
+									</div>
+									<Badge
+										className="whitespace-nowrap"
+										variant={canManageGithubInstallation ? "brand" : "neutral"}
+									>
+										{canManageGithubInstallation ? "editable" : "read only"}
+									</Badge>
+								</div>
+
+								{canManageGithubInstallation ? (
+									<div className="mt-4 grid gap-3">
+										{availableGithubRepositoriesQuery.isLoading ? (
+											<RealInlineStatus
+												icon={<LoaderCircle className="size-4 animate-spin" />}
+												message="선택 가능한 저장소를 불러오고 있어요."
+											/>
+										) : null}
+
+										{availableGithubRepositoriesQuery.error ? (
+											<RealInlineStatus
+												message={getApiErrorMessage(
+													availableGithubRepositoriesQuery.error,
+												)}
+											/>
+										) : null}
+
+										{availableGithubRepositoriesQuery.isSuccess &&
+										availableRepositories.length === 0 ? (
+											<div className="rounded-lg border border-dashed border-border bg-secondary/30 p-4">
+												<p className="text-sm leading-6 text-muted-foreground">
+													GitHub App이 접근할 수 있는 저장소가 없어요.
+												</p>
+											</div>
+										) : null}
+
+										{configurableRepositories.map((repository) => {
+											const selected = selectedGithubRepositoryIdSet.has(
+												repository.githubRepositoryId,
+											);
+											const available = availableGithubRepositoryIdSet.has(
+												repository.githubRepositoryId,
+											);
+
+											return (
+												<RealGithubRepositoryOption
+													disabled={
+														!canChangeGithubRepositories ||
+														(!available && !selected)
+													}
+													key={repository.githubRepositoryId}
+													onToggle={handleGithubRepositoryToggle}
+													repository={repository}
+													selected={selected}
+													unavailable={!available}
+												/>
+											);
+										})}
+
+										<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+											<p className="text-xs leading-5 text-muted-foreground">
+												{selectedGithubRepositoryIds.length}개 저장소 선택됨
+											</p>
+											<Button
+												disabled={!canSaveGithubRepositories}
+												onClick={handleSaveGithubRepositories}
+												type="button"
+											>
+												{setGithubRepositoriesMutation.isPending ? (
+													<LoaderCircle
+														className="animate-spin"
+														data-icon="inline-start"
+													/>
+												) : (
+													<Save data-icon="inline-start" />
+												)}
+												저장소 설정 저장
+											</Button>
+										</div>
+									</div>
+								) : (
+									<div className="mt-4 rounded-lg border border-dashed border-border bg-secondary/30 p-4">
+										<p className="text-sm leading-6 text-muted-foreground">
+											호스트만 GitHub 저장소 설정을 변경할 수 있어요.
+										</p>
+									</div>
+								)}
+							</div>
+						) : null}
+					</div>
+				) : null}
 			</div>
 		</AppPanel>
+	);
+}
+
+function RealGithubSubtabList({
+	onSelectSubtab,
+	selectedSubtab,
+}: {
+	onSelectSubtab: (subtab: GithubSubtabId) => void;
+	selectedSubtab: GithubSubtabId;
+}) {
+	return (
+		<div
+			aria-label="GitHub 세부 보기"
+			className="grid gap-1 rounded-lg border border-border/70 bg-secondary/50 p-1 sm:grid-cols-3"
+			role="tablist"
+		>
+			{githubSubtabs.map(({ icon: Icon, id, label }) => {
+				const selected = selectedSubtab === id;
+
+				return (
+					<button
+						aria-selected={selected}
+						className={cn(
+							"flex h-11 min-w-0 items-center justify-center gap-2 rounded-md px-3 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+							selected
+								? "border border-primary/20 bg-white text-brand-ink shadow-crisp"
+								: "text-muted-foreground hover:bg-white/65 hover:text-brand-ink",
+						)}
+						key={id}
+						onClick={() => onSelectSubtab(id)}
+						role="tab"
+						type="button"
+					>
+						<Icon
+							className={cn(
+								"size-4 shrink-0",
+								selected ? "text-primary" : "text-muted-foreground",
+							)}
+						/>
+						<span className="truncate">{label}</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+function RealGithubSubtabEmptyState({
+	action,
+	description,
+	icon: Icon,
+	title,
+}: {
+	action?: ReactNode;
+	description: string;
+	icon: LucideIcon;
+	title: string;
+}) {
+	return (
+		<div className="rounded-lg border border-dashed border-border bg-white p-6 text-center shadow-crisp">
+			<div className="mx-auto grid size-12 place-items-center rounded-lg bg-primary/10 text-primary">
+				<Icon className="size-5" />
+			</div>
+			<p className="mt-4 text-sm font-semibold text-brand-ink">{title}</p>
+			<p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+				{description}
+			</p>
+			{action ? <div className="mt-4 flex justify-center">{action}</div> : null}
+		</div>
 	);
 }
 

--- a/src/features/team/components/real-github-installation-panel.tsx
+++ b/src/features/team/components/real-github-installation-panel.tsx
@@ -309,10 +309,28 @@ export function RealGithubInstallationPanel({
 
 								{githubRepositoriesQuery.isSuccess &&
 								connectedRepositories.length === 0 ? (
-									<div className="rounded-lg border border-dashed border-border bg-white/65 p-4">
-										<p className="text-sm leading-6 text-muted-foreground">
-											아직 팀 스페이스에 등록된 GitHub 저장소가 없어요.
-										</p>
+									<div className="flex flex-col gap-3 rounded-lg border border-dashed border-border bg-white/65 p-4 sm:flex-row sm:items-center sm:justify-between">
+										<div>
+											<p className="text-sm font-semibold text-brand-ink">
+												등록된 GitHub 저장소가 없어요.
+											</p>
+											<p className="mt-1 text-sm leading-6 text-muted-foreground">
+												{canManageGithubInstallation
+													? "연동 설정에서 집계할 저장소를 선택하면 기여도가 표시돼요."
+													: "호스트가 연동 설정에서 집계할 저장소를 선택해야 해요."}
+											</p>
+										</div>
+										{canManageGithubInstallation ? (
+											<Button
+												className="shrink-0"
+												onClick={() => handleGithubSubtabSelect("integration")}
+												type="button"
+												variant="outline"
+											>
+												<Github data-icon="inline-start" />
+												연동 설정
+											</Button>
+										) : null}
 									</div>
 								) : null}
 

--- a/src/features/team/components/real-github-installation-panel.tsx
+++ b/src/features/team/components/real-github-installation-panel.tsx
@@ -173,6 +173,11 @@ export function RealGithubInstallationPanel({
 		githubStatusQuery.isSuccess &&
 		canManageGithubInstallation &&
 		!hasGithubRepositorySelection;
+	const shouldOpenGithubRepositorySetup =
+		githubStatusQuery.isSuccess &&
+		isGithubConnected &&
+		canManageGithubInstallation &&
+		!hasGithubRepositorySelection;
 
 	useEffect(() => {
 		if (!githubRepositoriesQuery.data) {
@@ -181,6 +186,16 @@ export function RealGithubInstallationPanel({
 
 		setSelectedGithubRepositoryIds(connectedRepositoryIds);
 	}, [connectedRepositoryIds, githubRepositoriesQuery.data]);
+
+	useEffect(() => {
+		if (!shouldOpenGithubRepositorySetup) {
+			return;
+		}
+
+		setSelectedGithubSubtab((current) =>
+			current === "contributions" ? "integration" : current,
+		);
+	}, [shouldOpenGithubRepositorySetup]);
 
 	function handleCreateInstallUrl() {
 		setFeedback(null);

--- a/src/features/team/lib/github-subtab-preview.ts
+++ b/src/features/team/lib/github-subtab-preview.ts
@@ -1,0 +1,101 @@
+import type { MyProjectGroup } from "@/lib/types/project-group";
+import type { GithubRepository } from "@/lib/types/team-space";
+
+export const githubSubtabPreviewProjectGroup = {
+	currentUserId: 1,
+	members: [
+		{
+			admin: true,
+			groupRole: "HOST",
+			level: 3,
+			memberRole: "FRONTEND",
+			nickname: "queue_runner",
+			profileImage: "https://i.pravatar.cc/240?img=12",
+			temperature: 50,
+			userId: 1,
+		},
+		{
+			admin: false,
+			groupRole: "MEMBER",
+			level: 4,
+			memberRole: "BACKEND",
+			nickname: "api_builder",
+			profileImage: null,
+			temperature: 53,
+			userId: 2,
+		},
+		{
+			admin: false,
+			groupRole: "MEMBER",
+			level: 3,
+			memberRole: "FRONTEND",
+			nickname: "pixel_runner",
+			profileImage: null,
+			temperature: 49,
+			userId: 3,
+		},
+	],
+	projectDescription:
+		"랜덤 팀 매칭 이후 팀이 바로 움직일 수 있도록 규칙과 체크리스트를 정리합니다.",
+	projectGroupId: 10,
+	projectMvp: "매칭 요청, 수락/거절, 팀 스페이스 홈, 첫 체크리스트 운영",
+	projectName: "Blue Sprint",
+	projectTitle: "Team-po 팀 운영 MVP",
+} satisfies MyProjectGroup;
+
+export const githubSubtabPreviewAvailableRepositories: GithubRepository[] = [
+	{
+		fullName: "team-po-labs/client",
+		githubRepositoryId: 100,
+		repoName: "client",
+	},
+	{
+		fullName: "team-po-labs/server",
+		githubRepositoryId: 200,
+		repoName: "server",
+	},
+	{
+		fullName: "team-po-labs/product-notes",
+		githubRepositoryId: 300,
+		repoName: "product-notes",
+	},
+];
+
+export const githubSubtabPreviewConnectedRepositories =
+	githubSubtabPreviewAvailableRepositories.slice(0, 2);
+
+export function createGithubSubtabPreviewContribution(
+	repository: GithubRepository,
+) {
+	const isServerRepository = repository.githubRepositoryId === 200;
+
+	return {
+		contributors: [
+			{
+				additions: isServerRepository ? 1240 : 860,
+				changedFiles: isServerRepository ? 42 : 34,
+				contributionScore: isServerRepository ? 55 : 40,
+				deletions: isServerRepository ? 310 : 190,
+				githubUserId: isServerRepository ? 503 : 501,
+				githubUsername: isServerRepository ? "server-runner" : "dev-a",
+				linkedIssueCount: isServerRepository ? 3 : 2,
+				mergedPrCount: isServerRepository ? 4 : 3,
+				userId: 1,
+			},
+			{
+				additions: 420,
+				changedFiles: 18,
+				contributionScore: 25,
+				deletions: 80,
+				githubUserId: 502,
+				githubUsername: "dev-b",
+				linkedIssueCount: 1,
+				mergedPrCount: 2,
+				userId: 2,
+			},
+		],
+		fullName: repository.fullName,
+		githubRepositoryId: repository.githubRepositoryId,
+		repoName: repository.repoName,
+	};
+}

--- a/src/features/team/lib/github-subtab-preview.ts
+++ b/src/features/team/lib/github-subtab-preview.ts
@@ -1,5 +1,8 @@
 import type { MyProjectGroup } from "@/lib/types/project-group";
-import type { GithubRepository } from "@/lib/types/team-space";
+import type {
+	GithubRepository,
+	GithubWeeklySummary,
+} from "@/lib/types/team-space";
 
 export const githubSubtabPreviewProjectGroup = {
 	currentUserId: 1,
@@ -99,3 +102,88 @@ export function createGithubSubtabPreviewContribution(
 		repoName: repository.repoName,
 	};
 }
+
+export const githubSubtabPreviewWeeklySummaries: Record<
+	number,
+	GithubWeeklySummary
+> = {
+	1: {
+		periodEnd: "2026-06-16T14:59:59.000Z",
+		periodStart: "2026-06-10T15:00:00.000Z",
+		sourceIssueCount: 4,
+		sourcePrCount: 7,
+		summary: {
+			followUpSuggestions: [
+				"주간 요약 상세 API 응답의 빈 상태를 한 번 더 점검하기",
+				"GitHub App 설치 완료 후 첫 동기화 안내 문구 정리하기",
+			],
+			issueHighlights: [
+				"팀 스페이스 GitHub 운영 탭 정보 구조 개선",
+				"주간 요약 상세 조회 API 연결",
+			],
+			mainActivities: [
+				"GitHub 탭을 기여도, 주간 요약, 연동으로 분리",
+				"저장소별 PR 기여도 카드의 정보 밀도 조정",
+				"리뷰 피드백 반영을 위한 프리뷰 라우트 구성",
+			],
+			pullRequestHighlights: [
+				"feat(team): add github weekly summary detail api",
+				"feat(team): add github panel subtabs",
+			],
+			summary:
+				"GitHub 운영 화면의 정보 구조를 정리하고, 주간 요약 API와 프리뷰 흐름을 연결했어요.",
+		},
+		weeklyGithubSummaryId: 4101,
+	},
+	2: {
+		periodEnd: "2026-06-16T14:59:59.000Z",
+		periodStart: "2026-06-10T15:00:00.000Z",
+		sourceIssueCount: 2,
+		sourcePrCount: 4,
+		summary: {
+			followUpSuggestions: [
+				"서버 OpenAPI 변경분과 FE 타입 이름 맞추기",
+				"권한 오류 응답 메시지 케이스 추가 확인하기",
+			],
+			issueHighlights: [
+				"GitHub weekly summary endpoint 검토",
+				"팀 스페이스 저장소 목록 동기화 확인",
+			],
+			mainActivities: [
+				"GitHub summary API 계약을 점검",
+				"저장소 연결 상태와 집계 대상 응답을 검증",
+			],
+			pullRequestHighlights: [
+				"feat(team): expose weekly github summaries",
+				"fix(team): align repository sync response",
+			],
+			summary:
+				"GitHub 요약과 저장소 연동 API 계약을 맞추고, FE에서 사용할 응답 형태를 정리했어요.",
+		},
+		weeklyGithubSummaryId: 4102,
+	},
+	3: {
+		periodEnd: "2026-06-16T14:59:59.000Z",
+		periodStart: "2026-06-10T15:00:00.000Z",
+		sourceIssueCount: 1,
+		sourcePrCount: 3,
+		summary: {
+			followUpSuggestions: [
+				"모바일에서 서브탭 전환 간격 확인하기",
+				"기여도 카드 숫자 포맷을 실제 데이터로 다시 점검하기",
+			],
+			issueHighlights: ["GitHub 탭 과밀도 개선", "로그인 없는 UI 프리뷰 요청"],
+			mainActivities: [
+				"GitHub 내부 서브탭 상호작용을 점검",
+				"프리뷰 화면의 fixture 데이터를 보강",
+			],
+			pullRequestHighlights: [
+				"feat(team): add github panel subtabs",
+				"fix(team): stabilize github preview route",
+			],
+			summary:
+				"GitHub 화면을 더 빠르게 훑어볼 수 있도록 탭 구조와 프리뷰 상태를 다듬었어요.",
+		},
+		weeklyGithubSummaryId: 4103,
+	},
+};

--- a/src/pages/github-subtabs-preview-page.tsx
+++ b/src/pages/github-subtabs-preview-page.tsx
@@ -1,0 +1,85 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { LoaderCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { RealGithubInstallationPanel } from "@/features/team/components/real-github-installation-panel";
+import { teamSpaceQueryKeys } from "@/features/team/hooks/use-team-space-queries";
+import {
+	createGithubSubtabPreviewContribution,
+	githubSubtabPreviewAvailableRepositories,
+	githubSubtabPreviewConnectedRepositories,
+	githubSubtabPreviewProjectGroup,
+} from "@/features/team/lib/github-subtab-preview";
+
+export function GithubSubtabsPreviewPage() {
+	const queryClient = useQueryClient();
+	const [ready, setReady] = useState(false);
+	const projectGroupId = githubSubtabPreviewProjectGroup.projectGroupId;
+
+	useEffect(() => {
+		queryClient.setQueryData(teamSpaceQueryKeys.githubStatus(projectGroupId), {
+			connected: true,
+			organizationLogin: "team-po-labs",
+			repositoryCount: githubSubtabPreviewConnectedRepositories.length,
+		});
+		queryClient.setQueryData(
+			teamSpaceQueryKeys.githubRepositories(projectGroupId),
+			{
+				repositories: githubSubtabPreviewConnectedRepositories,
+			},
+		);
+		queryClient.setQueryData(
+			teamSpaceQueryKeys.githubAvailableRepositories(projectGroupId),
+			{
+				repositories: githubSubtabPreviewAvailableRepositories,
+			},
+		);
+
+		for (const repository of githubSubtabPreviewConnectedRepositories) {
+			queryClient.setQueryData(
+				teamSpaceQueryKeys.githubRepositoryContributions(
+					projectGroupId,
+					repository.githubRepositoryId,
+				),
+				createGithubSubtabPreviewContribution(repository),
+			);
+		}
+
+		setReady(true);
+	}, [queryClient]);
+
+	return (
+		<div className="min-h-screen bg-[linear-gradient(180deg,hsl(var(--brand-soft)),hsl(var(--background))_18rem)] px-4 py-6 text-foreground sm:px-6 lg:px-8">
+			<main className="mx-auto grid max-w-6xl gap-5">
+				<div className="min-w-0">
+					<p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+						Preview
+					</p>
+					<h1 className="mt-1 text-2xl font-semibold text-brand-ink md:text-3xl">
+						GitHub 탭 세부 보기
+					</h1>
+					<p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+						로그인 없이 GitHub 내부 탭 구조와 각 상태를 확인하는 미리보기
+						화면입니다.
+					</p>
+				</div>
+
+				{ready ? (
+					<RealGithubInstallationPanel
+						canManageGithubInstallation={true}
+						completionFeedback={null}
+						isCompletingInstallation={false}
+						projectGroup={githubSubtabPreviewProjectGroup}
+					/>
+				) : (
+					<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
+						<div className="flex items-center gap-2 text-sm text-muted-foreground">
+							<LoaderCircle className="size-4 animate-spin" />
+							미리보기 데이터를 준비하고 있어요.
+						</div>
+					</div>
+				)}
+			</main>
+		</div>
+	);
+}

--- a/src/pages/github-subtabs-preview-page.tsx
+++ b/src/pages/github-subtabs-preview-page.tsx
@@ -1,53 +1,6 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { LoaderCircle } from "lucide-react";
-import { useEffect, useState } from "react";
-
-import { RealGithubInstallationPanel } from "@/features/team/components/real-github-installation-panel";
-import { teamSpaceQueryKeys } from "@/features/team/hooks/use-team-space-queries";
-import {
-	createGithubSubtabPreviewContribution,
-	githubSubtabPreviewAvailableRepositories,
-	githubSubtabPreviewConnectedRepositories,
-	githubSubtabPreviewProjectGroup,
-} from "@/features/team/lib/github-subtab-preview";
+import { GithubSubtabsPreviewPanel } from "@/features/team/components/github-subtabs-preview-panel";
 
 export function GithubSubtabsPreviewPage() {
-	const queryClient = useQueryClient();
-	const [ready, setReady] = useState(false);
-	const projectGroupId = githubSubtabPreviewProjectGroup.projectGroupId;
-
-	useEffect(() => {
-		queryClient.setQueryData(teamSpaceQueryKeys.githubStatus(projectGroupId), {
-			connected: true,
-			organizationLogin: "team-po-labs",
-			repositoryCount: githubSubtabPreviewConnectedRepositories.length,
-		});
-		queryClient.setQueryData(
-			teamSpaceQueryKeys.githubRepositories(projectGroupId),
-			{
-				repositories: githubSubtabPreviewConnectedRepositories,
-			},
-		);
-		queryClient.setQueryData(
-			teamSpaceQueryKeys.githubAvailableRepositories(projectGroupId),
-			{
-				repositories: githubSubtabPreviewAvailableRepositories,
-			},
-		);
-
-		for (const repository of githubSubtabPreviewConnectedRepositories) {
-			queryClient.setQueryData(
-				teamSpaceQueryKeys.githubRepositoryContributions(
-					projectGroupId,
-					repository.githubRepositoryId,
-				),
-				createGithubSubtabPreviewContribution(repository),
-			);
-		}
-
-		setReady(true);
-	}, [queryClient]);
-
 	return (
 		<div className="min-h-screen bg-[linear-gradient(180deg,hsl(var(--brand-soft)),hsl(var(--background))_18rem)] px-4 py-6 text-foreground sm:px-6 lg:px-8">
 			<main className="mx-auto grid max-w-6xl gap-5">
@@ -64,21 +17,7 @@ export function GithubSubtabsPreviewPage() {
 					</p>
 				</div>
 
-				{ready ? (
-					<RealGithubInstallationPanel
-						canManageGithubInstallation={true}
-						completionFeedback={null}
-						isCompletingInstallation={false}
-						projectGroup={githubSubtabPreviewProjectGroup}
-					/>
-				) : (
-					<div className="rounded-lg border border-border/70 bg-white p-5 shadow-crisp">
-						<div className="flex items-center gap-2 text-sm text-muted-foreground">
-							<LoaderCircle className="size-4 animate-spin" />
-							미리보기 데이터를 준비하고 있어요.
-						</div>
-					</div>
-				)}
+				<GithubSubtabsPreviewPanel />
 			</main>
 		</div>
 	);


### PR DESCRIPTION
Summary
- Split the team GitHub panel into contribution, weekly summary, and integration subtabs.
- Keep weekly summary and integration queries scoped to their selected subtab.
- Add a login-free preview route at /team/github-preview with seeded GitHub tab data.

Validation
- pnpm tsc --noEmit
- pnpm biome lint .
- pnpm build

Closes #124